### PR TITLE
feat(cli): add kctx CLI with file-based doc search for AI agents

### DIFF
--- a/.claude/skills/king-context/skill.md
+++ b/.claude/skills/king-context/skill.md
@@ -1,0 +1,160 @@
+# King Context — Documentation Search Skill
+
+Search indexed documentation efficiently using `kctx` CLI. Find the right section in ≤3 calls.
+
+**Triggers**: documentation lookup, "search docs", "find in docs", library usage questions, "how to use X", "what's the API for X"
+
+---
+
+## Search Strategy
+
+Follow this flowchart for every documentation lookup. Stop as soon as you have the answer.
+
+```
+1. Check _learned/     →  known shortcut?  → kctx read <doc> <path>  → DONE
+2. kctx list           →  which doc?
+3. kctx search "query" →  find section     → got it?
+4. kctx read --preview →  assess relevance → right section?
+5. kctx read           →  full content     → DONE
+6. Save discovery to _learned/
+```
+
+**Rules**:
+- ALWAYS check `_learned/` FIRST — costs ~100 tokens, saves thousands
+- ALWAYS verify learned paths still exist before using them (`kctx read` will error if stale)
+- Prefer `kctx search` over `kctx grep` — metadata search is faster and cheaper
+- Use `--preview` before full read — assess relevance before paying full token cost
+- Use `kctx grep` only when you need to find exact code patterns or API names
+- NEVER read all sections — search narrows, preview confirms, then read only what's needed
+
+---
+
+## Query Decomposition
+
+Transform user intent into efficient CLI queries:
+
+| User asks | CLI query |
+|-----------|-----------|
+| "How to stream audio with ElevenLabs" | `kctx search "streaming" --doc elevenlabs-api` |
+| "Authentication for the API" | `kctx search "auth api-key"` |
+| "What WebSocket events are available" | `kctx search "websocket events"` |
+| "Find where Client( is used" | `kctx grep "Client(" --doc httpx` |
+| "What topics does the docs cover" | `kctx topics elevenlabs-api` |
+
+**Tips**:
+- Use 1-2 specific keywords, not full sentences
+- Scope to `--doc` when you know which doc
+- Use `--top 3` to reduce output tokens
+- Keywords match exact terms; use_cases match substrings — "stream" matches "How to stream audio"
+
+---
+
+## CLI Command Reference
+
+### List available docs
+```bash
+kctx list                    # compact table: name, display_name, version, sections
+kctx list --json             # JSON array
+```
+
+### Search by metadata (keywords, use_cases, tags)
+```bash
+kctx search "query"                        # cross-doc search, top 5
+kctx search "streaming" --doc elevenlabs-api  # scoped to one doc
+kctx search "auth" --top 3                 # limit results
+kctx search "query" --json                 # JSON output
+```
+Returns: title, path, score, first use_case. **No content** — metadata only.
+
+### Read a section
+```bash
+kctx read <doc> <section-path>             # full content
+kctx read <doc> <section-path> --preview   # first ~200 tokens + total estimate
+kctx read <doc> <section-path> --json      # JSON output
+```
+If section not found, suggests similar paths.
+
+### Browse by topic
+```bash
+kctx topics <doc>                          # all tags with sections
+kctx topics <doc> --tag api-reference      # filter to one tag
+kctx topics <doc> --json                   # JSON output
+```
+
+### Grep content
+```bash
+kctx grep "pattern"                        # regex across all docs
+kctx grep "Client(" --doc httpx            # scoped to one doc
+kctx grep "pattern" --context 3            # surrounding lines
+kctx grep "pattern" --json                 # JSON output
+```
+
+### Index documentation
+```bash
+kctx index data/example.json              # index one doc
+kctx index --all                           # index all data/*.json
+```
+
+---
+
+## Self-Learning
+
+After finding a useful section, save a shortcut for future sessions.
+
+### When to save
+- You found the right section after searching
+- You discovered a gotcha or non-obvious behavior
+- You found a pattern that would help answer similar questions
+
+### How to save
+Write to `.king-context/_learned/<doc-name>.md`:
+
+```markdown
+# <Doc Name> - Learned Shortcuts
+
+## <Topic>
+- **<What>** → `<section-path>` section
+- Gotcha: <non-obvious behavior>
+- Related: `<other-section>` for <reason>
+
+---
+Last updated: <date>
+```
+
+### Format for each entry
+- **Query pattern**: what the user asked
+- **Section path**: the section that answered it
+- **Gotchas**: anything non-obvious (auth quirks, parameter caveats, etc.)
+- **Date**: when this was learned
+
+### Reading learned shortcuts
+Before any search, check if a learned file exists:
+1. Read `.king-context/_learned/<doc-name>.md`
+2. If a shortcut matches the current query, use it directly: `kctx read <doc> <path>`
+3. If the path no longer exists (stale), fall back to normal search and update the learned file
+
+---
+
+## Good vs Bad Search Strategies
+
+### Good (3 calls, ~400 tokens)
+```
+kctx search "streaming" --doc elevenlabs-api --top 3
+→ Found: "WebSocket Streaming" (websocket-streaming) score=8.50
+
+kctx read elevenlabs-api websocket-streaming --preview
+→ "# WebSocket Streaming\n\nConnect to ws://..." Tokens: 450
+
+kctx read elevenlabs-api websocket-streaming
+→ Full content
+```
+
+### Bad (wasteful, ~3000+ tokens)
+```
+kctx list
+kctx topics elevenlabs-api
+kctx read elevenlabs-api getting-started        # wrong section
+kctx read elevenlabs-api text-to-speech         # still wrong
+kctx search "websocket streaming audio real-time"  # too many terms
+kctx read elevenlabs-api websocket-streaming    # finally found it
+```

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ commit-create/
 
 # Scraper temp files
 .temp-docs/
+
+.claude/skills/tlc-spec-driven/
+.agents/
+.cursor/
+.specs/
+.king-context/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,41 @@ source .venv/bin/activate
 pip install -e .
 ```
 
-### Configure Claude Code
+### CLI Usage (Recommended)
+
+The `kctx` CLI is the recommended way for AI agents to access documentation. It operates on a file-based `.king-context/` data store — no SQLite required for reads.
+
+```bash
+# Index documentation from scraped data
+kctx index data/elevenlabs-api.json    # index one doc
+kctx index --all                        # index all data/*.json
+
+# List available docs
+kctx list
+
+# Search by keywords/use cases (metadata only, no content — token efficient)
+kctx search "streaming audio"
+kctx search "auth" --doc elevenlabs-api --top 3
+
+# Read a section (preview first, then full)
+kctx read elevenlabs-api websocket-streaming --preview
+kctx read elevenlabs-api websocket-streaming
+
+# Browse by topic
+kctx topics elevenlabs-api
+kctx topics elevenlabs-api --tag api-reference
+
+# Grep content for exact patterns
+kctx grep "Client(" --doc httpx --context 3
+```
+
+All commands support `--json` for machine-parseable output.
+
+A Claude Code skill (`.claude/skills/king-context/skill.md`) teaches agents the optimal search strategy: check learned shortcuts, list, search, preview, then read — finding the right section in ≤3 CLI calls.
+
+### MCP Server (Legacy)
+
+The MCP server is still available for tools that integrate via the Model Context Protocol.
 
 Using the CLI:
 
@@ -128,27 +162,9 @@ Or manually add to your MCP configuration:
 }
 ```
 
-### Seed Documentation
-
 ```bash
-# Place documentation JSON in data/
+# Seed the SQLite database (required for MCP)
 python -m king_context.seed_data
-
-# Or reset and reseed
-./scripts/run-seed-data.sh
-```
-
-### Usage
-
-```python
-# Search documentation
-search_docs("authentication", doc_name="openrouter")
-
-# List available docs
-list_docs()
-
-# Preview context injection (with token estimate)
-show_context("websocket streaming", doc_name="elevenlabs")
 ```
 
 ---
@@ -240,27 +256,23 @@ Contributions needed:
 
 ```
 king-context/
-├── src/king_context/       # Core Python package
-│   ├── __init__.py         # PROJECT_ROOT constant
+├── src/king_context/       # MCP server package
 │   ├── server.py           # MCP server (FastMCP)
 │   ├── db.py               # Cascade search engine + SQLite
 │   ├── seed_data.py        # Database seeding
 │   └── scraper/            # Scraping pipeline (king-scrape CLI)
+├── src/context_cli/        # CLI package (kctx)
+│   ├── cli.py              # Entry point with subcommands
+│   ├── store.py            # .king-context/ path resolution
+│   ├── indexer.py           # JSON → file structure indexer
+│   ├── searcher.py         # Metadata-based search engine
+│   ├── reader.py           # Section reader with preview
+│   ├── formatter.py        # Output formatting (plain/JSON)
+│   └── grep.py             # Content-level regex search
+├── .king-context/          # File-based data store (generated)
 ├── tests/                  # Test suite
-│   ├── conftest.py         # Shared fixtures
-│   ├── test_db.py          # Database & search tests
-│   ├── test_server.py      # MCP tool tests
-│   ├── test_seed_data.py   # Seeding tests
-│   ├── test_embeddings.py  # Dependency tests
-│   └── test_load_embeddings.py
-├── scripts/                # Utility scripts
-│   └── run-seed-data.sh    # Reset & reseed database
 ├── data/                   # Documentation JSONs + embeddings
-│   ├── *.json              # Indexed documentations
-│   ├── embeddings.npy      # Section embeddings
-│   └── _internal/          # Mapping files
-├── input/                  # Raw docs before processing
-├── docs/                   # Design documents
+├── scripts/                # Utility scripts
 ├── pyproject.toml          # Project configuration
 └── docs.db                 # SQLite database (generated)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,14 @@ dependencies = [
 [project.scripts]
 king-context = "king_context.server:main"
 king-scrape = "king_context.scraper.cli:main"
+kctx = "context_cli.cli:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/king_context"]
+packages = ["src/king_context", "src/context_cli"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/context_cli/__init__.py
+++ b/src/context_cli/__init__.py
@@ -1,0 +1,6 @@
+"""Context CLI - File-based documentation search for AI agents."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+STORE_DIR = PROJECT_ROOT / ".king-context"

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -11,8 +11,8 @@ from context_cli.formatter import (
     format_list,
     format_search,
     format_section,
+    format_topics,
 )
-from context_cli.formatter import format_topics
 from context_cli.grep import grep_docs
 from context_cli.indexer import index_all, index_doc
 from context_cli.reader import read_section

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -1,9 +1,80 @@
 """CLI entry point for kctx."""
 
 import argparse
+import sys
+from pathlib import Path
+
+from context_cli import PROJECT_ROOT, STORE_DIR
+from context_cli.formatter import (
+    format_list,
+    format_search,
+    format_section,
+)
+from context_cli.indexer import index_all, index_doc
+from context_cli.reader import read_section
+from context_cli.searcher import search
+from context_cli.store import list_docs
 
 
-def main() -> None:
+def _cmd_list(args: argparse.Namespace) -> None:
+    store_dir = STORE_DIR
+    docs = list_docs(store_dir)
+    if not docs and not args.json:
+        print("No docs indexed. Run: kctx index data/<file>.json")
+        return
+    print(format_list(docs, as_json=args.json))
+
+
+def _cmd_search(args: argparse.Namespace) -> None:
+    store_dir = STORE_DIR
+    results = search(
+        args.query,
+        store_dir,
+        doc_name=args.doc,
+        top=args.top,
+    )
+    print(format_search(results, as_json=args.json))
+
+
+def _cmd_read(args: argparse.Namespace) -> None:
+    store_dir = STORE_DIR
+    try:
+        content = read_section(
+            args.doc,
+            args.section,
+            store_dir,
+            preview=args.preview,
+        )
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+    print(format_section(content, as_json=args.json))
+
+
+def _cmd_index(args: argparse.Namespace) -> None:
+    store_dir = STORE_DIR
+    store_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.all:
+        data_dir = PROJECT_ROOT / "data"
+        if not data_dir.exists():
+            print("data/ directory not found.", file=sys.stderr)
+            sys.exit(1)
+        results = index_all(data_dir, store_dir)
+        for r in results:
+            print(f"Indexed {r.doc_name}: {r.section_count} sections")
+        if not results:
+            print("No JSON files found in data/.")
+    else:
+        json_path = Path(args.path)
+        if not json_path.exists():
+            print(f"File not found: {args.path}", file=sys.stderr)
+            sys.exit(1)
+        result = index_doc(json_path, store_dir)
+        print(f"Indexed {result.doc_name}: {result.section_count} sections")
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="kctx",
         description="File-based documentation search for AI agents",
@@ -11,9 +82,45 @@ def main() -> None:
     parser.add_argument(
         "--version", action="version", version="kctx 0.1.0"
     )
-    # Subcommands will be added in T7
-    parser.parse_args()
-    parser.print_help()
+    subparsers = parser.add_subparsers(dest="command")
+
+    # list
+    p_list = subparsers.add_parser("list", help="List indexed documentation")
+    p_list.add_argument("--json", action="store_true", help="JSON output")
+    p_list.set_defaults(func=_cmd_list)
+
+    # search
+    p_search = subparsers.add_parser("search", help="Search docs by keywords/use cases")
+    p_search.add_argument("query", help="Search query")
+    p_search.add_argument("--doc", default=None, help="Restrict to one doc")
+    p_search.add_argument("--top", type=int, default=5, help="Max results (default: 5)")
+    p_search.add_argument("--json", action="store_true", help="JSON output")
+    p_search.set_defaults(func=_cmd_search)
+
+    # read
+    p_read = subparsers.add_parser("read", help="Read a specific section")
+    p_read.add_argument("doc", help="Documentation name")
+    p_read.add_argument("section", help="Section path")
+    p_read.add_argument("--preview", action="store_true", help="Show first ~200 tokens only")
+    p_read.add_argument("--json", action="store_true", help="JSON output")
+    p_read.set_defaults(func=_cmd_read)
+
+    # index
+    p_index = subparsers.add_parser("index", help="Index documentation from JSON files")
+    p_index.add_argument("path", nargs="?", default=None, help="Path to a JSON file")
+    p_index.add_argument("--all", action="store_true", help="Index all data/*.json files")
+    p_index.set_defaults(func=_cmd_index)
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -1,0 +1,20 @@
+"""CLI entry point for kctx."""
+
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="kctx",
+        description="File-based documentation search for AI agents",
+    )
+    parser.add_argument(
+        "--version", action="version", version="kctx 0.1.0"
+    )
+    # Subcommands will be added in T7
+    parser.parse_args()
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -1,19 +1,23 @@
 """CLI entry point for kctx."""
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
 from context_cli import PROJECT_ROOT, STORE_DIR
 from context_cli.formatter import (
+    format_grep,
     format_list,
     format_search,
     format_section,
 )
+from context_cli.formatter import format_topics
+from context_cli.grep import grep_docs
 from context_cli.indexer import index_all, index_doc
 from context_cli.reader import read_section
 from context_cli.searcher import search
-from context_cli.store import list_docs
+from context_cli.store import doc_exists, list_docs
 
 
 def _cmd_list(args: argparse.Namespace) -> None:
@@ -49,6 +53,67 @@ def _cmd_read(args: argparse.Namespace) -> None:
         print(str(e), file=sys.stderr)
         sys.exit(1)
     print(format_section(content, as_json=args.json))
+
+
+def _cmd_grep(args: argparse.Namespace) -> None:
+    store_dir = STORE_DIR
+    matches = grep_docs(
+        args.pattern,
+        store_dir,
+        doc_name=args.doc,
+        context_lines=args.context,
+    )
+    print(format_grep(matches, as_json=args.json))
+
+
+def _cmd_topics(args: argparse.Namespace) -> None:
+    store_dir = STORE_DIR
+    doc_name = args.doc
+
+    if not doc_exists(doc_name, store_dir):
+        docs = list_docs(store_dir)
+        available = ", ".join(d.name for d in docs) if docs else "none"
+        print(
+            f"Doc '{doc_name}' not found. Available: {available}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    doc_dir = store_dir / doc_name
+    tags_path = doc_dir / "tags.json"
+    if not tags_path.exists():
+        print(format_topics({}, as_json=args.json))
+        return
+
+    tags_index: dict[str, list[str]] = json.loads(tags_path.read_text())
+
+    # Optionally filter to a single tag
+    if args.tag:
+        if args.tag in tags_index:
+            tags_index = {args.tag: tags_index[args.tag]}
+        else:
+            tags_index = {}
+
+    # Load section metadata for each tag
+    tag_groups: dict[str, list[dict]] = {}
+    sections_dir = doc_dir / "sections"
+
+    for tag, section_paths in tags_index.items():
+        sections = []
+        for spath in section_paths:
+            sec_file = sections_dir / f"{spath}.json"
+            if sec_file.exists():
+                sec_data = json.loads(sec_file.read_text())
+                sections.append({
+                    "title": sec_data.get("title", ""),
+                    "path": sec_data.get("path", spath),
+                    "priority": sec_data.get("priority", 0),
+                })
+        # Sort by priority descending
+        sections.sort(key=lambda s: s["priority"], reverse=True)
+        tag_groups[tag] = sections
+
+    print(format_topics(tag_groups, as_json=args.json))
 
 
 def _cmd_index(args: argparse.Namespace) -> None:
@@ -104,6 +169,21 @@ def _build_parser() -> argparse.ArgumentParser:
     p_read.add_argument("--preview", action="store_true", help="Show first ~200 tokens only")
     p_read.add_argument("--json", action="store_true", help="JSON output")
     p_read.set_defaults(func=_cmd_read)
+
+    # grep
+    p_grep = subparsers.add_parser("grep", help="Search content with regex patterns")
+    p_grep.add_argument("pattern", help="Regex pattern to search for")
+    p_grep.add_argument("--doc", default=None, help="Restrict to one doc")
+    p_grep.add_argument("--context", type=int, default=0, help="Surrounding lines")
+    p_grep.add_argument("--json", action="store_true", help="JSON output")
+    p_grep.set_defaults(func=_cmd_grep)
+
+    # topics
+    p_topics = subparsers.add_parser("topics", help="Show tags and sections for a doc")
+    p_topics.add_argument("doc", help="Documentation name")
+    p_topics.add_argument("--tag", default=None, help="Filter to a single tag")
+    p_topics.add_argument("--json", action="store_true", help="JSON output")
+    p_topics.set_defaults(func=_cmd_topics)
 
     # index
     p_index = subparsers.add_parser("index", help="Index documentation from JSON files")

--- a/src/context_cli/formatter.py
+++ b/src/context_cli/formatter.py
@@ -1,0 +1,133 @@
+"""Formatter — compact plain text and JSON output for CLI commands."""
+
+import json
+from dataclasses import asdict
+
+
+def _to_dict(obj):
+    """Convert a dataclass or namespace object to a dict."""
+    try:
+        return asdict(obj)
+    except TypeError:
+        return vars(obj)
+
+
+def format_list(docs, as_json=False) -> str:
+    """Format a list of DocInfo objects as a table or JSON.
+
+    Plain: compact table with columns Name | Display Name | Version | Sections.
+    JSON: list of doc dicts.
+    """
+    if as_json:
+        return json.dumps([_to_dict(d) for d in docs], indent=2)
+
+    if not docs:
+        return "No documentation indexed."
+
+    # Calculate column widths
+    headers = ("Name", "Display Name", "Version", "Sections")
+    rows = [
+        (d.name, d.display_name, d.version, str(d.section_count))
+        for d in docs
+    ]
+    widths = [
+        max(len(h), *(len(r[i]) for r in rows))
+        for i, h in enumerate(headers)
+    ]
+
+    def _row(cells):
+        return "  ".join(c.ljust(w) for c, w in zip(cells, widths)).rstrip()
+
+    lines = [_row(headers), "  ".join("-" * w for w in widths)]
+    for r in rows:
+        lines.append(_row(r))
+    return "\n".join(lines)
+
+
+def format_search(results, as_json=False) -> str:
+    """Format ranked search results as a numbered list or JSON.
+
+    Plain: numbered list with title, path, score, first use_case.
+    JSON: list of result dicts.
+    """
+    if as_json:
+        return json.dumps([_to_dict(r) for r in results], indent=2)
+
+    if not results:
+        return "No results found."
+
+    lines = []
+    for i, r in enumerate(results, 1):
+        use_case = r.use_cases[0] if r.use_cases else ""
+        line = f"{i}. {r.title} ({r.doc_name}/{r.section_path}) score={r.score:.2f}"
+        if use_case:
+            line += f"\n   {use_case}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def format_section(content, as_json=False) -> str:
+    """Format a single section's content or JSON.
+
+    Plain: "# title\\n\\ncontent\\n\\n---\\nURL: url | Tokens: N [PREVIEW]"
+    JSON: content dict.
+    """
+    if as_json:
+        return json.dumps(_to_dict(content), indent=2)
+
+    footer_parts = []
+    if content.url:
+        footer_parts.append(f"URL: {content.url}")
+    footer_parts.append(f"Tokens: {content.token_estimate}")
+    if content.is_preview:
+        footer_parts.append("[PREVIEW]")
+
+    footer = " | ".join(footer_parts)
+    return f"# {content.title}\n\n{content.content}\n\n---\n{footer}"
+
+
+def format_topics(tag_groups, as_json=False) -> str:
+    """Format sections grouped by tag.
+
+    tag_groups: dict[str, list[dict]] where each dict has title, path, priority.
+    Plain: "## tag (N sections)\\n  - title (path) [priority: N]"
+    JSON: the tag_groups dict.
+    """
+    if as_json:
+        return json.dumps(tag_groups, indent=2)
+
+    if not tag_groups:
+        return "No topics found."
+
+    lines = []
+    for tag, sections in tag_groups.items():
+        lines.append(f"## {tag} ({len(sections)} sections)")
+        for s in sections:
+            lines.append(f"  - {s['title']} ({s['path']}) [priority: {s['priority']}]")
+    return "\n".join(lines)
+
+
+def format_grep(matches, as_json=False) -> str:
+    """Format grep matches grouped by section.
+
+    Plain: "## doc/section-title\\n  line_number: line_content"
+    JSON: list of match dicts.
+    """
+    if as_json:
+        return json.dumps([_to_dict(m) for m in matches], indent=2)
+
+    if not matches:
+        return "No matches found."
+
+    # Group by doc_name + section_title
+    groups: dict[str, list] = {}
+    for m in matches:
+        key = f"{m.doc_name}/{m.section_title}"
+        groups.setdefault(key, []).append(m)
+
+    lines = []
+    for heading, group in groups.items():
+        lines.append(f"## {heading}")
+        for m in group:
+            lines.append(f"  {m.line_number}: {m.line_content}")
+    return "\n".join(lines)

--- a/src/context_cli/grep.py
+++ b/src/context_cli/grep.py
@@ -1,0 +1,87 @@
+"""Grep engine — content-level regex search within indexed sections."""
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class GrepMatch:
+    doc_name: str
+    section_path: str
+    section_title: str
+    line_number: int
+    line_content: str
+    context_before: list[str] = field(default_factory=list)
+    context_after: list[str] = field(default_factory=list)
+
+
+def grep_docs(
+    pattern: str,
+    store_dir: Path,
+    doc_name: str | None = None,
+    context_lines: int = 0,
+) -> list[GrepMatch]:
+    """Search section content for lines matching a regex pattern.
+
+    Args:
+        pattern: Regular expression to match (case-insensitive).
+        store_dir: Path to the .king-context/ directory.
+        doc_name: If set, restrict search to this doc only.
+        context_lines: Number of surrounding lines to include.
+
+    Returns:
+        List of GrepMatch objects, grouped by section (matches within the
+        same section are adjacent in the list).
+    """
+    regex = re.compile(pattern, re.IGNORECASE)
+
+    if not store_dir.exists():
+        return []
+
+    # Determine which doc directories to scan
+    if doc_name is not None:
+        doc_dirs = [store_dir / doc_name]
+    else:
+        doc_dirs = sorted(
+            d for d in store_dir.iterdir()
+            if d.is_dir() and not d.name.startswith("_")
+        )
+
+    matches: list[GrepMatch] = []
+
+    for doc_dir in doc_dirs:
+        sections_dir = doc_dir / "sections"
+        if not sections_dir.exists():
+            continue
+
+        for section_file in sorted(sections_dir.glob("*.json")):
+            try:
+                data = json.loads(section_file.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+
+            content = data.get("content", "")
+            title = data.get("title", "")
+            section_path = data.get("path", section_file.stem)
+            lines = content.split("\n")
+
+            section_matches: list[GrepMatch] = []
+            for i, line in enumerate(lines):
+                if regex.search(line):
+                    before = lines[max(0, i - context_lines):i]
+                    after = lines[i + 1:i + 1 + context_lines]
+                    section_matches.append(GrepMatch(
+                        doc_name=doc_dir.name,
+                        section_path=section_path,
+                        section_title=title,
+                        line_number=i + 1,
+                        line_content=line,
+                        context_before=before,
+                        context_after=after,
+                    ))
+
+            matches.extend(section_matches)
+
+    return matches

--- a/src/context_cli/indexer.py
+++ b/src/context_cli/indexer.py
@@ -1,0 +1,97 @@
+"""Indexer — reads data/*.json monolithic files and generates .king-context/ structure."""
+
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+@dataclass
+class IndexResult:
+    doc_name: str
+    section_count: int
+    store_path: Path
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from text (words * 1.33)."""
+    return int(len(text.split()) * 1.33)
+
+
+def index_doc(json_path: Path, store_dir: Path) -> IndexResult:
+    """Read a monolithic JSON and create the .king-context/<doc>/ structure."""
+    data = json.loads(json_path.read_text())
+
+    name = data["name"]
+    doc_dir = store_dir / name
+
+    # Clean previous index
+    if doc_dir.exists():
+        shutil.rmtree(doc_dir)
+
+    sections_dir = doc_dir / "sections"
+    sections_dir.mkdir(parents=True)
+
+    # Write index.json (metadata only)
+    sections = data.get("sections", [])
+    index_meta = {
+        "name": name,
+        "display_name": data.get("display_name", name),
+        "version": data.get("version", ""),
+        "base_url": data.get("base_url", ""),
+        "section_count": len(sections),
+        "indexed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (doc_dir / "index.json").write_text(json.dumps(index_meta, indent=2))
+
+    # Reverse indexes
+    keywords_index: dict[str, list[str]] = {}
+    use_cases_index: dict[str, list[str]] = {}
+    tags_index: dict[str, list[str]] = {}
+
+    for section in sections:
+        path = section.get("path", "")
+        content = section.get("content", "")
+
+        # Write individual section file
+        section_data = {
+            "title": section.get("title", ""),
+            "path": path,
+            "url": section.get("url", ""),
+            "keywords": section.get("keywords", []),
+            "use_cases": section.get("use_cases", []),
+            "tags": section.get("tags", []),
+            "priority": section.get("priority", 0),
+            "content": content,
+            "token_estimate": _estimate_tokens(content),
+        }
+        (sections_dir / f"{path}.json").write_text(
+            json.dumps(section_data, indent=2)
+        )
+
+        # Build reverse indexes
+        for kw in section.get("keywords", []):
+            keywords_index.setdefault(kw, []).append(path)
+        for uc in section.get("use_cases", []):
+            use_cases_index.setdefault(uc, []).append(path)
+        for tag in section.get("tags", []):
+            tags_index.setdefault(tag, []).append(path)
+
+    # Write reverse indexes
+    (doc_dir / "keywords.json").write_text(json.dumps(keywords_index, indent=2))
+    (doc_dir / "use_cases.json").write_text(json.dumps(use_cases_index, indent=2))
+    (doc_dir / "tags.json").write_text(json.dumps(tags_index, indent=2))
+
+    return IndexResult(
+        doc_name=name,
+        section_count=len(sections),
+        store_path=doc_dir,
+    )
+
+
+def index_all(data_dir: Path, store_dir: Path) -> list[IndexResult]:
+    """Index all *.json files in data_dir."""
+    results: list[IndexResult] = []
+    for json_file in sorted(data_dir.glob("*.json")):
+        results.append(index_doc(json_file, store_dir))
+    return results

--- a/src/context_cli/reader.py
+++ b/src/context_cli/reader.py
@@ -1,0 +1,106 @@
+"""Reader module — reads section content with optional preview truncation."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SectionContent:
+    title: str
+    content: str
+    url: str
+    token_estimate: int
+    is_preview: bool
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from text (words * 1.33)."""
+    return int(len(text.split()) * 1.33)
+
+
+def read_section(
+    doc_name: str,
+    section_path: str,
+    store_dir: Path,
+    preview: bool = False,
+) -> SectionContent:
+    """Read a section file and return its content.
+
+    Args:
+        doc_name: Name of the documentation (directory under store_dir).
+        section_path: Filename stem of the section (without .json).
+        store_dir: Root .king-context/ directory.
+        preview: If True, truncate content to ~200 tokens (~150 words).
+
+    Returns:
+        SectionContent with the (possibly truncated) content.
+
+    Raises:
+        FileNotFoundError: When the section file does not exist.
+            The error message includes up to 5 similar path suggestions.
+    """
+    section_file = store_dir / doc_name / "sections" / f"{section_path}.json"
+
+    if not section_file.exists():
+        suggestions = suggest_similar(doc_name, section_path, store_dir)
+        hint = ""
+        if suggestions:
+            hint = "\n  Did you mean:\n" + "\n".join(
+                f"    - {s}" for s in suggestions
+            )
+        raise FileNotFoundError(
+            f"Section '{section_path}' not found in '{doc_name}'.{hint}"
+        )
+
+    data = json.loads(section_file.read_text())
+    content = data.get("content", "")
+    full_token_estimate = data.get("token_estimate", _estimate_tokens(content))
+
+    is_preview = False
+    if preview and content:
+        words = content.split()
+        if len(words) > 150:
+            content = " ".join(words[:150])
+            is_preview = True
+
+    return SectionContent(
+        title=data.get("title", ""),
+        content=content,
+        url=data.get("url", ""),
+        token_estimate=full_token_estimate,
+        is_preview=is_preview,
+    )
+
+
+def suggest_similar(
+    doc_name: str,
+    section_path: str,
+    store_dir: Path,
+) -> list[str]:
+    """Return up to 5 section paths similar to *section_path*.
+
+    Uses simple substring and prefix matching against the filenames in
+    the doc's sections/ directory.
+    """
+    sections_dir = store_dir / doc_name / "sections"
+    if not sections_dir.is_dir():
+        return []
+
+    all_paths = sorted(
+        p.stem for p in sections_dir.iterdir() if p.suffix == ".json"
+    )
+
+    query = section_path.lower()
+
+    # Score each candidate: prefix match scores higher than substring match.
+    scored: list[tuple[int, str]] = []
+    for name in all_paths:
+        lower = name.lower()
+        if lower.startswith(query) or query.startswith(lower):
+            scored.append((0, name))
+        elif query in lower or lower in query:
+            scored.append((1, name))
+
+    scored.sort()
+    return [name for _, name in scored[:5]]

--- a/src/context_cli/searcher.py
+++ b/src/context_cli/searcher.py
@@ -1,0 +1,137 @@
+"""Searcher — metadata-based scoring on reverse indexes in .king-context/."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SearchResult:
+    doc_name: str
+    section_path: str
+    title: str
+    score: float
+    keywords: list[str]
+    use_cases: list[str]
+    tags: list[str]
+    priority: int
+
+
+def _normalize_query(query: str) -> list[str]:
+    """Lowercase, strip, and tokenize query into terms."""
+    return query.lower().strip().split()
+
+
+def _load_json(path: Path) -> dict:
+    """Load a JSON file, returning empty dict on failure."""
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, FileNotFoundError, OSError):
+        return {}
+
+
+def _score_sections_in_doc(
+    terms: list[str],
+    doc_dir: Path,
+) -> dict[str, float]:
+    """Score sections using reverse indexes in a single doc directory.
+
+    Returns a dict mapping section_path to its accumulated score.
+    """
+    keywords_index = _load_json(doc_dir / "keywords.json")
+    use_cases_index = _load_json(doc_dir / "use_cases.json")
+    tags_index = _load_json(doc_dir / "tags.json")
+
+    scores: dict[str, float] = {}
+
+    # Keyword exact match (weight 3)
+    for term in terms:
+        for key, paths in keywords_index.items():
+            if term == key.lower():
+                for p in paths:
+                    scores[p] = scores.get(p, 0.0) + 3.0
+
+    # Use-case substring match (weight 2)
+    for term in terms:
+        for use_case, paths in use_cases_index.items():
+            if term in use_case.lower():
+                for p in paths:
+                    scores[p] = scores.get(p, 0.0) + 2.0
+
+    # Tag exact match (weight 1)
+    for term in terms:
+        for key, paths in tags_index.items():
+            if term == key.lower():
+                for p in paths:
+                    scores[p] = scores.get(p, 0.0) + 1.0
+
+    return scores
+
+
+def search(
+    query: str,
+    store_dir: Path,
+    doc_name: str | None = None,
+    top: int = 5,
+) -> list[SearchResult]:
+    """Search documentation sections by query using reverse-index scoring.
+
+    Args:
+        query: The search query string.
+        store_dir: Path to the .king-context/ directory.
+        doc_name: If given, restrict search to this doc only.
+        top: Maximum number of results to return.
+
+    Returns:
+        List of SearchResult sorted by score descending, limited to `top`.
+    """
+    terms = _normalize_query(query)
+    if not terms:
+        return []
+
+    # Determine which doc directories to search
+    if doc_name is not None:
+        doc_dir = store_dir / doc_name
+        if not doc_dir.is_dir() or not (doc_dir / "index.json").exists():
+            return []
+        doc_dirs = [(doc_name, doc_dir)]
+    else:
+        doc_dirs = []
+        if store_dir.exists():
+            for entry in sorted(store_dir.iterdir()):
+                if not entry.is_dir() or entry.name.startswith("_"):
+                    continue
+                if not (entry / "index.json").exists():
+                    continue
+                doc_dirs.append((entry.name, entry))
+
+    # Score all sections across selected docs
+    candidates: list[SearchResult] = []
+
+    for d_name, doc_dir in doc_dirs:
+        section_scores = _score_sections_in_doc(terms, doc_dir)
+
+        sections_dir = doc_dir / "sections"
+        for section_path, base_score in section_scores.items():
+            section_file = sections_dir / f"{section_path}.json"
+            section_data = _load_json(section_file)
+            if not section_data:
+                continue
+
+            priority = section_data.get("priority", 0)
+            final_score = base_score + priority * 0.5
+
+            candidates.append(SearchResult(
+                doc_name=d_name,
+                section_path=section_path,
+                title=section_data.get("title", ""),
+                score=final_score,
+                keywords=section_data.get("keywords", []),
+                use_cases=section_data.get("use_cases", []),
+                tags=section_data.get("tags", []),
+                priority=priority,
+            ))
+
+    # Sort by score descending, then limit
+    candidates.sort(key=lambda r: r.score, reverse=True)
+    return candidates[:top]

--- a/src/context_cli/store.py
+++ b/src/context_cli/store.py
@@ -1,0 +1,53 @@
+"""Store module — path resolution for .king-context/, doc listing, validation."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from context_cli import STORE_DIR
+
+
+@dataclass
+class DocInfo:
+    name: str
+    display_name: str
+    version: str
+    section_count: int
+    base_url: str
+
+
+def get_store_dir() -> Path:
+    """Return the .king-context/ path relative to PROJECT_ROOT."""
+    return STORE_DIR
+
+
+def list_docs(store_dir: Path) -> list[DocInfo]:
+    """Read all <doc>/index.json and return a list of DocInfo."""
+    if not store_dir.exists():
+        return []
+
+    docs: list[DocInfo] = []
+    for entry in sorted(store_dir.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("_"):
+            continue
+        index_file = entry / "index.json"
+        if not index_file.exists():
+            continue
+        try:
+            data = json.loads(index_file.read_text())
+            docs.append(DocInfo(
+                name=data["name"],
+                display_name=data.get("display_name", data["name"]),
+                version=data.get("version", ""),
+                section_count=data.get("section_count", 0),
+                base_url=data.get("base_url", ""),
+            ))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return docs
+
+
+def doc_exists(doc_name: str, store_dir: Path) -> bool:
+    """Check if a doc directory with a valid index.json exists."""
+    doc_dir = store_dir / doc_name
+    return doc_dir.is_dir() and (doc_dir / "index.json").exists()

--- a/tests/test_context_cli/test_cli.py
+++ b/tests/test_context_cli/test_cli.py
@@ -1,0 +1,216 @@
+"""Integration tests for context_cli.cli module."""
+
+import json
+import sys
+
+import pytest
+
+from context_cli.indexer import index_doc
+
+
+@pytest.fixture
+def store_with_doc(tmp_path, monkeypatch):
+    """Create a .king-context/ store with one indexed doc and patch STORE_DIR."""
+    store_dir = tmp_path / ".king-context"
+    store_dir.mkdir()
+
+    # Create source JSON
+    source = {
+        "name": "test-api",
+        "display_name": "Test API",
+        "version": "v1",
+        "base_url": "https://example.com",
+        "sections": [
+            {
+                "title": "Getting Started",
+                "path": "getting-started",
+                "url": "https://example.com/getting-started",
+                "keywords": ["setup", "install"],
+                "use_cases": ["How to install the SDK"],
+                "tags": ["guide"],
+                "priority": 10,
+                "content": "Install with pip install test-api. Then configure your key.",
+            },
+            {
+                "title": "Authentication",
+                "path": "authentication",
+                "url": "https://example.com/auth",
+                "keywords": ["auth", "api-key", "security"],
+                "use_cases": ["How to authenticate requests"],
+                "tags": ["guide", "security"],
+                "priority": 8,
+                "content": "Use your API key in the x-api-key header for all requests.",
+            },
+        ],
+    }
+    src_file = tmp_path / "test-api.json"
+    src_file.write_text(json.dumps(source))
+    index_doc(src_file, store_dir)
+
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+
+    return store_dir, tmp_path, src_file
+
+
+def _run_cli(args, monkeypatch):
+    """Run CLI by patching sys.argv and calling main()."""
+    from context_cli.cli import main
+    monkeypatch.setattr(sys, "argv", ["kctx"] + args)
+    main()
+
+
+def test_list_shows_docs(store_with_doc, monkeypatch, capsys):
+    _run_cli(["list"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "test-api" in out
+    assert "Test API" in out
+
+
+def test_list_json(store_with_doc, monkeypatch, capsys):
+    _run_cli(["list", "--json"], monkeypatch)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert len(data) == 1
+    assert data[0]["name"] == "test-api"
+
+
+def test_list_empty_store(tmp_path, monkeypatch, capsys):
+    empty_store = tmp_path / ".king-context"
+    empty_store.mkdir()
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", empty_store)
+
+    _run_cli(["list"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "No docs indexed" in out
+
+
+def test_search_returns_results(store_with_doc, monkeypatch, capsys):
+    _run_cli(["search", "install"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Getting Started" in out
+    assert "score=" in out
+
+
+def test_search_with_doc_filter(store_with_doc, monkeypatch, capsys):
+    _run_cli(["search", "auth", "--doc", "test-api"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Authentication" in out
+
+
+def test_search_with_top(store_with_doc, monkeypatch, capsys):
+    _run_cli(["search", "guide", "--top", "1"], monkeypatch)
+    out = capsys.readouterr().out
+    # Should have exactly 1 numbered result
+    lines = [l for l in out.strip().split("\n") if l and l[0].isdigit()]
+    assert len(lines) == 1
+
+
+def test_search_no_results(store_with_doc, monkeypatch, capsys):
+    _run_cli(["search", "zzzznonexistent"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "No results" in out
+
+
+def test_read_full(store_with_doc, monkeypatch, capsys):
+    _run_cli(["read", "test-api", "getting-started"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Getting Started" in out
+    assert "pip install test-api" in out
+
+
+def test_read_preview(store_with_doc, monkeypatch, capsys):
+    _run_cli(["read", "test-api", "authentication", "--preview"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Authentication" in out
+    assert "Tokens:" in out
+
+
+def test_read_not_found(store_with_doc, monkeypatch):
+    with pytest.raises(SystemExit):
+        _run_cli(["read", "test-api", "nonexistent"], monkeypatch)
+
+
+def test_read_json(store_with_doc, monkeypatch, capsys):
+    _run_cli(["read", "test-api", "authentication", "--json"], monkeypatch)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["title"] == "Authentication"
+    assert "content" in data
+
+
+def test_index_single_file(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+
+    source = {
+        "name": "new-api",
+        "display_name": "New API",
+        "version": "v1",
+        "base_url": "https://new.com",
+        "sections": [
+            {
+                "title": "Intro",
+                "path": "intro",
+                "url": "https://new.com/intro",
+                "keywords": ["intro"],
+                "use_cases": ["Getting started"],
+                "tags": ["guide"],
+                "priority": 5,
+                "content": "Welcome to the new API.",
+            }
+        ],
+    }
+    src_file = tmp_path / "new-api.json"
+    src_file.write_text(json.dumps(source))
+
+    _run_cli(["index", str(src_file)], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Indexed new-api" in out
+    assert (store_dir / "new-api" / "index.json").exists()
+
+
+def test_index_all(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+
+    for name in ["api-a", "api-b"]:
+        src = {
+            "name": name,
+            "display_name": name.title(),
+            "version": "v1",
+            "base_url": f"https://{name}.com",
+            "sections": [],
+        }
+        (data_dir / f"{name}.json").write_text(json.dumps(src))
+
+    _run_cli(["index", "--all"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Indexed api-a" in out
+    assert "Indexed api-b" in out
+
+
+def test_index_file_not_found(tmp_path, monkeypatch):
+    store_dir = tmp_path / ".king-context"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+
+    with pytest.raises(SystemExit):
+        _run_cli(["index", "/nonexistent/file.json"], monkeypatch)
+
+
+def test_help_shows_subcommands(monkeypatch, capsys):
+    _run_cli([], monkeypatch)
+    out = capsys.readouterr().out
+    assert "list" in out
+    assert "search" in out
+    assert "read" in out
+    assert "index" in out

--- a/tests/test_context_cli/test_formatter.py
+++ b/tests/test_context_cli/test_formatter.py
@@ -1,0 +1,257 @@
+"""Tests for context_cli.formatter module."""
+
+import json
+from types import SimpleNamespace
+
+from context_cli.formatter import (
+    format_grep,
+    format_list,
+    format_search,
+    format_section,
+    format_topics,
+)
+
+
+def _doc(**kwargs):
+    defaults = dict(
+        name="react",
+        display_name="React",
+        version="v18",
+        section_count=42,
+        base_url="https://react.dev",
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _result(**kwargs):
+    defaults = dict(
+        doc_name="react",
+        section_path="hooks/use-state",
+        title="useState",
+        score=0.95,
+        keywords=["state", "hooks"],
+        use_cases=["manage component state"],
+        tags=["hooks"],
+        priority=10,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _section(**kwargs):
+    defaults = dict(
+        title="useState",
+        content="useState is a React Hook...",
+        url="https://react.dev/reference/react/useState",
+        token_estimate=120,
+        is_preview=False,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _grep_match(**kwargs):
+    defaults = dict(
+        doc_name="react",
+        section_path="hooks/use-state",
+        section_title="useState",
+        line_number=15,
+        line_content="const [count, setCount] = useState(0);",
+        context_before=["// initialize state"],
+        context_after=["return count;"],
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+# --- format_list ---
+
+
+def test_format_list_plain():
+    docs = [_doc(), _doc(name="vue", display_name="Vue.js", version="v3", section_count=30)]
+    output = format_list(docs)
+
+    assert "Name" in output
+    assert "Display Name" in output
+    assert "react" in output
+    assert "Vue.js" in output
+    assert "42" in output
+    assert "30" in output
+    # Table has header, separator, and 2 data rows
+    lines = output.strip().split("\n")
+    assert len(lines) == 4
+
+
+def test_format_list_plain_empty():
+    assert format_list([]) == "No documentation indexed."
+
+
+def test_format_list_json():
+    docs = [_doc()]
+    output = format_list(docs, as_json=True)
+    data = json.loads(output)
+
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name"] == "react"
+    assert data[0]["section_count"] == 42
+
+
+# --- format_search ---
+
+
+def test_format_search_plain():
+    results = [
+        _result(),
+        _result(title="useEffect", section_path="hooks/use-effect", score=0.80,
+                use_cases=["run side effects"]),
+    ]
+    output = format_search(results)
+
+    assert "1. useState" in output
+    assert "score=0.95" in output
+    assert "manage component state" in output
+    assert "2. useEffect" in output
+    assert "score=0.80" in output
+    assert "run side effects" in output
+
+
+def test_format_search_plain_empty():
+    assert format_search([]) == "No results found."
+
+
+def test_format_search_plain_no_use_case():
+    results = [_result(use_cases=[])]
+    output = format_search(results)
+    assert "1. useState" in output
+    # No indented use_case line
+    assert output.count("\n") == 0
+
+
+def test_format_search_json():
+    results = [_result()]
+    output = format_search(results, as_json=True)
+    data = json.loads(output)
+
+    assert isinstance(data, list)
+    assert data[0]["doc_name"] == "react"
+    assert data[0]["score"] == 0.95
+    assert data[0]["keywords"] == ["state", "hooks"]
+
+
+# --- format_section ---
+
+
+def test_format_section_plain():
+    content = _section()
+    output = format_section(content)
+
+    assert output.startswith("# useState")
+    assert "useState is a React Hook..." in output
+    assert "---" in output
+    assert "URL: https://react.dev/reference/react/useState" in output
+    assert "Tokens: 120" in output
+    assert "[PREVIEW]" not in output
+
+
+def test_format_section_plain_preview():
+    content = _section(is_preview=True)
+    output = format_section(content)
+    assert "[PREVIEW]" in output
+
+
+def test_format_section_plain_no_url():
+    content = _section(url="")
+    output = format_section(content)
+    assert "URL:" not in output
+    assert "Tokens: 120" in output
+
+
+def test_format_section_json():
+    content = _section()
+    output = format_section(content, as_json=True)
+    data = json.loads(output)
+
+    assert data["title"] == "useState"
+    assert data["token_estimate"] == 120
+    assert data["is_preview"] is False
+
+
+# --- format_topics ---
+
+
+def test_format_topics_plain():
+    tag_groups = {
+        "hooks": [
+            {"title": "useState", "path": "hooks/use-state", "priority": 10},
+            {"title": "useEffect", "path": "hooks/use-effect", "priority": 8},
+        ],
+        "components": [
+            {"title": "Fragment", "path": "api/fragment", "priority": 5},
+        ],
+    }
+    output = format_topics(tag_groups)
+
+    assert "## hooks (2 sections)" in output
+    assert "  - useState (hooks/use-state) [priority: 10]" in output
+    assert "  - useEffect (hooks/use-effect) [priority: 8]" in output
+    assert "## components (1 sections)" in output
+    assert "  - Fragment (api/fragment) [priority: 5]" in output
+
+
+def test_format_topics_plain_empty():
+    assert format_topics({}) == "No topics found."
+
+
+def test_format_topics_json():
+    tag_groups = {
+        "hooks": [{"title": "useState", "path": "hooks/use-state", "priority": 10}],
+    }
+    output = format_topics(tag_groups, as_json=True)
+    data = json.loads(output)
+
+    assert "hooks" in data
+    assert data["hooks"][0]["title"] == "useState"
+
+
+# --- format_grep ---
+
+
+def test_format_grep_plain():
+    matches = [
+        _grep_match(),
+        _grep_match(line_number=20, line_content="setCount(prev => prev + 1);"),
+    ]
+    output = format_grep(matches)
+
+    assert "## react/useState" in output
+    assert "  15: const [count, setCount] = useState(0);" in output
+    assert "  20: setCount(prev => prev + 1);" in output
+
+
+def test_format_grep_plain_multiple_sections():
+    matches = [
+        _grep_match(),
+        _grep_match(doc_name="vue", section_title="ref", line_number=5,
+                     line_content="const count = ref(0);"),
+    ]
+    output = format_grep(matches)
+
+    assert "## react/useState" in output
+    assert "## vue/ref" in output
+
+
+def test_format_grep_plain_empty():
+    assert format_grep([]) == "No matches found."
+
+
+def test_format_grep_json():
+    matches = [_grep_match()]
+    output = format_grep(matches, as_json=True)
+    data = json.loads(output)
+
+    assert isinstance(data, list)
+    assert data[0]["doc_name"] == "react"
+    assert data[0]["line_number"] == 15
+    assert data[0]["context_before"] == ["// initialize state"]

--- a/tests/test_context_cli/test_grep.py
+++ b/tests/test_context_cli/test_grep.py
@@ -1,0 +1,244 @@
+"""Tests for context_cli.grep module."""
+
+import json
+
+import pytest
+
+from context_cli.grep import GrepMatch, grep_docs
+
+
+def _create_store(tmp_path, docs):
+    """Build a .king-context/ structure from a dict specification.
+
+    docs: dict mapping doc_name -> list of section dicts.
+    Each section dict has keys: title, path, content (and optionally others).
+    Returns the store_dir path.
+    """
+    store_dir = tmp_path / ".king-context"
+    for doc_name, sections in docs.items():
+        sections_dir = store_dir / doc_name / "sections"
+        sections_dir.mkdir(parents=True)
+
+        # Write index.json
+        index_data = {
+            "name": doc_name,
+            "display_name": doc_name.title(),
+            "version": "v1",
+            "base_url": f"https://{doc_name}.example.com",
+            "section_count": len(sections),
+        }
+        (store_dir / doc_name / "index.json").write_text(
+            json.dumps(index_data, indent=2)
+        )
+
+        for section in sections:
+            section_data = {
+                "title": section["title"],
+                "path": section["path"],
+                "url": section.get("url", ""),
+                "keywords": section.get("keywords", []),
+                "use_cases": section.get("use_cases", []),
+                "tags": section.get("tags", []),
+                "priority": section.get("priority", 0),
+                "content": section["content"],
+            }
+            (sections_dir / f"{section['path']}.json").write_text(
+                json.dumps(section_data, indent=2)
+            )
+
+    return store_dir
+
+
+class TestGrepDocs:
+    """Tests for grep_docs function."""
+
+    def test_basic_text_match(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Getting Started",
+                    "path": "getting-started",
+                    "content": "Install with pip install my-api.\nThen run the setup command.",
+                },
+            ],
+        })
+
+        results = grep_docs("pip install", store)
+
+        assert len(results) == 1
+        assert results[0].doc_name == "my-api"
+        assert results[0].section_path == "getting-started"
+        assert results[0].section_title == "Getting Started"
+        assert results[0].line_number == 1
+        assert "pip install" in results[0].line_content
+
+    def test_regex_pattern_match(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Config",
+                    "path": "config",
+                    "content": "Set timeout to 30s.\nOr set timeout to 60s.\nDone.",
+                },
+            ],
+        })
+
+        results = grep_docs(r"timeout to \d+s", store)
+
+        assert len(results) == 2
+        assert results[0].line_number == 1
+        assert results[1].line_number == 2
+
+    def test_context_lines(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Steps",
+                    "path": "steps",
+                    "content": "Line A\nLine B\nLine C\nLine D\nLine E",
+                },
+            ],
+        })
+
+        results = grep_docs("Line C", store, context_lines=1)
+
+        assert len(results) == 1
+        m = results[0]
+        assert m.line_number == 3
+        assert m.context_before == ["Line B"]
+        assert m.context_after == ["Line D"]
+
+    def test_scoped_to_one_doc(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "alpha": [
+                {
+                    "title": "Alpha Intro",
+                    "path": "intro",
+                    "content": "Welcome to alpha.",
+                },
+            ],
+            "beta": [
+                {
+                    "title": "Beta Intro",
+                    "path": "intro",
+                    "content": "Welcome to beta.",
+                },
+            ],
+        })
+
+        results = grep_docs("Welcome", store, doc_name="alpha")
+
+        assert len(results) == 1
+        assert results[0].doc_name == "alpha"
+
+    def test_no_matches_returns_empty(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Intro",
+                    "path": "intro",
+                    "content": "Hello world.",
+                },
+            ],
+        })
+
+        results = grep_docs("zzz-nonexistent-pattern", store)
+
+        assert results == []
+
+    def test_grouped_by_section(self, tmp_path):
+        """Multiple matches in the same section should be adjacent."""
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "First Section",
+                    "path": "first",
+                    "content": "apple pie\norange juice\napple sauce",
+                },
+                {
+                    "title": "Second Section",
+                    "path": "second",
+                    "content": "apple cider\nbanana split",
+                },
+            ],
+        })
+
+        results = grep_docs("apple", store)
+
+        assert len(results) == 3
+        # First two matches should come from "first" section (grouped)
+        assert results[0].section_path == "first"
+        assert results[1].section_path == "first"
+        # Third from "second"
+        assert results[2].section_path == "second"
+
+    def test_case_insensitive(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Casing",
+                    "path": "casing",
+                    "content": "Hello World\nhello world\nHELLO WORLD",
+                },
+            ],
+        })
+
+        results = grep_docs("hello world", store)
+
+        assert len(results) == 3
+
+    def test_empty_store(self, tmp_path):
+        store = tmp_path / ".king-context"
+        # store does not exist at all
+        results = grep_docs("anything", store)
+        assert results == []
+
+    def test_context_lines_at_boundaries(self, tmp_path):
+        """Context lines should not go out of bounds at start/end of content."""
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Boundary",
+                    "path": "boundary",
+                    "content": "First line\nSecond line\nThird line",
+                },
+            ],
+        })
+
+        # Match first line - context_before should be empty
+        results = grep_docs("First line", store, context_lines=2)
+        assert len(results) == 1
+        assert results[0].context_before == []
+        assert results[0].context_after == ["Second line", "Third line"]
+
+        # Match last line - context_after should be empty
+        results = grep_docs("Third line", store, context_lines=2)
+        assert len(results) == 1
+        assert results[0].context_before == ["First line", "Second line"]
+        assert results[0].context_after == []
+
+    def test_skips_underscore_directories(self, tmp_path):
+        store = _create_store(tmp_path, {
+            "my-api": [
+                {
+                    "title": "Visible",
+                    "path": "visible",
+                    "content": "match here",
+                },
+            ],
+        })
+        # Create an underscore directory that should be skipped
+        hidden_dir = store / "_internal" / "sections"
+        hidden_dir.mkdir(parents=True)
+        (store / "_internal" / "index.json").write_text('{"name":"_internal"}')
+        section_data = {
+            "title": "Hidden",
+            "path": "hidden",
+            "content": "match here too",
+        }
+        (hidden_dir / "hidden.json").write_text(json.dumps(section_data))
+
+        results = grep_docs("match", store)
+
+        assert len(results) == 1
+        assert results[0].doc_name == "my-api"

--- a/tests/test_context_cli/test_indexer.py
+++ b/tests/test_context_cli/test_indexer.py
@@ -1,0 +1,185 @@
+"""Tests for context_cli.indexer module."""
+
+import json
+
+from context_cli.indexer import IndexResult, index_all, index_doc
+
+
+def _make_source_json(path, name="test-api", sections=None):
+    """Create a monolithic source JSON file."""
+    if sections is None:
+        sections = [
+            {
+                "title": "Getting Started",
+                "path": "getting-started",
+                "url": "https://example.com/getting-started",
+                "keywords": ["setup", "install"],
+                "use_cases": ["How to install the SDK"],
+                "tags": ["guide"],
+                "priority": 10,
+                "content": "Install with pip install test-api",
+            },
+            {
+                "title": "Authentication",
+                "path": "authentication",
+                "url": "https://example.com/auth",
+                "keywords": ["auth", "api-key"],
+                "use_cases": ["How to authenticate requests"],
+                "tags": ["guide", "security"],
+                "priority": 8,
+                "content": "Use your API key in the header",
+            },
+        ]
+    data = {
+        "name": name,
+        "display_name": "Test API",
+        "version": "v1",
+        "base_url": "https://example.com",
+        "sections": sections,
+    }
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_index_doc_creates_structure(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    result = index_doc(src, store)
+
+    assert result.doc_name == "test-api"
+    assert result.section_count == 2
+    assert (store / "test-api" / "index.json").exists()
+    assert (store / "test-api" / "sections" / "getting-started.json").exists()
+    assert (store / "test-api" / "sections" / "authentication.json").exists()
+
+
+def test_index_doc_creates_index_json(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    index_doc(src, store)
+    index_data = json.loads((store / "test-api" / "index.json").read_text())
+
+    assert index_data["name"] == "test-api"
+    assert index_data["display_name"] == "Test API"
+    assert index_data["section_count"] == 2
+    assert "indexed_at" in index_data
+    # index.json should not contain content
+    assert "sections" not in index_data
+    assert "content" not in index_data
+
+
+def test_index_doc_section_files_have_token_estimate(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    index_doc(src, store)
+    section = json.loads(
+        (store / "test-api" / "sections" / "getting-started.json").read_text()
+    )
+
+    assert "token_estimate" in section
+    assert section["token_estimate"] > 0
+    assert section["content"] == "Install with pip install test-api"
+
+
+def test_index_doc_keywords_reverse_index(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    index_doc(src, store)
+    keywords = json.loads((store / "test-api" / "keywords.json").read_text())
+
+    assert "setup" in keywords
+    assert "getting-started" in keywords["setup"]
+    assert "auth" in keywords
+    assert "authentication" in keywords["auth"]
+
+
+def test_index_doc_use_cases_reverse_index(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    index_doc(src, store)
+    use_cases = json.loads((store / "test-api" / "use_cases.json").read_text())
+
+    assert "How to install the SDK" in use_cases
+    assert "getting-started" in use_cases["How to install the SDK"]
+
+
+def test_index_doc_tags_reverse_index(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    index_doc(src, store)
+    tags = json.loads((store / "test-api" / "tags.json").read_text())
+
+    assert "guide" in tags
+    assert "getting-started" in tags["guide"]
+    assert "authentication" in tags["guide"]
+    assert "security" in tags
+    assert "authentication" in tags["security"]
+
+
+def test_index_doc_reindex_overwrites(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json")
+    store = tmp_path / "store"
+    store.mkdir()
+
+    # First index
+    index_doc(src, store)
+    # Create a stale file that should be removed on re-index
+    (store / "test-api" / "sections" / "stale-section.json").write_text("{}")
+
+    # Re-index
+    index_doc(src, store)
+    assert not (store / "test-api" / "sections" / "stale-section.json").exists()
+    assert (store / "test-api" / "sections" / "getting-started.json").exists()
+
+
+def test_index_doc_empty_sections(tmp_path):
+    src = _make_source_json(tmp_path / "test-api.json", sections=[])
+    store = tmp_path / "store"
+    store.mkdir()
+
+    result = index_doc(src, store)
+
+    assert result.section_count == 0
+    assert (store / "test-api" / "index.json").exists()
+    keywords = json.loads((store / "test-api" / "keywords.json").read_text())
+    assert keywords == {}
+
+
+def test_index_all(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _make_source_json(data_dir / "api-one.json", name="api-one")
+    _make_source_json(data_dir / "api-two.json", name="api-two")
+
+    store = tmp_path / "store"
+    store.mkdir()
+
+    results = index_all(data_dir, store)
+
+    assert len(results) == 2
+    assert results[0].doc_name == "api-one"
+    assert results[1].doc_name == "api-two"
+    assert (store / "api-one" / "index.json").exists()
+    assert (store / "api-two" / "index.json").exists()
+
+
+def test_index_all_empty_dir(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    store = tmp_path / "store"
+    store.mkdir()
+
+    results = index_all(data_dir, store)
+    assert results == []

--- a/tests/test_context_cli/test_reader.py
+++ b/tests/test_context_cli/test_reader.py
@@ -1,0 +1,143 @@
+"""Tests for context_cli.reader module."""
+
+import json
+
+import pytest
+
+from context_cli.reader import SectionContent, read_section, suggest_similar
+
+
+def _make_section(store_dir, doc_name, section_path, title="Test Section",
+                  content="Some content here.", url="https://example.com/s",
+                  keywords=None, use_cases=None, tags=None, priority=5):
+    """Helper to create a doc structure with a single section file."""
+    sections_dir = store_dir / doc_name / "sections"
+    sections_dir.mkdir(parents=True, exist_ok=True)
+
+    token_estimate = int(len(content.split()) * 1.33)
+    data = {
+        "title": title,
+        "path": section_path,
+        "url": url,
+        "keywords": keywords or [],
+        "use_cases": use_cases or [],
+        "tags": tags or [],
+        "priority": priority,
+        "content": content,
+        "token_estimate": token_estimate,
+    }
+    (sections_dir / f"{section_path}.json").write_text(json.dumps(data))
+    return sections_dir / f"{section_path}.json"
+
+
+# --- Full read ---
+
+def test_full_read_returns_complete_content(tmp_path):
+    content = "This is the full content of the section."
+    _make_section(tmp_path, "my-api", "getting-started", content=content)
+
+    result = read_section("my-api", "getting-started", tmp_path)
+
+    assert isinstance(result, SectionContent)
+    assert result.content == content
+    assert result.title == "Test Section"
+    assert result.url == "https://example.com/s"
+    assert result.is_preview is False
+    assert result.token_estimate == int(len(content.split()) * 1.33)
+
+
+# --- Preview mode ---
+
+def test_preview_mode_truncates_long_content(tmp_path):
+    # Build content with 300 words (well over the 150-word preview limit).
+    words = [f"word{i}" for i in range(300)]
+    long_content = " ".join(words)
+    _make_section(tmp_path, "my-api", "long-section", content=long_content)
+
+    result = read_section("my-api", "long-section", tmp_path, preview=True)
+
+    assert result.is_preview is True
+    # Preview should contain only the first 150 words.
+    assert result.content == " ".join(words[:150])
+
+
+def test_preview_includes_full_token_estimate(tmp_path):
+    words = [f"word{i}" for i in range(300)]
+    long_content = " ".join(words)
+    full_estimate = int(len(long_content.split()) * 1.33)
+    _make_section(tmp_path, "my-api", "long-section", content=long_content)
+
+    result = read_section("my-api", "long-section", tmp_path, preview=True)
+
+    # token_estimate reflects the *full* content, not the truncated preview.
+    assert result.token_estimate == full_estimate
+
+
+def test_preview_short_content_not_truncated(tmp_path):
+    short = "A few words only."
+    _make_section(tmp_path, "my-api", "short", content=short)
+
+    result = read_section("my-api", "short", tmp_path, preview=True)
+
+    assert result.content == short
+    assert result.is_preview is False
+
+
+# --- Section not found ---
+
+def test_section_not_found_raises(tmp_path):
+    # Create doc dir with one section so suggestions can be generated.
+    _make_section(tmp_path, "my-api", "getting-started")
+
+    with pytest.raises(FileNotFoundError, match="not found in 'my-api'"):
+        read_section("my-api", "nonexistent-section", tmp_path)
+
+
+def test_section_not_found_includes_suggestions(tmp_path):
+    _make_section(tmp_path, "my-api", "getting-started")
+
+    with pytest.raises(FileNotFoundError, match="getting-started"):
+        read_section("my-api", "getting", tmp_path)
+
+
+# --- suggest_similar ---
+
+def test_suggest_similar_returns_matching_paths(tmp_path):
+    _make_section(tmp_path, "my-api", "getting-started")
+    _make_section(tmp_path, "my-api", "getting-advanced")
+    _make_section(tmp_path, "my-api", "auth-setup")
+    _make_section(tmp_path, "my-api", "configuration")
+
+    results = suggest_similar("my-api", "getting", tmp_path)
+
+    assert "getting-started" in results
+    assert "getting-advanced" in results
+    # "auth-setup" and "configuration" should not match "getting"
+    assert "auth-setup" not in results
+    assert "configuration" not in results
+
+
+def test_suggest_similar_max_five(tmp_path):
+    for i in range(10):
+        _make_section(tmp_path, "my-api", f"setup-{i}")
+
+    results = suggest_similar("my-api", "setup", tmp_path)
+
+    assert len(results) <= 5
+
+
+def test_suggest_similar_no_sections_dir(tmp_path):
+    results = suggest_similar("nonexistent", "anything", tmp_path)
+    assert results == []
+
+
+# --- Edge case: empty content ---
+
+def test_empty_content(tmp_path):
+    _make_section(tmp_path, "my-api", "empty-section", content="")
+
+    result = read_section("my-api", "empty-section", tmp_path)
+
+    assert result.content == ""
+    assert result.is_preview is False
+    assert result.token_estimate == 0

--- a/tests/test_context_cli/test_searcher.py
+++ b/tests/test_context_cli/test_searcher.py
@@ -1,0 +1,258 @@
+"""Tests for context_cli.searcher module."""
+
+import json
+
+from context_cli.searcher import SearchResult, search
+
+
+def _make_doc(store_dir, name, sections):
+    """Create a full .king-context/<doc>/ structure with reverse indexes.
+
+    Each section dict must have: path, title, keywords, use_cases, tags, priority, content.
+    """
+    doc_dir = store_dir / name
+    sections_dir = doc_dir / "sections"
+    sections_dir.mkdir(parents=True)
+
+    # index.json
+    (doc_dir / "index.json").write_text(json.dumps({
+        "name": name,
+        "display_name": name,
+        "version": "v1",
+        "base_url": "https://example.com",
+        "section_count": len(sections),
+    }))
+
+    # Build reverse indexes
+    keywords_index: dict[str, list[str]] = {}
+    use_cases_index: dict[str, list[str]] = {}
+    tags_index: dict[str, list[str]] = {}
+
+    for s in sections:
+        path = s["path"]
+        section_data = {
+            "title": s["title"],
+            "path": path,
+            "url": s.get("url", ""),
+            "keywords": s.get("keywords", []),
+            "use_cases": s.get("use_cases", []),
+            "tags": s.get("tags", []),
+            "priority": s.get("priority", 0),
+            "content": s.get("content", ""),
+            "token_estimate": len(s.get("content", "").split()),
+        }
+        (sections_dir / f"{path}.json").write_text(json.dumps(section_data))
+
+        for kw in s.get("keywords", []):
+            keywords_index.setdefault(kw, []).append(path)
+        for uc in s.get("use_cases", []):
+            use_cases_index.setdefault(uc, []).append(path)
+        for tag in s.get("tags", []):
+            tags_index.setdefault(tag, []).append(path)
+
+    (doc_dir / "keywords.json").write_text(json.dumps(keywords_index))
+    (doc_dir / "use_cases.json").write_text(json.dumps(use_cases_index))
+    (doc_dir / "tags.json").write_text(json.dumps(tags_index))
+
+    return doc_dir
+
+
+SECTIONS_A = [
+    {
+        "path": "getting-started",
+        "title": "Getting Started",
+        "keywords": ["setup", "install"],
+        "use_cases": ["How to install the SDK"],
+        "tags": ["guide"],
+        "priority": 10,
+        "content": "Install with pip install test-api",
+    },
+    {
+        "path": "authentication",
+        "title": "Authentication",
+        "keywords": ["auth", "api-key"],
+        "use_cases": ["How to authenticate requests"],
+        "tags": ["guide", "security"],
+        "priority": 8,
+        "content": "Use your API key in the header",
+    },
+    {
+        "path": "rate-limiting",
+        "title": "Rate Limiting",
+        "keywords": ["rate-limit", "throttle"],
+        "use_cases": ["How to handle rate limits"],
+        "tags": ["reference"],
+        "priority": 5,
+        "content": "Rate limits are 100 requests per minute",
+    },
+]
+
+SECTIONS_B = [
+    {
+        "path": "setup",
+        "title": "Setup Guide",
+        "keywords": ["setup", "configuration"],
+        "use_cases": ["How to set up the CLI tool"],
+        "tags": ["guide"],
+        "priority": 9,
+        "content": "Run the setup wizard to get started",
+    },
+    {
+        "path": "plugins",
+        "title": "Plugins",
+        "keywords": ["plugins", "extensions"],
+        "use_cases": ["How to install plugins"],
+        "tags": ["reference"],
+        "priority": 6,
+        "content": "Plugins extend the core functionality",
+    },
+]
+
+
+def test_keyword_match_scoring(tmp_path):
+    """Keyword exact match should add 3 points per hit."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("setup", tmp_path, doc_name="test-api")
+
+    assert len(results) >= 1
+    # "getting-started" has keyword "setup" (3) + priority 10*0.5 (5) = 8
+    gs = [r for r in results if r.section_path == "getting-started"][0]
+    assert gs.score == 3.0 + 10 * 0.5
+
+
+def test_use_case_substring_match(tmp_path):
+    """Use-case substring match should add 2 points per hit."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("install", tmp_path, doc_name="test-api")
+
+    # "getting-started" has keyword "install" (3) + use_case contains "install" (2)
+    # + priority 10*0.5 (5) = 10
+    gs = [r for r in results if r.section_path == "getting-started"][0]
+    assert gs.score == 3.0 + 2.0 + 10 * 0.5
+
+
+def test_tag_match_scoring(tmp_path):
+    """Tag exact match should add 1 point per hit."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("guide", tmp_path, doc_name="test-api")
+
+    # Both "getting-started" and "authentication" have tag "guide"
+    paths = {r.section_path for r in results}
+    assert "getting-started" in paths
+    assert "authentication" in paths
+    # "getting-started": tag "guide"(1) + priority 10*0.5(5) = 6
+    gs = [r for r in results if r.section_path == "getting-started"][0]
+    assert gs.score == 1.0 + 10 * 0.5
+
+
+def test_combined_scoring(tmp_path):
+    """A term matching keywords, use_cases, and tags should accumulate all weights."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    # "security" matches tag "security" on authentication section
+    # Also "authenticate" in use_case "How to authenticate requests" would not match
+    # because the term is "security" not "authenticate".
+    # auth section: tag "security"(1) + priority 8*0.5(4) = 5
+    results = search("security", tmp_path, doc_name="test-api")
+
+    auth = [r for r in results if r.section_path == "authentication"][0]
+    assert auth.score == 1.0 + 8 * 0.5
+
+
+def test_cross_doc_search(tmp_path):
+    """Search without doc_name should return results from all docs."""
+    _make_doc(tmp_path, "api-a", SECTIONS_A)
+    _make_doc(tmp_path, "api-b", SECTIONS_B)
+
+    results = search("setup", tmp_path)
+
+    doc_names = {r.doc_name for r in results}
+    assert "api-a" in doc_names
+    assert "api-b" in doc_names
+
+
+def test_single_doc_filtering(tmp_path):
+    """Search with doc_name should only return results from that doc."""
+    _make_doc(tmp_path, "api-a", SECTIONS_A)
+    _make_doc(tmp_path, "api-b", SECTIONS_B)
+
+    results = search("setup", tmp_path, doc_name="api-a")
+
+    for r in results:
+        assert r.doc_name == "api-a"
+
+
+def test_empty_results(tmp_path):
+    """Search with no matching terms should return empty list."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("nonexistent-foobar", tmp_path, doc_name="test-api")
+
+    assert results == []
+
+
+def test_top_n_limiting(tmp_path):
+    """Results should be limited to the top parameter."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("guide", tmp_path, doc_name="test-api", top=1)
+
+    assert len(results) == 1
+    # Should return highest-scored result (getting-started has higher priority)
+    assert results[0].section_path == "getting-started"
+
+
+def test_empty_query_returns_nothing(tmp_path):
+    """An empty query string should return empty list."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("", tmp_path, doc_name="test-api")
+
+    assert results == []
+
+
+def test_nonexistent_doc_returns_empty(tmp_path):
+    """Searching a doc_name that does not exist returns empty."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("setup", tmp_path, doc_name="no-such-doc")
+
+    assert results == []
+
+
+def test_results_sorted_by_score_descending(tmp_path):
+    """Results must come back sorted highest score first."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("guide", tmp_path, doc_name="test-api")
+
+    scores = [r.score for r in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_search_result_has_metadata_fields(tmp_path):
+    """Each SearchResult should carry metadata from the section file."""
+    _make_doc(tmp_path, "test-api", SECTIONS_A)
+
+    results = search("setup", tmp_path, doc_name="test-api")
+
+    gs = [r for r in results if r.section_path == "getting-started"][0]
+    assert gs.title == "Getting Started"
+    assert "setup" in gs.keywords
+    assert gs.priority == 10
+    assert isinstance(gs.use_cases, list)
+    assert isinstance(gs.tags, list)
+
+
+def test_skips_underscore_directories(tmp_path):
+    """Directories starting with underscore should be skipped in cross-doc search."""
+    _make_doc(tmp_path, "real-doc", SECTIONS_A)
+    _make_doc(tmp_path, "_internal", SECTIONS_B)
+
+    results = search("setup", tmp_path)
+
+    doc_names = {r.doc_name for r in results}
+    assert "_internal" not in doc_names

--- a/tests/test_context_cli/test_store.py
+++ b/tests/test_context_cli/test_store.py
@@ -1,0 +1,94 @@
+"""Tests for context_cli.store module."""
+
+import json
+
+from context_cli.store import doc_exists, get_store_dir, list_docs
+
+
+def _make_doc(store_dir, name, display_name="Test Doc", version="v1",
+              section_count=5, base_url="https://example.com"):
+    """Helper to create a doc directory with index.json."""
+    doc_dir = store_dir / name
+    doc_dir.mkdir(parents=True)
+    index = {
+        "name": name,
+        "display_name": display_name,
+        "version": version,
+        "section_count": section_count,
+        "base_url": base_url,
+    }
+    (doc_dir / "index.json").write_text(json.dumps(index))
+    return doc_dir
+
+
+def test_get_store_dir_returns_path():
+    result = get_store_dir()
+    assert result.name == ".king-context"
+    assert result.is_absolute()
+
+
+def test_list_docs_empty_store(tmp_path):
+    assert list_docs(tmp_path) == []
+
+
+def test_list_docs_nonexistent_dir(tmp_path):
+    assert list_docs(tmp_path / "nonexistent") == []
+
+
+def test_list_docs_single_doc(tmp_path):
+    _make_doc(tmp_path, "my-api", display_name="My API", section_count=10)
+    docs = list_docs(tmp_path)
+    assert len(docs) == 1
+    assert docs[0].name == "my-api"
+    assert docs[0].display_name == "My API"
+    assert docs[0].section_count == 10
+
+
+def test_list_docs_multiple_sorted(tmp_path):
+    _make_doc(tmp_path, "zebra-api")
+    _make_doc(tmp_path, "alpha-api")
+    docs = list_docs(tmp_path)
+    assert len(docs) == 2
+    assert docs[0].name == "alpha-api"
+    assert docs[1].name == "zebra-api"
+
+
+def test_list_docs_skips_underscore_dirs(tmp_path):
+    _make_doc(tmp_path, "real-doc")
+    learned = tmp_path / "_learned"
+    learned.mkdir()
+    (learned / "index.json").write_text('{"name": "_learned"}')
+    docs = list_docs(tmp_path)
+    assert len(docs) == 1
+    assert docs[0].name == "real-doc"
+
+
+def test_list_docs_skips_dirs_without_index(tmp_path):
+    _make_doc(tmp_path, "valid-doc")
+    (tmp_path / "no-index").mkdir()
+    docs = list_docs(tmp_path)
+    assert len(docs) == 1
+
+
+def test_list_docs_skips_malformed_json(tmp_path):
+    _make_doc(tmp_path, "good-doc")
+    bad_dir = tmp_path / "bad-doc"
+    bad_dir.mkdir()
+    (bad_dir / "index.json").write_text("not json")
+    docs = list_docs(tmp_path)
+    assert len(docs) == 1
+    assert docs[0].name == "good-doc"
+
+
+def test_doc_exists_true(tmp_path):
+    _make_doc(tmp_path, "my-api")
+    assert doc_exists("my-api", tmp_path) is True
+
+
+def test_doc_exists_false_no_dir(tmp_path):
+    assert doc_exists("nope", tmp_path) is False
+
+
+def test_doc_exists_false_no_index(tmp_path):
+    (tmp_path / "partial").mkdir()
+    assert doc_exists("partial", tmp_path) is False

--- a/tests/test_context_cli/test_topics.py
+++ b/tests/test_context_cli/test_topics.py
@@ -1,0 +1,176 @@
+"""Tests for the topics subcommand in context_cli.cli."""
+
+import json
+import sys
+
+import pytest
+
+
+def _build_doc(store_dir, doc_name="test-api"):
+    """Create a .king-context/<doc>/ structure with tags.json and section files.
+
+    Returns the doc directory path.
+    """
+    doc_dir = store_dir / doc_name
+    sections_dir = doc_dir / "sections"
+    sections_dir.mkdir(parents=True)
+
+    # index.json so doc_exists() returns True
+    index_meta = {
+        "name": doc_name,
+        "display_name": "Test API",
+        "version": "v1",
+        "base_url": "https://example.com",
+        "section_count": 3,
+    }
+    (doc_dir / "index.json").write_text(json.dumps(index_meta))
+
+    # Section files
+    sections = [
+        {
+            "title": "Getting Started",
+            "path": "getting-started",
+            "url": "https://example.com/getting-started",
+            "keywords": ["setup", "install"],
+            "use_cases": ["How to install the SDK"],
+            "tags": ["guide"],
+            "priority": 10,
+            "content": "Install with pip.",
+            "token_estimate": 5,
+        },
+        {
+            "title": "Authentication",
+            "path": "authentication",
+            "url": "https://example.com/auth",
+            "keywords": ["auth", "api-key"],
+            "use_cases": ["How to authenticate"],
+            "tags": ["guide", "security"],
+            "priority": 8,
+            "content": "Use your API key.",
+            "token_estimate": 6,
+        },
+        {
+            "title": "Rate Limits",
+            "path": "rate-limits",
+            "url": "https://example.com/rate-limits",
+            "keywords": ["limits", "throttle"],
+            "use_cases": ["Handle rate limits"],
+            "tags": ["security"],
+            "priority": 5,
+            "content": "Rate limit is 100 req/s.",
+            "token_estimate": 7,
+        },
+    ]
+
+    for sec in sections:
+        (sections_dir / f"{sec['path']}.json").write_text(json.dumps(sec))
+
+    # tags.json — reverse index: tag -> [section paths]
+    tags_index = {
+        "guide": ["getting-started", "authentication"],
+        "security": ["authentication", "rate-limits"],
+    }
+    (doc_dir / "tags.json").write_text(json.dumps(tags_index))
+
+    return doc_dir
+
+
+@pytest.fixture
+def store_with_topics(tmp_path, monkeypatch):
+    """Create a store with one doc and patch STORE_DIR."""
+    store_dir = tmp_path / ".king-context"
+    store_dir.mkdir()
+    _build_doc(store_dir)
+
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+
+    return store_dir
+
+
+def _run_cli(args, monkeypatch):
+    """Run CLI by patching sys.argv and calling main()."""
+    from context_cli.cli import main
+    monkeypatch.setattr(sys, "argv", ["kctx"] + args)
+    main()
+
+
+def test_topics_all_tags_shown(store_with_topics, monkeypatch, capsys):
+    """All tags are shown with their section counts."""
+    _run_cli(["topics", "test-api"], monkeypatch)
+    out = capsys.readouterr().out
+
+    assert "## guide (2 sections)" in out
+    assert "## security (2 sections)" in out
+    # Sections should appear under their tags
+    assert "Getting Started" in out
+    assert "Authentication" in out
+    assert "Rate Limits" in out
+
+
+def test_topics_sections_sorted_by_priority(store_with_topics, monkeypatch, capsys):
+    """Sections within each tag are sorted by priority descending."""
+    _run_cli(["topics", "test-api"], monkeypatch)
+    out = capsys.readouterr().out
+
+    # Under "guide": Getting Started (priority 10) should come before Authentication (priority 8)
+    guide_start = out.index("## guide")
+    gs_pos = out.index("Getting Started", guide_start)
+    auth_pos = out.index("Authentication", guide_start)
+    assert gs_pos < auth_pos
+
+    # Under "security": Authentication (priority 8) should come before Rate Limits (priority 5)
+    sec_start = out.index("## security")
+    auth_pos2 = out.index("Authentication", sec_start)
+    rl_pos = out.index("Rate Limits", sec_start)
+    assert auth_pos2 < rl_pos
+
+
+def test_topics_filter_by_tag(store_with_topics, monkeypatch, capsys):
+    """Filtering by --tag shows only that tag's sections."""
+    _run_cli(["topics", "test-api", "--tag", "security"], monkeypatch)
+    out = capsys.readouterr().out
+
+    assert "## security" in out
+    assert "Authentication" in out
+    assert "Rate Limits" in out
+    # "guide" tag should NOT appear
+    assert "## guide" not in out
+
+
+def test_topics_json_output(store_with_topics, monkeypatch, capsys):
+    """JSON output returns a dict of tag -> list of section dicts."""
+    _run_cli(["topics", "test-api", "--json"], monkeypatch)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+
+    assert isinstance(data, dict)
+    assert "guide" in data
+    assert "security" in data
+    assert len(data["guide"]) == 2
+    assert len(data["security"]) == 2
+
+    # Each entry has title, path, priority
+    entry = data["guide"][0]
+    assert "title" in entry
+    assert "path" in entry
+    assert "priority" in entry
+
+
+def test_topics_doc_not_found(tmp_path, monkeypatch, capsys):
+    """When the doc does not exist, an error message with available docs is shown."""
+    store_dir = tmp_path / ".king-context"
+    store_dir.mkdir()
+
+    # Create a different doc so the error can list available docs
+    _build_doc(store_dir, doc_name="other-api")
+
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+
+    with pytest.raises(SystemExit):
+        _run_cli(["topics", "nonexistent-api"], monkeypatch)
+
+    err = capsys.readouterr().err
+    assert "nonexistent-api" in err or "not found" in err.lower()
+    assert "other-api" in err


### PR DESCRIPTION
> **⚠️ WIP — Do not merge yet.** Still under testing. Will only merge after quality standards are guaranteed.

## Summary

Add `kctx` CLI — a file-based documentation search tool that gives AI agents direct control over search strategy, replacing the MCP protocol intermediary with faster, more token-efficient CLI commands.

## Why?

The MCP server approach forces a protocol intermediary between the agent and docs. Industry leaders (Playwright, Context7) are migrating to CLI + Skill because it gives agents direct control over search granularity — resulting in better accuracy and lower token usage. The `kctx` CLI operates on a `.king-context/` file store (no SQLite for reads) and a companion skill teaches the agent an optimal search strategy.

## What changed

- **New `context_cli` package** (`src/context_cli/`) with 7 modules: store, indexer, searcher, reader, formatter, grep, cli
- **`kctx` entry point** with 6 subcommands: `list`, `search`, `read`, `index`, `topics`, `grep`
- **File-based data store** (`.king-context/`) with per-doc structure: `index.json`, `sections/*.json`, reverse indexes (`keywords.json`, `use_cases.json`, `tags.json`)
- **Search scoring**: `keyword_hits*3 + use_case_hits*2 + tag_hits*1 + priority*0.5`
- **King-context skill** (`.claude/skills/king-context/skill.md`) with search strategy flowchart, CLI reference, and self-learning instructions
- **README updated** to position CLI as recommended approach, MCP as legacy
- **92 tests** across 8 test files, zero external dependencies (stdlib only)

## How to test

1. `pip install -e .` then `kctx --help` — verify all subcommands listed
2. `kctx index data/elevenlabs-api.json` — should index 187 sections
3. `kctx list` — should show elevenlabs-api with section count
4. `kctx search "streaming audio" --top 3` — should return ranked results
5. `kctx read elevenlabs-api <section-path> --preview` — should show ~200 token preview
6. `pytest tests/test_context_cli/ -v` — 92 tests should pass

## Checklist

- [x] Self-review done
- [x] No debug code left
- [x] Tests passing (92/92)
- [x] Quality review before merge