### PR TITLE
feat(research): add king-research CLI + split stores

### DIFF
--- a/.claude/skills/king-context/skill.md
+++ b/.claude/skills/king-context/skill.md
@@ -1,18 +1,34 @@
 # King Context — Documentation Search Skill
 
-Search indexed documentation efficiently using `kctx` CLI. Find the right section in ≤3 calls.
+Search indexed documentation and research corpora efficiently using `kctx`. Find the right section in ≤3 calls.
 
-**Triggers**: documentation lookup, "search docs", "find in docs", library usage questions, "how to use X", "what's the API for X"
+**Triggers**: documentation lookup, "search docs", "find in docs", library usage questions, "how to use X", "what's the API for X", "what does our research say about X"
+
+---
+
+## Two Stores, One CLI
+
+King Context keeps two separate stores:
+
+| Store | Populated by | What's in it |
+|---|---|---|
+| `docs` | `king-scrape <url>` | Scraped product/API documentation (e.g. `exa`, `elevenlabs-api`, `httpx`) |
+| `research` | `king-research <topic>` | Topic-driven research corpora pulled from the open web (e.g. `prompt-engineering-techniques`) |
+
+Every `kctx` command is source-aware:
+- Default: searches **both** stores, merged by score.
+- `--source docs|research` scopes to one store.
+- `--doc <name>` scopes to a single doc (works across stores — most precise filter).
+
+Every search/grep hit is prefixed `[docs]` or `[research]` so you can tell the source at a glance.
 
 ---
 
 ## Search Strategy
 
-Follow this flowchart for every documentation lookup. Stop as soon as you have the answer.
-
 ```
 1. Check _learned/     →  known shortcut?  → kctx read <doc> <path>  → DONE
-2. kctx list           →  which doc?
+2. kctx list           →  which doc + which store?
 3. kctx search "query" →  find section     → got it?
 4. kctx read --preview →  assess relevance → right section?
 5. kctx read           →  full content     → DONE
@@ -20,12 +36,26 @@ Follow this flowchart for every documentation lookup. Stop as soon as you have t
 ```
 
 **Rules**:
-- ALWAYS check `_learned/` FIRST — costs ~100 tokens, saves thousands
-- ALWAYS verify learned paths still exist before using them (`kctx read` will error if stale)
-- Prefer `kctx search` over `kctx grep` — metadata search is faster and cheaper
-- Use `--preview` before full read — assess relevance before paying full token cost
-- Use `kctx grep` only when you need to find exact code patterns or API names
-- NEVER read all sections — search narrows, preview confirms, then read only what's needed
+- ALWAYS check `_learned/` FIRST — costs ~100 tokens, saves thousands.
+- ALWAYS verify learned paths still exist before using them (`kctx read` errors if stale).
+- Prefer `kctx search` over `kctx grep` — metadata search is faster and cheaper.
+- Use `--preview` before full read — assess relevance before paying full token cost.
+- Use `kctx grep` only for exact code patterns, API names, or error strings.
+- **Scope aggressively**: `--doc <name>` > `--source <store>` > unfiltered.
+- NEVER read all sections — search narrows, preview confirms, then read only what's needed.
+
+---
+
+## Picking a Filter (decision tree)
+
+```
+User asks about a specific library/product/SDK?  → --doc <name>
+User asks about a research topic you scraped?    → --doc <research-slug>
+User asks something generic, unsure which doc?   → --source docs or --source research
+User asks "is it anywhere in our indexed stuff?" → no filter (search both)
+```
+
+`--doc` is the sharpest tool. Run `kctx list` once if you don't know the name.
 
 ---
 
@@ -36,64 +66,95 @@ Transform user intent into efficient CLI queries:
 | User asks | CLI query |
 |-----------|-----------|
 | "How to stream audio with ElevenLabs" | `kctx search "streaming" --doc elevenlabs-api` |
-| "Authentication for the API" | `kctx search "auth api-key"` |
-| "What WebSocket events are available" | `kctx search "websocket events"` |
-| "Find where Client( is used" | `kctx grep "Client(" --doc httpx` |
+| "Authentication for the Exa API" | `kctx search "auth api-key" --doc exa` |
+| "What does our research say on Chain of Thought" | `kctx search "chain of thought" --source research` |
+| "Compare ToT vs CoT — anything indexed?" | `kctx search "tree of thoughts" --source research --top 5` |
+| "Is rate limiting documented anywhere?" | `kctx search "rate limit"` (both stores) |
+| "Find where `Client(` is used in httpx" | `kctx grep "Client\\(" --doc httpx` |
 | "What topics does the docs cover" | `kctx topics elevenlabs-api` |
+| "Show only our research corpora" | `kctx list research` |
 
 **Tips**:
-- Use 1-2 specific keywords, not full sentences
-- Scope to `--doc` when you know which doc
-- Use `--top 3` to reduce output tokens
-- Keywords match exact terms; use_cases match substrings — "stream" matches "How to stream audio"
+- Use 1–2 specific keywords, not full sentences.
+- Scope to `--doc` when you know which doc.
+- Use `--top 3` to reduce output tokens.
+- Keywords match exact terms; use_cases match substrings — "stream" matches "How to stream audio".
 
 ---
 
 ## CLI Command Reference
 
-### List available docs
+### List indexed content
 ```bash
-kctx list                    # compact table: name, display_name, version, sections
-kctx list --json             # JSON array
+kctx list                    # both stores with == Docs == / == Research == headers
+kctx list docs               # only scraped docs
+kctx list research           # only research corpora
+kctx list --json             # JSON (grouped dict when "all", flat list when filtered)
 ```
 
 ### Search by metadata (keywords, use_cases, tags)
 ```bash
-kctx search "query"                        # cross-doc search, top 5
-kctx search "streaming" --doc elevenlabs-api  # scoped to one doc
-kctx search "auth" --top 3                 # limit results
-kctx search "query" --json                 # JSON output
+kctx search "query"                              # cross-store, top 5, merged by score
+kctx search "streaming" --doc elevenlabs-api     # scoped to a single doc (auto-resolves store)
+kctx search "reasoning" --source research        # only research corpora
+kctx search "livecrawl" --source docs            # only scraped docs
+kctx search "auth" --top 3                       # limit results
+kctx search "query" --json                       # JSON output
 ```
-Returns: title, path, score, first use_case. **No content** — metadata only.
+Output tags every hit with `[docs]` or `[research]`. Returns title, path, score, first use_case. **No content** — metadata only.
 
 ### Read a section
 ```bash
-kctx read <doc> <section-path>             # full content
+kctx read <doc> <section-path>             # full content (auto-finds the store)
 kctx read <doc> <section-path> --preview   # first ~200 tokens + total estimate
+kctx read <doc> <section-path> --source research   # force store (rarely needed)
 kctx read <doc> <section-path> --json      # JSON output
 ```
-If section not found, suggests similar paths.
+If the doc name isn't unique, pass `--source`. If section not found, suggests similar paths.
 
 ### Browse by topic
 ```bash
 kctx topics <doc>                          # all tags with sections
 kctx topics <doc> --tag api-reference      # filter to one tag
+kctx topics <doc> --source research        # disambiguate if needed
 kctx topics <doc> --json                   # JSON output
 ```
 
 ### Grep content
 ```bash
-kctx grep "pattern"                        # regex across all docs
-kctx grep "Client(" --doc httpx            # scoped to one doc
+kctx grep "pattern"                        # regex across both stores
+kctx grep "Client\\(" --doc httpx          # scoped to one doc
+kctx grep "livecrawl" --source docs        # scoped to docs store
 kctx grep "pattern" --context 3            # surrounding lines
 kctx grep "pattern" --json                 # JSON output
 ```
 
-### Index documentation
+### Index / re-index
 ```bash
-kctx index .king-context/data/example.json # index one doc
-kctx index --all                           # index all .king-context/data/*.json
+kctx index .king-context/data/example.json         # auto-detects via section.source_type
+kctx index .king-context/data/research/topic.json  # also auto-detected as research
+kctx index <path> --source research                # force-route to research store
+kctx index --all                                   # walks data/*.json + data/research/*.json
 ```
+
+---
+
+## Generating New Content
+
+Two producers feed the stores:
+
+```bash
+# Scrape a product/API doc site → .king-context/docs/<name>/
+king-scrape https://docs.example.com
+
+# Research a topic from the open web → .king-context/research/<slug>/
+king-research "prompt engineering techniques" --basic     # 3 queries, no deepening
+king-research "retrieval augmented generation" --medium   # 5 queries + 1 deepening iteration
+king-research "mixture of experts" --high                 # 8 + 2 iterations
+king-research "<topic>" --extrahigh                       # 12 + 3 iterations (most thorough)
+```
+
+Both auto-index on completion — the new doc is immediately searchable via `kctx`. `king-research` outputs are tagged `source_type: "research"` in every section so `--source research` and the `[research]` prefix work automatically.
 
 ---
 
@@ -102,9 +163,9 @@ kctx index --all                           # index all .king-context/data/*.json
 After finding a useful section, save a shortcut for future sessions.
 
 ### When to save
-- You found the right section after searching
-- You discovered a gotcha or non-obvious behavior
-- You found a pattern that would help answer similar questions
+- You found the right section after searching.
+- You discovered a gotcha or non-obvious behavior.
+- You found a pattern that would help answer similar questions.
 
 ### How to save
 Write to `.king-context/_learned/<doc-name>.md`:
@@ -114,6 +175,7 @@ Write to `.king-context/_learned/<doc-name>.md`:
 
 ## <Topic>
 - **<What>** → `<section-path>` section
+- Store: docs | research
 - Gotcha: <non-obvious behavior>
 - Related: `<other-section>` for <reason>
 
@@ -121,17 +183,13 @@ Write to `.king-context/_learned/<doc-name>.md`:
 Last updated: <date>
 ```
 
-### Format for each entry
-- **Query pattern**: what the user asked
-- **Section path**: the section that answered it
-- **Gotchas**: anything non-obvious (auth quirks, parameter caveats, etc.)
-- **Date**: when this was learned
+Tracking the store lets you skip `kctx list` on the next lookup.
 
 ### Reading learned shortcuts
-Before any search, check if a learned file exists:
-1. Read `.king-context/_learned/<doc-name>.md`
-2. If a shortcut matches the current query, use it directly: `kctx read <doc> <path>`
-3. If the path no longer exists (stale), fall back to normal search and update the learned file
+Before any search:
+1. Read `.king-context/_learned/<doc-name>.md`.
+2. If a shortcut matches the current query, use it directly: `kctx read <doc> <path>`.
+3. If the path no longer exists (stale), fall back to normal search and update the learned file.
 
 ---
 
@@ -140,7 +198,7 @@ Before any search, check if a learned file exists:
 ### Good (3 calls, ~400 tokens)
 ```
 kctx search "streaming" --doc elevenlabs-api --top 3
-→ Found: "WebSocket Streaming" (websocket-streaming) score=8.50
+→ 1. [docs] WebSocket Streaming (elevenlabs-api/websocket-streaming) score=8.50
 
 kctx read elevenlabs-api websocket-streaming --preview
 → "# WebSocket Streaming\n\nConnect to ws://..." Tokens: 450
@@ -149,12 +207,21 @@ kctx read elevenlabs-api websocket-streaming
 → Full content
 ```
 
+### Good (research-scoped, 2 calls)
+```
+kctx search "zero shot cot" --source research --top 3
+→ 1. [research] Zero-Shot CoT (prompt-engineering-techniques/ai-prompt-engineering-...) score=12.50
+
+kctx read prompt-engineering-techniques ai-prompt-engineering-patterns-cot-react-tot-zero-shot-cot
+→ Full content
+```
+
 ### Bad (wasteful, ~3000+ tokens)
 ```
 kctx list
 kctx topics elevenlabs-api
-kctx read elevenlabs-api getting-started        # wrong section
-kctx read elevenlabs-api text-to-speech         # still wrong
-kctx search "websocket streaming audio real-time"  # too many terms
-kctx read elevenlabs-api websocket-streaming    # finally found it
+kctx read elevenlabs-api getting-started              # wrong section
+kctx read elevenlabs-api text-to-speech               # still wrong
+kctx search "websocket streaming audio real-time"     # too many terms
+kctx read elevenlabs-api websocket-streaming          # finally found it
 ```

--- a/.claude/skills/king-research/skill.md
+++ b/.claude/skills/king-research/skill.md
@@ -1,0 +1,164 @@
+# King Research — Topic Research Skill
+
+Invoke `king-research` to build a research corpus on any topic. The user describes what they want; you extract the topic, pick the effort mode, and run the pipeline.
+
+**Triggers**: "/king-research", "research about X", "pesquise sobre Y", "pesquisa de Z", "build a corpus on W", "find sources about Q", "state of the art for R"
+
+---
+
+## When to use this skill
+
+| User wants... | Use |
+|---|---|
+| Sources on an open-web topic (papers, blog posts, discussions) | **king-research** (this skill) |
+| A specific product/API doc site scraped | **scraper-workflow** (`king-scrape`) |
+| To query already-indexed content | **king-context** (`kctx search`) |
+
+If the user already mentions a URL or a specific product's docs, hand off to `scraper-workflow`.
+
+---
+
+## Step 1: Extract the topic
+
+Pull the topic from the user's message as a concise phrase (2–6 words).
+
+**Rules**:
+- Strip filler: "please", "por favor", "pode fazer", "quero que", "me faça".
+- Keep semantic qualifiers: "for RAG pipelines", "in production", "2025".
+- Prefer the user's wording over paraphrase.
+- Quote multi-word topics when passing to the CLI.
+
+If the topic is vague (e.g. "faz um research aí", "pesquise algo"), ask ONE clarifying question before running: **"What topic?"**
+
+---
+
+## Step 2: Pick the effort mode
+
+### Explicit signals (override inference)
+
+| Signal in the user's message | Mode |
+|---|---|
+| "rápido", "quick", "basic", "só uma ideia", "overview", "simples" | `--basic` |
+| (no qualifier) | `--medium` (default) |
+| "detalhado", "aprofundado", "profundo", "detailed", "in-depth", "completo" | `--high` |
+| "exaustivo", "estado da arte", "thorough", "comprehensive", "state of the art", "máximo", "tudo que tiver" | `--extrahigh` |
+
+### Inferred from complexity (when no explicit signal)
+
+| Topic shape | Mode |
+|---|---|
+| Narrow, well-known (e.g. "httpx timeouts") | `--basic` |
+| Standard technical topic (e.g. "prompt caching strategies") | `--medium` (default) |
+| Broad or comparative (e.g. "RAG vs fine-tuning") | `--high` |
+| Bleeding-edge / multi-domain survey (e.g. "mixture of experts state of the art 2025") | `--extrahigh` |
+
+### Cost & time budget
+
+| Mode | Initial queries | Deepening iterations | ~Time | API cost |
+|---|---|---|---|---|
+| `--basic` | 3 | 0 | ~30s | minimal |
+| `--medium` | 5 | 1 | ~2 min | low |
+| `--high` | 8 | 2 | ~5 min | medium |
+| `--extrahigh` | 12 | 3 | ~10 min | high |
+
+For `--high` or `--extrahigh`, state the expected time before running so the user isn't surprised. No need to ask permission — just warn.
+
+---
+
+## Step 3: Run the pipeline
+
+```bash
+.king-context/bin/king-research "<topic>" --<mode> --yes
+```
+
+**Flags to remember**:
+- `--yes` / `-y` — skip the enrichment cost prompt (default ON from this skill; the user invoked us to do the work, not to be interrupted).
+- `--name <slug>` — override the auto-generated slug (rarely needed; only if the user explicitly names it).
+- `--no-auto-index` — don't auto-index into `.king-context/research/` (rarely; only if the user explicitly asks for JSON-only output).
+- `--step <stage>` / `--stop-after <stage>` — resume or partial-run (only for debugging; don't use proactively).
+
+**Pipeline stages** (for reference when resuming): `generate → search → chunk → enrich → export`.
+
+---
+
+## Step 4: Report + hand off to search
+
+After the pipeline finishes, report concisely:
+
+1. The slug it was saved under (auto-indexed in `.king-context/research/<slug>/`).
+2. Section count.
+3. Example commands to search it.
+
+Template:
+```
+Indexed "<slug>" — N sections. Try:
+  kctx search "<keyword>" --doc <slug>
+  kctx topics <slug>
+  kctx list research
+```
+
+Don't dump the full topic tree or section titles — let the user drive the search.
+
+---
+
+## Error handling
+
+| Error | Action |
+|---|---|
+| `EXA_API_KEY is not set` | "Set `EXA_API_KEY` in `.king-context/.env` or `./.env`, then retry." |
+| `OPENROUTER_API_KEY` missing | Same — both are required (query generation + enrichment). |
+| Zero results from Exa | Topic may be too niche or mis-spelled. Suggest rephrasing or adding context. |
+| Pipeline fails with "no chunks" or "no enriched sections" | Report which stage; usually means the topic returned no fetchable pages. Try broadening the topic. |
+| User hit a high/extrahigh run by mistake | Remind them `Ctrl+C` cancels; partial progress in `.king-context/_temp/research/<slug>/` is kept for resume via `--step`. |
+
+---
+
+## Examples
+
+### Implicit mode (inferred from complexity)
+```
+User: "pesquise sobre chain of thought prompting"
+→ Topic: "chain of thought prompting"
+→ Standard technical topic → --medium
+→ .king-context/bin/king-research "chain of thought prompting" --medium --yes
+→ "Indexed chain-of-thought-prompting — 14 sections."
+```
+
+### Explicit mode — quick
+```
+User: "faz um research rápido sobre retry backoff"
+→ Topic: "retry backoff"
+→ Signal "rápido" → --basic
+→ .king-context/bin/king-research "retry backoff" --basic --yes
+```
+
+### Explicit mode — exhaustive
+```
+User: "quero tudo sobre mixture of experts, estado da arte"
+→ Topic: "mixture of experts"
+→ Signal "estado da arte" → --extrahigh
+→ Warn: "~10 minutes and higher API cost — proceeding"
+→ .king-context/bin/king-research "mixture of experts" --extrahigh --yes
+```
+
+### Comparative (inferred high)
+```
+User: "compare RAG vs fine-tuning for code assistants"
+→ Topic: "RAG vs fine-tuning code assistants"
+→ Comparative, broad → --high
+→ .king-context/bin/king-research "RAG vs fine-tuning code assistants" --high --yes
+```
+
+### Vague topic (ask first)
+```
+User: "faz um research aí"
+→ Ask: "What topic?"
+→ (wait for reply, then resume from Step 1)
+```
+
+### User provides a URL — hand off
+```
+User: "research stripe docs"
+→ This is a doc site, not an open-web topic.
+→ Hand off to scraper-workflow: king-scrape https://docs.stripe.com
+```

--- a/installer/lib/doctor.js
+++ b/installer/lib/doctor.js
@@ -77,6 +77,7 @@ function checkSkills(projectDir) {
   const skills = [
     { path: '.claude/skills/king-context/skill.md', name: 'king-context' },
     { path: '.claude/skills/scraper-workflow/skill.md', name: 'scraper-workflow' },
+    { path: '.claude/skills/king-research/skill.md', name: 'king-research' },
   ];
 
   for (const skill of skills) {

--- a/installer/lib/doctor.js
+++ b/installer/lib/doctor.js
@@ -56,6 +56,19 @@ function checkCliTools(projectDir) {
     results.push({ status: 'warn', label: 'CLI: king-scrape found but returned an error' });
   }
 
+  // Check king-research
+  const researchPath = path.join(binDir, 'king-research');
+  try {
+    if (fs.existsSync(researchPath)) {
+      execSync(`"${researchPath}" --help`, { stdio: 'pipe', timeout: 10000 });
+      results.push({ status: 'ok', label: 'CLI: king-research is working' });
+    } else {
+      results.push({ status: 'fail', label: 'CLI: king-research not found' });
+    }
+  } catch {
+    results.push({ status: 'warn', label: 'CLI: king-research found but returned an error' });
+  }
+
   return results;
 }
 
@@ -125,6 +138,7 @@ function checkDirStructure(projectDir) {
     '.king-context/core',
     '.king-context/data',
     '.king-context/docs',
+    '.king-context/research',
     '.king-context/_learned',
     '.king-context/_temp',
   ];

--- a/installer/lib/scaffold.js
+++ b/installer/lib/scaffold.js
@@ -8,6 +8,7 @@ const DIRS = [
   'core',
   'data',
   'docs',
+  'research',
   '_learned',
   '_temp',
 ];
@@ -36,6 +37,7 @@ function writeWrappers(projectDir) {
   const wrappers = [
     { template: 'wrapper-kctx.sh', target: 'kctx' },
     { template: 'wrapper-scrape.sh', target: 'king-scrape' },
+    { template: 'wrapper-research.sh', target: 'king-research' },
   ];
 
   for (const { template, target } of wrappers) {

--- a/installer/lib/skills.js
+++ b/installer/lib/skills.js
@@ -51,6 +51,7 @@ function mergeSettings(projectDir) {
       allow: [
         'Bash(.king-context/bin/kctx *)',
         'Bash(.king-context/bin/king-scrape *)',
+        'Bash(.king-context/bin/king-research *)',
         'Bash(python3 *)',
         'Bash(python3*)',
         'Write(.king-context/**)',
@@ -116,6 +117,7 @@ function updateGitignore(projectDir) {
     marker,
     '.king-context/core/',
     '.king-context/docs/',
+    '.king-context/research/',
     '.king-context/data/',
     '.king-context/_temp/',
     '.king-context/_learned/',

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@king-context/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Installer for King Context — local-first documentation search for AI agents",
   "bin": {
     "king-context": "./bin/king-context.js"

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@king-context/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Installer for King Context — local-first documentation search for AI agents",
   "bin": {
     "king-context": "./bin/king-context.js"

--- a/installer/templates/env.example
+++ b/installer/templates/env.example
@@ -10,3 +10,32 @@ FIRECRAWL_API_KEY=
 # Not needed if using Claude Code sub-agents (Workflow B)
 # Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=
+
+# Required — Exa API key for king-research topic-driven web search
+# Powers semantic search and content retrieval for the research pipeline
+# Get yours at https://dashboard.exa.ai/api-keys
+EXA_API_KEY=
+
+# Optional — Jina API key for reranking and embeddings in king-research
+# The anonymous tier works for light use; set a key to raise rate limits
+# Get yours at https://jina.ai/api
+JINA_API_KEY=
+
+# Optional — OpenRouter model used by king-research for query generation and deepening follow-ups
+# When empty, falls back to OPENROUTER_MODEL_ENRICH (or the enrichment model default)
+OPENROUTER_MODEL_RESEARCH=
+
+# Optional — Effort-ladder overrides for king-research
+# Uncomment any line to override the built-in defaults shown below
+#RESEARCH_BASIC_QUERIES=3
+#RESEARCH_MEDIUM_QUERIES=5
+#RESEARCH_MEDIUM_ITERATIONS=1
+#RESEARCH_MEDIUM_FOLLOWUPS=3
+#RESEARCH_HIGH_QUERIES=8
+#RESEARCH_HIGH_ITERATIONS=2
+#RESEARCH_HIGH_FOLLOWUPS=5
+#RESEARCH_EXTRAHIGH_QUERIES=12
+#RESEARCH_EXTRAHIGH_ITERATIONS=3
+#RESEARCH_EXTRAHIGH_FOLLOWUPS=8
+#EXA_RESULTS_PER_QUERY=10
+#EXA_MAX_CHARS=15000

--- a/installer/templates/skills/king-context/skill.md
+++ b/installer/templates/skills/king-context/skill.md
@@ -1,31 +1,61 @@
 # King Context — Documentation Search Skill
 
-Search indexed documentation efficiently using `kctx` CLI. Find the right section in ≤3 calls.
+Search indexed documentation and research corpora efficiently using `.king-context/bin/kctx`. Find the right section in ≤3 calls.
 
-**Triggers**: documentation lookup, "search docs", "find in docs", library usage questions, "how to use X", "what's the API for X"
+**Triggers**: documentation lookup, "search docs", "find in docs", library usage questions, "how to use X", "what's the API for X", "what does our research say about X"
+
+---
+
+## Two Stores, One CLI
+
+King Context keeps two separate stores:
+
+| Store | Populated by | What's in it |
+|---|---|---|
+| `docs` | `.king-context/bin/king-scrape <url>` | Scraped product/API documentation |
+| `research` | `.king-context/bin/king-research <topic>` | Topic-driven research corpora from the open web |
+
+Every `kctx` command is source-aware:
+- Default: searches **both** stores, merged by score.
+- `--source docs|research` scopes to one store.
+- `--doc <name>` scopes to a single doc (works across stores — most precise filter).
+
+Every search/grep hit is prefixed `[docs]` or `[research]` so you can tell the source at a glance.
 
 ---
 
 ## Search Strategy
 
-Follow this flowchart for every documentation lookup. Stop as soon as you have the answer.
-
 ```
-1. Check _learned/     →  known shortcut?  → .king-context/bin/kctx read <doc> <path>  → DONE
-2. .king-context/bin/kctx list           →  which doc?
-3. .king-context/bin/kctx search "query" →  find section     → got it?
-4. .king-context/bin/kctx read --preview →  assess relevance → right section?
-5. .king-context/bin/kctx read           →  full content     → DONE
+1. Check _learned/                           →  known shortcut?  → .king-context/bin/kctx read <doc> <path>  → DONE
+2. .king-context/bin/kctx list               →  which doc + which store?
+3. .king-context/bin/kctx search "query"     →  find section     → got it?
+4. .king-context/bin/kctx read --preview     →  assess relevance → right section?
+5. .king-context/bin/kctx read               →  full content     → DONE
 6. Save discovery to _learned/
 ```
 
 **Rules**:
-- ALWAYS check `_learned/` FIRST — costs ~100 tokens, saves thousands
-- ALWAYS verify learned paths still exist before using them (`.king-context/bin/kctx read` will error if stale)
-- Prefer `.king-context/bin/kctx search` over `.king-context/bin/kctx grep` — metadata search is faster and cheaper
-- Use `--preview` before full read — assess relevance before paying full token cost
-- Use `.king-context/bin/kctx grep` only when you need to find exact code patterns or API names
-- NEVER read all sections — search narrows, preview confirms, then read only what's needed
+- ALWAYS check `_learned/` FIRST — costs ~100 tokens, saves thousands.
+- ALWAYS verify learned paths still exist before using them (`.king-context/bin/kctx read` errors if stale).
+- Prefer `.king-context/bin/kctx search` over `.king-context/bin/kctx grep` — metadata search is faster and cheaper.
+- Use `--preview` before full read — assess relevance before paying full token cost.
+- Use `.king-context/bin/kctx grep` only for exact code patterns, API names, or error strings.
+- **Scope aggressively**: `--doc <name>` > `--source <store>` > unfiltered.
+- NEVER read all sections — search narrows, preview confirms, then read only what's needed.
+
+---
+
+## Picking a Filter (decision tree)
+
+```
+User asks about a specific library/product/SDK?  → --doc <name>
+User asks about a research topic you scraped?    → --doc <research-slug>
+User asks something generic, unsure which doc?   → --source docs or --source research
+User asks "is it anywhere in our indexed stuff?" → no filter (search both)
+```
+
+`--doc` is the sharpest tool. Run `.king-context/bin/kctx list` once if you don't know the name.
 
 ---
 
@@ -36,64 +66,95 @@ Transform user intent into efficient CLI queries:
 | User asks | CLI query |
 |-----------|-----------|
 | "How to stream audio with ElevenLabs" | `.king-context/bin/kctx search "streaming" --doc elevenlabs-api` |
-| "Authentication for the API" | `.king-context/bin/kctx search "auth api-key"` |
-| "What WebSocket events are available" | `.king-context/bin/kctx search "websocket events"` |
-| "Find where Client( is used" | `.king-context/bin/kctx grep "Client(" --doc httpx` |
+| "Authentication for the Exa API" | `.king-context/bin/kctx search "auth api-key" --doc exa` |
+| "What does our research say on Chain of Thought" | `.king-context/bin/kctx search "chain of thought" --source research` |
+| "Compare ToT vs CoT — anything indexed?" | `.king-context/bin/kctx search "tree of thoughts" --source research --top 5` |
+| "Is rate limiting documented anywhere?" | `.king-context/bin/kctx search "rate limit"` (both stores) |
+| "Find where `Client(` is used in httpx" | `.king-context/bin/kctx grep "Client\\(" --doc httpx` |
 | "What topics does the docs cover" | `.king-context/bin/kctx topics elevenlabs-api` |
+| "Show only our research corpora" | `.king-context/bin/kctx list research` |
 
 **Tips**:
-- Use 1-2 specific keywords, not full sentences
-- Scope to `--doc` when you know which doc
-- Use `--top 3` to reduce output tokens
-- Keywords match exact terms; use_cases match substrings — "stream" matches "How to stream audio"
+- Use 1–2 specific keywords, not full sentences.
+- Scope to `--doc` when you know which doc.
+- Use `--top 3` to reduce output tokens.
+- Keywords match exact terms; use_cases match substrings — "stream" matches "How to stream audio".
 
 ---
 
 ## CLI Command Reference
 
-### List available docs
+### List indexed content
 ```bash
-.king-context/bin/kctx list                    # compact table: name, display_name, version, sections
-.king-context/bin/kctx list --json             # JSON array
+.king-context/bin/kctx list                    # both stores with == Docs == / == Research == headers
+.king-context/bin/kctx list docs               # only scraped docs
+.king-context/bin/kctx list research           # only research corpora
+.king-context/bin/kctx list --json             # JSON (grouped dict when "all", flat list when filtered)
 ```
 
 ### Search by metadata (keywords, use_cases, tags)
 ```bash
-.king-context/bin/kctx search "query"                        # cross-doc search, top 5
-.king-context/bin/kctx search "streaming" --doc elevenlabs-api  # scoped to one doc
-.king-context/bin/kctx search "auth" --top 3                 # limit results
-.king-context/bin/kctx search "query" --json                 # JSON output
+.king-context/bin/kctx search "query"                              # cross-store, top 5, merged by score
+.king-context/bin/kctx search "streaming" --doc elevenlabs-api     # scoped to a single doc (auto-resolves store)
+.king-context/bin/kctx search "reasoning" --source research        # only research corpora
+.king-context/bin/kctx search "livecrawl" --source docs            # only scraped docs
+.king-context/bin/kctx search "auth" --top 3                       # limit results
+.king-context/bin/kctx search "query" --json                       # JSON output
 ```
-Returns: title, path, score, first use_case. **No content** — metadata only.
+Output tags every hit with `[docs]` or `[research]`. Returns title, path, score, first use_case. **No content** — metadata only.
 
 ### Read a section
 ```bash
-.king-context/bin/kctx read <doc> <section-path>             # full content
+.king-context/bin/kctx read <doc> <section-path>             # full content (auto-finds the store)
 .king-context/bin/kctx read <doc> <section-path> --preview   # first ~200 tokens + total estimate
+.king-context/bin/kctx read <doc> <section-path> --source research   # force store (rarely needed)
 .king-context/bin/kctx read <doc> <section-path> --json      # JSON output
 ```
-If section not found, suggests similar paths.
+If the doc name isn't unique, pass `--source`. If section not found, suggests similar paths.
 
 ### Browse by topic
 ```bash
 .king-context/bin/kctx topics <doc>                          # all tags with sections
 .king-context/bin/kctx topics <doc> --tag api-reference      # filter to one tag
+.king-context/bin/kctx topics <doc> --source research        # disambiguate if needed
 .king-context/bin/kctx topics <doc> --json                   # JSON output
 ```
 
 ### Grep content
 ```bash
-.king-context/bin/kctx grep "pattern"                        # regex across all docs
-.king-context/bin/kctx grep "Client(" --doc httpx            # scoped to one doc
+.king-context/bin/kctx grep "pattern"                        # regex across both stores
+.king-context/bin/kctx grep "Client\\(" --doc httpx          # scoped to one doc
+.king-context/bin/kctx grep "livecrawl" --source docs        # scoped to docs store
 .king-context/bin/kctx grep "pattern" --context 3            # surrounding lines
 .king-context/bin/kctx grep "pattern" --json                 # JSON output
 ```
 
-### Index documentation
+### Index / re-index
 ```bash
-.king-context/bin/kctx index .king-context/data/example.json # index one doc
-.king-context/bin/kctx index --all                           # index all .king-context/data/*.json
+.king-context/bin/kctx index .king-context/data/example.json         # auto-detects via section.source_type
+.king-context/bin/kctx index .king-context/data/research/topic.json  # also auto-detected as research
+.king-context/bin/kctx index <path> --source research                # force-route to research store
+.king-context/bin/kctx index --all                                   # walks data/*.json + data/research/*.json
 ```
+
+---
+
+## Generating New Content
+
+Two producers feed the stores:
+
+```bash
+# Scrape a product/API doc site → .king-context/docs/<name>/
+.king-context/bin/king-scrape https://docs.example.com
+
+# Research a topic from the open web → .king-context/research/<slug>/
+.king-context/bin/king-research "prompt engineering techniques" --basic     # 3 queries, no deepening
+.king-context/bin/king-research "retrieval augmented generation" --medium   # 5 queries + 1 deepening iteration
+.king-context/bin/king-research "mixture of experts" --high                 # 8 + 2 iterations
+.king-context/bin/king-research "<topic>" --extrahigh                       # 12 + 3 iterations (most thorough)
+```
+
+Both auto-index on completion — the new doc is immediately searchable via `kctx`. `king-research` outputs are tagged `source_type: "research"` in every section so `--source research` and the `[research]` prefix work automatically.
 
 ---
 
@@ -102,9 +163,9 @@ If section not found, suggests similar paths.
 After finding a useful section, save a shortcut for future sessions.
 
 ### When to save
-- You found the right section after searching
-- You discovered a gotcha or non-obvious behavior
-- You found a pattern that would help answer similar questions
+- You found the right section after searching.
+- You discovered a gotcha or non-obvious behavior.
+- You found a pattern that would help answer similar questions.
 
 ### How to save
 Write to `.king-context/_learned/<doc-name>.md`:
@@ -114,6 +175,7 @@ Write to `.king-context/_learned/<doc-name>.md`:
 
 ## <Topic>
 - **<What>** → `<section-path>` section
+- Store: docs | research
 - Gotcha: <non-obvious behavior>
 - Related: `<other-section>` for <reason>
 
@@ -121,17 +183,13 @@ Write to `.king-context/_learned/<doc-name>.md`:
 Last updated: <date>
 ```
 
-### Format for each entry
-- **Query pattern**: what the user asked
-- **Section path**: the section that answered it
-- **Gotchas**: anything non-obvious (auth quirks, parameter caveats, etc.)
-- **Date**: when this was learned
+Tracking the store lets you skip `kctx list` on the next lookup.
 
 ### Reading learned shortcuts
-Before any search, check if a learned file exists:
-1. Read `.king-context/_learned/<doc-name>.md`
-2. If a shortcut matches the current query, use it directly: `.king-context/bin/kctx read <doc> <path>`
-3. If the path no longer exists (stale), fall back to normal search and update the learned file
+Before any search:
+1. Read `.king-context/_learned/<doc-name>.md`.
+2. If a shortcut matches the current query, use it directly: `.king-context/bin/kctx read <doc> <path>`.
+3. If the path no longer exists (stale), fall back to normal search and update the learned file.
 
 ---
 
@@ -140,7 +198,7 @@ Before any search, check if a learned file exists:
 ### Good (3 calls, ~400 tokens)
 ```
 .king-context/bin/kctx search "streaming" --doc elevenlabs-api --top 3
-→ Found: "WebSocket Streaming" (websocket-streaming) score=8.50
+→ 1. [docs] WebSocket Streaming (elevenlabs-api/websocket-streaming) score=8.50
 
 .king-context/bin/kctx read elevenlabs-api websocket-streaming --preview
 → "# WebSocket Streaming\n\nConnect to ws://..." Tokens: 450
@@ -149,12 +207,21 @@ Before any search, check if a learned file exists:
 → Full content
 ```
 
+### Good (research-scoped, 2 calls)
+```
+.king-context/bin/kctx search "zero shot cot" --source research --top 3
+→ 1. [research] Zero-Shot CoT (prompt-engineering-techniques/ai-prompt-engineering-...) score=12.50
+
+.king-context/bin/kctx read prompt-engineering-techniques ai-prompt-engineering-patterns-cot-react-tot-zero-shot-cot
+→ Full content
+```
+
 ### Bad (wasteful, ~3000+ tokens)
 ```
 .king-context/bin/kctx list
 .king-context/bin/kctx topics elevenlabs-api
-.king-context/bin/kctx read elevenlabs-api getting-started        # wrong section
-.king-context/bin/kctx read elevenlabs-api text-to-speech         # still wrong
-.king-context/bin/kctx search "websocket streaming audio real-time"  # too many terms
-.king-context/bin/kctx read elevenlabs-api websocket-streaming    # finally found it
+.king-context/bin/kctx read elevenlabs-api getting-started              # wrong section
+.king-context/bin/kctx read elevenlabs-api text-to-speech               # still wrong
+.king-context/bin/kctx search "websocket streaming audio real-time"     # too many terms
+.king-context/bin/kctx read elevenlabs-api websocket-streaming          # finally found it
 ```

--- a/installer/templates/skills/king-research/skill.md
+++ b/installer/templates/skills/king-research/skill.md
@@ -1,0 +1,164 @@
+# King Research — Topic Research Skill
+
+Invoke `king-research` to build a research corpus on any topic. The user describes what they want; you extract the topic, pick the effort mode, and run the pipeline.
+
+**Triggers**: "/king-research", "research about X", "pesquise sobre Y", "pesquisa de Z", "build a corpus on W", "find sources about Q", "state of the art for R"
+
+---
+
+## When to use this skill
+
+| User wants... | Use |
+|---|---|
+| Sources on an open-web topic (papers, blog posts, discussions) | **king-research** (this skill) |
+| A specific product/API doc site scraped | **scraper-workflow** (`king-scrape`) |
+| To query already-indexed content | **king-context** (`kctx search`) |
+
+If the user already mentions a URL or a specific product's docs, hand off to `scraper-workflow`.
+
+---
+
+## Step 1: Extract the topic
+
+Pull the topic from the user's message as a concise phrase (2–6 words).
+
+**Rules**:
+- Strip filler: "please", "por favor", "pode fazer", "quero que", "me faça".
+- Keep semantic qualifiers: "for RAG pipelines", "in production", "2025".
+- Prefer the user's wording over paraphrase.
+- Quote multi-word topics when passing to the CLI.
+
+If the topic is vague (e.g. "faz um research aí", "pesquise algo"), ask ONE clarifying question before running: **"What topic?"**
+
+---
+
+## Step 2: Pick the effort mode
+
+### Explicit signals (override inference)
+
+| Signal in the user's message | Mode |
+|---|---|
+| "rápido", "quick", "basic", "só uma ideia", "overview", "simples" | `--basic` |
+| (no qualifier) | `--medium` (default) |
+| "detalhado", "aprofundado", "profundo", "detailed", "in-depth", "completo" | `--high` |
+| "exaustivo", "estado da arte", "thorough", "comprehensive", "state of the art", "máximo", "tudo que tiver" | `--extrahigh` |
+
+### Inferred from complexity (when no explicit signal)
+
+| Topic shape | Mode |
+|---|---|
+| Narrow, well-known (e.g. "httpx timeouts") | `--basic` |
+| Standard technical topic (e.g. "prompt caching strategies") | `--medium` (default) |
+| Broad or comparative (e.g. "RAG vs fine-tuning") | `--high` |
+| Bleeding-edge / multi-domain survey (e.g. "mixture of experts state of the art 2025") | `--extrahigh` |
+
+### Cost & time budget
+
+| Mode | Initial queries | Deepening iterations | ~Time | API cost |
+|---|---|---|---|---|
+| `--basic` | 3 | 0 | ~30s | minimal |
+| `--medium` | 5 | 1 | ~2 min | low |
+| `--high` | 8 | 2 | ~5 min | medium |
+| `--extrahigh` | 12 | 3 | ~10 min | high |
+
+For `--high` or `--extrahigh`, state the expected time before running so the user isn't surprised. No need to ask permission — just warn.
+
+---
+
+## Step 3: Run the pipeline
+
+```bash
+.king-context/bin/king-research "<topic>" --<mode> --yes
+```
+
+**Flags to remember**:
+- `--yes` / `-y` — skip the enrichment cost prompt (default ON from this skill; the user invoked us to do the work, not to be interrupted).
+- `--name <slug>` — override the auto-generated slug (rarely needed; only if the user explicitly names it).
+- `--no-auto-index` — don't auto-index into `.king-context/research/` (rarely; only if the user explicitly asks for JSON-only output).
+- `--step <stage>` / `--stop-after <stage>` — resume or partial-run (only for debugging; don't use proactively).
+
+**Pipeline stages** (for reference when resuming): `generate → search → chunk → enrich → export`.
+
+---
+
+## Step 4: Report + hand off to search
+
+After the pipeline finishes, report concisely:
+
+1. The slug it was saved under (auto-indexed in `.king-context/research/<slug>/`).
+2. Section count.
+3. Example commands to search it.
+
+Template:
+```
+Indexed "<slug>" — N sections. Try:
+  kctx search "<keyword>" --doc <slug>
+  kctx topics <slug>
+  kctx list research
+```
+
+Don't dump the full topic tree or section titles — let the user drive the search.
+
+---
+
+## Error handling
+
+| Error | Action |
+|---|---|
+| `EXA_API_KEY is not set` | "Set `EXA_API_KEY` in `.king-context/.env` or `./.env`, then retry." |
+| `OPENROUTER_API_KEY` missing | Same — both are required (query generation + enrichment). |
+| Zero results from Exa | Topic may be too niche or mis-spelled. Suggest rephrasing or adding context. |
+| Pipeline fails with "no chunks" or "no enriched sections" | Report which stage; usually means the topic returned no fetchable pages. Try broadening the topic. |
+| User hit a high/extrahigh run by mistake | Remind them `Ctrl+C` cancels; partial progress in `.king-context/_temp/research/<slug>/` is kept for resume via `--step`. |
+
+---
+
+## Examples
+
+### Implicit mode (inferred from complexity)
+```
+User: "pesquise sobre chain of thought prompting"
+→ Topic: "chain of thought prompting"
+→ Standard technical topic → --medium
+→ .king-context/bin/king-research "chain of thought prompting" --medium --yes
+→ "Indexed chain-of-thought-prompting — 14 sections."
+```
+
+### Explicit mode — quick
+```
+User: "faz um research rápido sobre retry backoff"
+→ Topic: "retry backoff"
+→ Signal "rápido" → --basic
+→ .king-context/bin/king-research "retry backoff" --basic --yes
+```
+
+### Explicit mode — exhaustive
+```
+User: "quero tudo sobre mixture of experts, estado da arte"
+→ Topic: "mixture of experts"
+→ Signal "estado da arte" → --extrahigh
+→ Warn: "~10 minutes and higher API cost — proceeding"
+→ .king-context/bin/king-research "mixture of experts" --extrahigh --yes
+```
+
+### Comparative (inferred high)
+```
+User: "compare RAG vs fine-tuning for code assistants"
+→ Topic: "RAG vs fine-tuning code assistants"
+→ Comparative, broad → --high
+→ .king-context/bin/king-research "RAG vs fine-tuning code assistants" --high --yes
+```
+
+### Vague topic (ask first)
+```
+User: "faz um research aí"
+→ Ask: "What topic?"
+→ (wait for reply, then resume from Step 1)
+```
+
+### User provides a URL — hand off
+```
+User: "research stripe docs"
+→ This is a doc site, not an open-web topic.
+→ Hand off to scraper-workflow: king-scrape https://docs.stripe.com
+```

--- a/installer/templates/wrapper-research.sh
+++ b/installer/templates/wrapper-research.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/king-research" "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "firecrawl-py>=1.0.0",
     "httpx>=0.27.0",
+    "exa-py>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -21,6 +22,7 @@ dev = [
 [project.scripts]
 king-context = "king_context.server:main"
 king-scrape = "king_context.scraper.cli:main"
+king-research = "king_context.research.cli:main"
 kctx = "context_cli.cli:main"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 dev = [
     "pytest>=9.0",
     "pytest-asyncio>=0.25.0",
+    "respx>=0.22.0",
 ]
 
 [project.scripts]

--- a/src/context_cli/__init__.py
+++ b/src/context_cli/__init__.py
@@ -4,3 +4,4 @@ from pathlib import Path
 
 PROJECT_ROOT = Path.cwd()
 STORE_DIR = PROJECT_ROOT / ".king-context" / "docs"
+RESEARCH_STORE_DIR = PROJECT_ROOT / ".king-context" / "research"

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -3,9 +3,10 @@
 import argparse
 import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
-from context_cli import PROJECT_ROOT, STORE_DIR
+from context_cli import PROJECT_ROOT, RESEARCH_STORE_DIR, STORE_DIR
 from context_cli.formatter import (
     format_grep,
     format_list,
@@ -14,39 +15,106 @@ from context_cli.formatter import (
     format_topics,
 )
 from context_cli.grep import grep_docs
-from context_cli.indexer import index_all, index_doc
+from context_cli.indexer import index_doc
 from context_cli.reader import read_section
 from context_cli.searcher import search
-from context_cli.store import doc_exists, list_docs
+from context_cli.store import list_docs
+
+
+SOURCE_CHOICES = ("all", "docs", "research")
+
+
+def _active_stores(source: str) -> list[tuple[str, Path]]:
+    """Return [(label, store_dir), ...] the given source selector targets."""
+    if source == "docs":
+        return [("docs", STORE_DIR)]
+    if source == "research":
+        return [("research", RESEARCH_STORE_DIR)]
+    return [("docs", STORE_DIR), ("research", RESEARCH_STORE_DIR)]
+
+
+def _find_doc_store(doc_name: str, source: str) -> Path | None:
+    """Find which store contains a given doc_name. Returns None if not found."""
+    for _, store_dir in _active_stores(source):
+        if (store_dir / doc_name / "index.json").exists():
+            return store_dir
+    return None
+
+
+def _detect_source(json_path: Path) -> str:
+    """Inspect the JSON at json_path and classify as 'research' or 'docs'."""
+    try:
+        data = json.loads(json_path.read_text())
+        sections = data.get("sections", [])
+        if any(s.get("source_type") == "research" for s in sections):
+            return "research"
+    except (json.JSONDecodeError, OSError, KeyError):
+        pass
+    return "docs"
 
 
 def _cmd_list(args: argparse.Namespace) -> None:
-    store_dir = STORE_DIR
-    docs = list_docs(store_dir)
-    if not docs and not args.json:
-        print("No docs indexed. Run: kctx index .king-context/data/<file>.json")
+    source = args.source or "all"
+    stores = _active_stores(source)
+
+    if args.json:
+        payload = {label: [asdict(d) for d in list_docs(s)] for label, s in stores}
+        if source != "all":
+            print(json.dumps(payload[source], indent=2))
+        else:
+            print(json.dumps(payload, indent=2))
         return
-    print(format_list(docs, as_json=args.json))
+
+    blocks: list[str] = []
+    total = 0
+    for label, store_dir in stores:
+        docs = list_docs(store_dir)
+        total += len(docs)
+        if not docs:
+            continue
+        header = f"== {label.title()} ({len(docs)}) =="
+        blocks.append(header + "\n" + format_list(docs))
+
+    if total == 0:
+        print("No docs indexed. Run: king-scrape <url>  or  king-research <topic>")
+        return
+
+    print("\n\n".join(blocks))
 
 
 def _cmd_search(args: argparse.Namespace) -> None:
-    store_dir = STORE_DIR
-    results = search(
-        args.query,
-        store_dir,
-        doc_name=args.doc,
-        top=args.top,
-    )
-    print(format_search(results, as_json=args.json))
+    source = args.source or "all"
+    stores = _active_stores(source)
+
+    all_results = []
+    for label, store_dir in stores:
+        if args.doc is not None and not (store_dir / args.doc / "index.json").exists():
+            continue
+        all_results.extend(
+            search(args.query, store_dir, doc_name=args.doc, top=args.top, source=label)
+        )
+
+    all_results.sort(key=lambda r: r.score, reverse=True)
+    all_results = all_results[: args.top]
+    print(format_search(all_results, as_json=args.json))
 
 
 def _cmd_read(args: argparse.Namespace) -> None:
-    store_dir = STORE_DIR
+    source = args.source or "all"
+    target_store = _find_doc_store(args.doc, source)
+    if target_store is None:
+        stores = ", ".join(label for label, _ in _active_stores(source))
+        print(
+            f"Doc '{args.doc}' not found in {stores} store(s).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     try:
         content = read_section(
             args.doc,
             args.section,
-            store_dir,
+            target_store,
             preview=args.preview,
         )
     except FileNotFoundError as e:
@@ -56,30 +124,35 @@ def _cmd_read(args: argparse.Namespace) -> None:
 
 
 def _cmd_grep(args: argparse.Namespace) -> None:
-    store_dir = STORE_DIR
-    matches = grep_docs(
-        args.pattern,
-        store_dir,
-        doc_name=args.doc,
-        context_lines=args.context,
-    )
-    print(format_grep(matches, as_json=args.json))
+    source = args.source or "all"
+    stores = _active_stores(source)
+
+    all_matches = []
+    for label, store_dir in stores:
+        if args.doc is not None and not (store_dir / args.doc / "index.json").exists():
+            continue
+        all_matches.extend(
+            grep_docs(args.pattern, store_dir, doc_name=args.doc,
+                      context_lines=args.context, source=label)
+        )
+    print(format_grep(all_matches, as_json=args.json))
 
 
 def _cmd_topics(args: argparse.Namespace) -> None:
-    store_dir = STORE_DIR
-    doc_name = args.doc
-
-    if not doc_exists(doc_name, store_dir):
-        docs = list_docs(store_dir)
-        available = ", ".join(d.name for d in docs) if docs else "none"
+    source = args.source or "all"
+    target_store = _find_doc_store(args.doc, source)
+    if target_store is None:
+        available: list[str] = []
+        for _, store_dir in _active_stores(source):
+            available.extend(d.name for d in list_docs(store_dir))
+        available_str = ", ".join(available) if available else "none"
         print(
-            f"Doc '{doc_name}' not found. Available: {available}",
+            f"Doc '{args.doc}' not found. Available: {available_str}",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    doc_dir = store_dir / doc_name
+    doc_dir = target_store / args.doc
     tags_path = doc_dir / "tags.json"
     if not tags_path.exists():
         print(format_topics({}, as_json=args.json))
@@ -87,14 +160,12 @@ def _cmd_topics(args: argparse.Namespace) -> None:
 
     tags_index: dict[str, list[str]] = json.loads(tags_path.read_text())
 
-    # Optionally filter to a single tag
     if args.tag:
         if args.tag in tags_index:
             tags_index = {args.tag: tags_index[args.tag]}
         else:
             tags_index = {}
 
-    # Load section metadata for each tag
     tag_groups: dict[str, list[dict]] = {}
     sections_dir = doc_dir / "sections"
 
@@ -109,34 +180,61 @@ def _cmd_topics(args: argparse.Namespace) -> None:
                     "path": sec_data.get("path", spath),
                     "priority": sec_data.get("priority", 0),
                 })
-        # Sort by priority descending
         sections.sort(key=lambda s: s["priority"], reverse=True)
         tag_groups[tag] = sections
 
     print(format_topics(tag_groups, as_json=args.json))
 
 
-def _cmd_index(args: argparse.Namespace) -> None:
-    store_dir = STORE_DIR
-    store_dir.mkdir(parents=True, exist_ok=True)
+def _resolve_index_store(json_path: Path, args: argparse.Namespace) -> tuple[str, Path]:
+    """Pick the target store for a given index command invocation."""
+    if args.source == "docs":
+        return "docs", STORE_DIR
+    if args.source == "research":
+        return "research", RESEARCH_STORE_DIR
+    label = _detect_source(json_path)
+    return label, (RESEARCH_STORE_DIR if label == "research" else STORE_DIR)
 
+
+def _cmd_index(args: argparse.Namespace) -> None:
     if args.all:
-        data_dir = PROJECT_ROOT / ".king-context" / "data"
-        if not data_dir.exists():
+        data_root = PROJECT_ROOT / ".king-context" / "data"
+        if not data_root.exists():
             print(".king-context/data/ directory not found.", file=sys.stderr)
             sys.exit(1)
-        results = index_all(data_dir, store_dir)
-        for r in results:
-            print(f"Indexed {r.doc_name}: {r.section_count} sections")
-        if not results:
+
+        candidates = list(data_root.glob("*.json"))
+        research_dir = data_root / "research"
+        if research_dir.exists():
+            candidates.extend(research_dir.glob("*.json"))
+
+        if not candidates:
             print("No JSON files found in .king-context/data/.")
+            return
+
+        for json_path in sorted(candidates):
+            label, target_store = _resolve_index_store(json_path, args)
+            target_store.mkdir(parents=True, exist_ok=True)
+            result = index_doc(json_path, target_store)
+            print(f"Indexed {result.doc_name} ({label}): {result.section_count} sections")
     else:
         json_path = Path(args.path)
         if not json_path.exists():
             print(f"File not found: {args.path}", file=sys.stderr)
             sys.exit(1)
-        result = index_doc(json_path, store_dir)
-        print(f"Indexed {result.doc_name}: {result.section_count} sections")
+        label, target_store = _resolve_index_store(json_path, args)
+        target_store.mkdir(parents=True, exist_ok=True)
+        result = index_doc(json_path, target_store)
+        print(f"Indexed {result.doc_name} ({label}): {result.section_count} sections")
+
+
+def _add_source_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--source",
+        choices=SOURCE_CHOICES,
+        default="all",
+        help="Which store(s) to target: docs, research, or all (default: all)",
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -149,8 +247,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command")
 
-    # list
+    # list [source]
     p_list = subparsers.add_parser("list", help="List indexed documentation")
+    p_list.add_argument(
+        "source",
+        nargs="?",
+        choices=SOURCE_CHOICES,
+        default="all",
+        help="Filter by store: docs, research, or all (default: all)",
+    )
     p_list.add_argument("--json", action="store_true", help="JSON output")
     p_list.set_defaults(func=_cmd_list)
 
@@ -159,6 +264,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_search.add_argument("query", help="Search query")
     p_search.add_argument("--doc", default=None, help="Restrict to one doc")
     p_search.add_argument("--top", type=int, default=5, help="Max results (default: 5)")
+    _add_source_arg(p_search)
     p_search.add_argument("--json", action="store_true", help="JSON output")
     p_search.set_defaults(func=_cmd_search)
 
@@ -167,6 +273,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_read.add_argument("doc", help="Documentation name")
     p_read.add_argument("section", help="Section path")
     p_read.add_argument("--preview", action="store_true", help="Show first ~200 tokens only")
+    _add_source_arg(p_read)
     p_read.add_argument("--json", action="store_true", help="JSON output")
     p_read.set_defaults(func=_cmd_read)
 
@@ -175,6 +282,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_grep.add_argument("pattern", help="Regex pattern to search for")
     p_grep.add_argument("--doc", default=None, help="Restrict to one doc")
     p_grep.add_argument("--context", type=int, default=0, help="Surrounding lines")
+    _add_source_arg(p_grep)
     p_grep.add_argument("--json", action="store_true", help="JSON output")
     p_grep.set_defaults(func=_cmd_grep)
 
@@ -182,13 +290,21 @@ def _build_parser() -> argparse.ArgumentParser:
     p_topics = subparsers.add_parser("topics", help="Show tags and sections for a doc")
     p_topics.add_argument("doc", help="Documentation name")
     p_topics.add_argument("--tag", default=None, help="Filter to a single tag")
+    _add_source_arg(p_topics)
     p_topics.add_argument("--json", action="store_true", help="JSON output")
     p_topics.set_defaults(func=_cmd_topics)
 
     # index
     p_index = subparsers.add_parser("index", help="Index documentation from JSON files")
     p_index.add_argument("path", nargs="?", default=None, help="Path to a JSON file")
-    p_index.add_argument("--all", action="store_true", help="Index all .king-context/data/*.json files")
+    p_index.add_argument("--all", action="store_true",
+                         help="Index all .king-context/data/*.json files (including research/)")
+    p_index.add_argument(
+        "--source",
+        choices=SOURCE_CHOICES,
+        default="all",
+        help="Force routing to a specific store (default: auto-detect from source_type)",
+    )
     p_index.set_defaults(func=_cmd_index)
 
     return parser

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -24,6 +24,10 @@ from context_cli.store import list_docs
 SOURCE_CHOICES = ("all", "docs", "research")
 
 
+class AmbiguousDocError(RuntimeError):
+    """Raised when a doc slug exists in multiple stores."""
+
+
 def _active_stores(source: str) -> list[tuple[str, Path]]:
     """Return [(label, store_dir), ...] the given source selector targets."""
     if source == "docs":
@@ -35,10 +39,20 @@ def _active_stores(source: str) -> list[tuple[str, Path]]:
 
 def _find_doc_store(doc_name: str, source: str) -> Path | None:
     """Find which store contains a given doc_name. Returns None if not found."""
-    for _, store_dir in _active_stores(source):
-        if (store_dir / doc_name / "index.json").exists():
-            return store_dir
-    return None
+    matches = [
+        (label, store_dir)
+        for label, store_dir in _active_stores(source)
+        if (store_dir / doc_name / "index.json").exists()
+    ]
+    if not matches:
+        return None
+    if source == "all" and len(matches) > 1:
+        labels = ", ".join(label for label, _ in matches)
+        raise AmbiguousDocError(
+            f"Doc '{doc_name}' exists in multiple stores ({labels}). "
+            "Re-run with --source docs or --source research."
+        )
+    return matches[0][1]
 
 
 def _detect_source(json_path: Path) -> str:
@@ -101,7 +115,11 @@ def _cmd_search(args: argparse.Namespace) -> None:
 
 def _cmd_read(args: argparse.Namespace) -> None:
     source = args.source or "all"
-    target_store = _find_doc_store(args.doc, source)
+    try:
+        target_store = _find_doc_store(args.doc, source)
+    except AmbiguousDocError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
     if target_store is None:
         stores = ", ".join(label for label, _ in _active_stores(source))
         print(
@@ -140,7 +158,11 @@ def _cmd_grep(args: argparse.Namespace) -> None:
 
 def _cmd_topics(args: argparse.Namespace) -> None:
     source = args.source or "all"
-    target_store = _find_doc_store(args.doc, source)
+    try:
+        target_store = _find_doc_store(args.doc, source)
+    except AmbiguousDocError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
     if target_store is None:
         available: list[str] = []
         for _, store_dir in _active_stores(source):

--- a/src/context_cli/formatter.py
+++ b/src/context_cli/formatter.py
@@ -59,7 +59,8 @@ def format_search(results, as_json=False) -> str:
     lines = []
     for i, r in enumerate(results, 1):
         use_case = r.use_cases[0] if r.use_cases else ""
-        line = f"{i}. {r.title} ({r.doc_name}/{r.section_path}) score={r.score:.2f}"
+        source = getattr(r, "source", "docs")
+        line = f"{i}. [{source}] {r.title} ({r.doc_name}/{r.section_path}) score={r.score:.2f}"
         if use_case:
             line += f"\n   {use_case}"
         lines.append(line)
@@ -119,10 +120,11 @@ def format_grep(matches, as_json=False) -> str:
     if not matches:
         return "No matches found."
 
-    # Group by doc_name + section_title
+    # Group by source + doc_name + section_title
     groups: dict[str, list] = {}
     for m in matches:
-        key = f"{m.doc_name}/{m.section_title}"
+        source = getattr(m, "source", "docs")
+        key = f"[{source}] {m.doc_name}/{m.section_title}"
         groups.setdefault(key, []).append(m)
 
     lines = []

--- a/src/context_cli/grep.py
+++ b/src/context_cli/grep.py
@@ -15,6 +15,7 @@ class GrepMatch:
     line_content: str
     context_before: list[str] = field(default_factory=list)
     context_after: list[str] = field(default_factory=list)
+    source: str = "docs"
 
 
 def grep_docs(
@@ -22,6 +23,7 @@ def grep_docs(
     store_dir: Path,
     doc_name: str | None = None,
     context_lines: int = 0,
+    source: str = "docs",
 ) -> list[GrepMatch]:
     """Search section content for lines matching a regex pattern.
 
@@ -80,6 +82,7 @@ def grep_docs(
                         line_content=line,
                         context_before=before,
                         context_after=after,
+                        source=source,
                     ))
 
             matches.extend(section_matches)

--- a/src/context_cli/searcher.py
+++ b/src/context_cli/searcher.py
@@ -15,6 +15,7 @@ class SearchResult:
     use_cases: list[str]
     tags: list[str]
     priority: int
+    source: str = "docs"
 
 
 def _normalize_query(query: str) -> list[str]:
@@ -73,6 +74,7 @@ def search(
     store_dir: Path,
     doc_name: str | None = None,
     top: int = 5,
+    source: str = "docs",
 ) -> list[SearchResult]:
     """Search documentation sections by query using reverse-index scoring.
 
@@ -130,6 +132,7 @@ def search(
                 use_cases=section_data.get("use_cases", []),
                 tags=section_data.get("tags", []),
                 priority=priority,
+                source=source,
             ))
 
     # Sort by score descending, then limit

--- a/src/king_context/research/__init__.py
+++ b/src/king_context/research/__init__.py
@@ -1,0 +1,1 @@
+"""King Context research package."""

--- a/src/king_context/research/cli.py
+++ b/src/king_context/research/cli.py
@@ -1,0 +1,113 @@
+import argparse
+import asyncio
+import logging
+
+from king_context.research.config import EffortLevel, load_research_config
+from king_context.research.pipeline import RESEARCH_STEPS, run_pipeline
+from king_context.scraper.config import ConfigError
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="king-research",
+        description="Research a topic and index sources into .king-context/data/research/",
+    )
+    parser.add_argument("topic", help="Research topic (quote multi-word topics)")
+
+    effort = parser.add_mutually_exclusive_group()
+    effort.add_argument(
+        "--basic",
+        dest="effort_flag",
+        action="store_const",
+        const=EffortLevel.BASIC,
+        help="Basic effort: fewer queries, no deepening iterations",
+    )
+    effort.add_argument(
+        "--medium",
+        dest="effort_flag",
+        action="store_const",
+        const=EffortLevel.MEDIUM,
+        help="Medium effort (default)",
+    )
+    effort.add_argument(
+        "--high",
+        dest="effort_flag",
+        action="store_const",
+        const=EffortLevel.HIGH,
+        help="High effort: more queries and deepening iterations",
+    )
+    effort.add_argument(
+        "--extrahigh",
+        dest="effort_flag",
+        action="store_const",
+        const=EffortLevel.EXTRAHIGH,
+        help="Extra-high effort: maximum queries and iterations",
+    )
+
+    parser.add_argument(
+        "--name",
+        default=None,
+        help="Slug override for the output JSON (default: derived from topic)",
+    )
+    parser.add_argument(
+        "--step",
+        choices=RESEARCH_STEPS,
+        default=None,
+        help="Start the pipeline from this step (P1: no rehydration)",
+    )
+    parser.add_argument(
+        "--stop-after",
+        dest="stop_after",
+        choices=RESEARCH_STEPS,
+        default=None,
+        help="Run up to and including this step, then stop",
+    )
+    parser.add_argument(
+        "--no-filter",
+        dest="no_filter",
+        action="store_true",
+        help="Skip relevance filter (P1: filter is not implemented — this is a no-op)",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        dest="yes",
+        action="store_true",
+        help="Skip the enrichment cost prompt",
+    )
+    parser.add_argument(
+        "--no-auto-index",
+        dest="no_auto_index",
+        action="store_true",
+        help="Do not run auto_index after export",
+    )
+    parser.add_argument(
+        "--force",
+        dest="force",
+        action="store_true",
+        help="(P3) Skip URL dedup — currently a no-op",
+    )
+    return parser
+
+
+def _resolve_effort(args: argparse.Namespace) -> EffortLevel:
+    return args.effort_flag if args.effort_flag is not None else EffortLevel.MEDIUM
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    args.effort = _resolve_effort(args)
+
+    if args.no_filter:
+        logging.getLogger("king_context.research.cli").info(
+            "--no-filter accepted (filter is not implemented in P1)"
+        )
+
+    try:
+        config = load_research_config()
+        asyncio.run(run_pipeline(args, config))
+    except ConfigError as exc:
+        parser.error(str(exc))

--- a/src/king_context/research/cli.py
+++ b/src/king_context/research/cli.py
@@ -111,3 +111,7 @@ def main() -> None:
         asyncio.run(run_pipeline(args, config))
     except ConfigError as exc:
         parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/king_context/research/config.py
+++ b/src/king_context/research/config.py
@@ -1,0 +1,111 @@
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+from king_context.scraper.config import ConfigError, ScraperConfig, load_config
+
+
+@dataclass
+class ResearchConfig:
+    scraper: ScraperConfig
+    exa_api_key: str = ""
+    jina_api_key: str = ""
+    research_model: str = ""
+    basic_queries: int = 3
+    medium_queries: int = 5
+    medium_iterations: int = 1
+    medium_followups: int = 3
+    high_queries: int = 8
+    high_iterations: int = 2
+    high_followups: int = 5
+    extrahigh_queries: int = 12
+    extrahigh_iterations: int = 3
+    extrahigh_followups: int = 8
+    exa_results_per_query: int = 10
+    exa_max_chars: int = 15000
+    relevance_threshold: float = 0.5
+
+
+class EffortLevel(str, Enum):
+    BASIC = "basic"
+    MEDIUM = "medium"
+    HIGH = "high"
+    EXTRAHIGH = "extrahigh"
+
+
+@dataclass(frozen=True)
+class EffortProfile:
+    initial_queries: int
+    iterations: int
+    followups_per_iteration: int
+
+
+def effort_profile(level: EffortLevel, config: ResearchConfig) -> EffortProfile:
+    if level == EffortLevel.BASIC:
+        return EffortProfile(
+            initial_queries=config.basic_queries,
+            iterations=0,
+            followups_per_iteration=0,
+        )
+    if level == EffortLevel.MEDIUM:
+        return EffortProfile(
+            initial_queries=config.medium_queries,
+            iterations=config.medium_iterations,
+            followups_per_iteration=config.medium_followups,
+        )
+    if level == EffortLevel.HIGH:
+        return EffortProfile(
+            initial_queries=config.high_queries,
+            iterations=config.high_iterations,
+            followups_per_iteration=config.high_followups,
+        )
+    return EffortProfile(
+        initial_queries=config.extrahigh_queries,
+        iterations=config.extrahigh_iterations,
+        followups_per_iteration=config.extrahigh_followups,
+    )
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def load_research_config(**overrides) -> ResearchConfig:
+    scraper_cfg = load_config()
+
+    exa_api_key = os.environ.get("EXA_API_KEY", "").strip()
+    if not exa_api_key:
+        raise ConfigError("EXA_API_KEY is not set")
+
+    jina_api_key = os.environ.get("JINA_API_KEY", "").strip()
+    research_model = os.environ.get("OPENROUTER_MODEL_RESEARCH", "").strip()
+
+    config = ResearchConfig(
+        scraper=scraper_cfg,
+        exa_api_key=exa_api_key,
+        jina_api_key=jina_api_key,
+        research_model=research_model,
+        basic_queries=_env_int("RESEARCH_BASIC_QUERIES", 3),
+        medium_queries=_env_int("RESEARCH_MEDIUM_QUERIES", 5),
+        medium_iterations=_env_int("RESEARCH_MEDIUM_ITERATIONS", 1),
+        medium_followups=_env_int("RESEARCH_MEDIUM_FOLLOWUPS", 3),
+        high_queries=_env_int("RESEARCH_HIGH_QUERIES", 8),
+        high_iterations=_env_int("RESEARCH_HIGH_ITERATIONS", 2),
+        high_followups=_env_int("RESEARCH_HIGH_FOLLOWUPS", 5),
+        extrahigh_queries=_env_int("RESEARCH_EXTRAHIGH_QUERIES", 12),
+        extrahigh_iterations=_env_int("RESEARCH_EXTRAHIGH_ITERATIONS", 3),
+        extrahigh_followups=_env_int("RESEARCH_EXTRAHIGH_FOLLOWUPS", 8),
+        exa_results_per_query=_env_int("EXA_RESULTS_PER_QUERY", 10),
+        exa_max_chars=_env_int("EXA_MAX_CHARS", 15000),
+    )
+
+    for key, value in overrides.items():
+        setattr(config, key, value)
+
+    return config

--- a/src/king_context/research/deepen.py
+++ b/src/king_context/research/deepen.py
@@ -1,0 +1,137 @@
+"""Deepening loop that orchestrates iterative query generation and fetching."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+
+import httpx
+
+from king_context.research.config import EffortLevel, ResearchConfig, effort_profile
+from king_context.research.fetch import SourceDoc, fetch_for_query as fetch_fn
+from king_context.research.queries import (
+    QueryGenerationError,
+    SourceSummary,
+    generate_queries as generate_queries_fn,
+)
+
+log = logging.getLogger(__name__)
+
+_HIGHLIGHT_MAX_CHARS = 240
+
+
+def _build_summaries(docs: list[SourceDoc]) -> list[SourceSummary]:
+    summaries: list[SourceSummary] = []
+    for doc in docs:
+        content = doc.content or ""
+        snippet = content[:_HIGHLIGHT_MAX_CHARS].strip()
+        summaries.append(SourceSummary(title=doc.title, top_highlight=snippet))
+    return summaries
+
+
+def _dedup_by_url(docs: list[SourceDoc]) -> list[SourceDoc]:
+    seen: set[str] = set()
+    out: list[SourceDoc] = []
+    for doc in docs:
+        if doc.url in seen:
+            continue
+        seen.add(doc.url)
+        out.append(doc)
+    return out
+
+
+def _write_iteration_snapshot(
+    work_dir: Path, iteration: int, docs: list[SourceDoc]
+) -> None:
+    path = work_dir / f"iteration_{iteration}.json"
+    payload = [asdict(doc) for doc in docs]
+    try:
+        path.write_text(
+            json.dumps(payload, default=str, indent=2), encoding="utf-8"
+        )
+    except OSError as exc:
+        log.warning("Failed to write iteration snapshot %s: %s", path, exc)
+
+
+async def _fetch_batch(
+    queries: list[str],
+    iteration: int,
+    config: ResearchConfig,
+    jina_client: httpx.AsyncClient,
+) -> list[SourceDoc]:
+    results = await asyncio.gather(
+        *[fetch_fn(q, iteration, config, jina_client) for q in queries],
+        return_exceptions=True,
+    )
+    docs: list[SourceDoc] = []
+    for r in results:
+        if isinstance(r, BaseException):
+            log.warning("fetch_for_query failed: %s", r)
+            continue
+        docs.extend(r)
+    return docs
+
+
+async def run_deepening_loop(
+    topic: str,
+    effort: EffortLevel,
+    config: ResearchConfig,
+    work_dir: Path,
+) -> list[SourceDoc]:
+    """Run the discovery loop: initial queries + optional deepening iterations."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    profile = effort_profile(effort, config)
+
+    all_docs: list[SourceDoc] = []
+    seen_queries: list[str] = []
+
+    async with httpx.AsyncClient() as jina_client:
+        try:
+            initial_queries = await generate_queries_fn(
+                topic,
+                count=profile.initial_queries,
+                config=config,
+            )
+        except QueryGenerationError as exc:
+            log.warning("Initial query generation failed: %s", exc)
+            return []
+
+        if not initial_queries:
+            log.warning("Initial query generation returned no queries")
+            return []
+
+        seen_queries.extend(initial_queries)
+        iter0_docs = await _fetch_batch(initial_queries, 0, config, jina_client)
+        _write_iteration_snapshot(work_dir, 0, iter0_docs)
+        all_docs.extend(iter0_docs)
+
+        for i in range(1, profile.iterations + 1):
+            summaries = _build_summaries(all_docs)
+            try:
+                follow_ups = await generate_queries_fn(
+                    topic,
+                    count=profile.followups_per_iteration,
+                    config=config,
+                    previous_results=summaries,
+                    previous_queries=seen_queries,
+                )
+            except QueryGenerationError as exc:
+                log.warning(
+                    "Deepening iteration %d: query generation failed: %s", i, exc
+                )
+                break
+
+            if not follow_ups:
+                log.info(
+                    "Deepening iteration %d returned no new queries; stopping", i
+                )
+                break
+
+            seen_queries.extend(follow_ups)
+            iter_docs = await _fetch_batch(follow_ups, i, config, jina_client)
+            _write_iteration_snapshot(work_dir, i, iter_docs)
+            all_docs.extend(iter_docs)
+
+    return _dedup_by_url(all_docs)

--- a/src/king_context/research/exa.py
+++ b/src/king_context/research/exa.py
@@ -1,0 +1,152 @@
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+
+from exa_py import Exa
+
+from king_context.research.config import ResearchConfig
+
+logger = logging.getLogger(__name__)
+
+
+MAX_ATTEMPTS = 3
+BACKOFF_DELAYS = (1.0, 2.0)
+
+
+@dataclass
+class ExaResult:
+    url: str
+    title: str
+    text: str
+    highlights: list[str]
+    author: str | None
+    published_date: str | None
+    score: float
+
+
+class ExaTransientError(Exception):
+    """Retry-able: 429, 5xx, network errors."""
+
+
+class ExaPermanentError(Exception):
+    """Skip this query: 422 (per-query issue)."""
+
+
+class ExaBudgetError(Exception):
+    """Fatal: 402 — credits exhausted. Abort the whole run."""
+
+
+class ExaConfigError(Exception):
+    """Fatal: 400 or 401 — bug in request or missing/invalid key."""
+
+
+_STATUS_RE = re.compile(r"\b(4\d\d|5\d\d)\b")
+
+
+def _extract_status(err: Exception) -> int | None:
+    code = getattr(err, "status_code", None)
+    if isinstance(code, int):
+        return code
+    status = getattr(err, "status", None)
+    if isinstance(status, int):
+        return status
+    match = _STATUS_RE.search(str(err))
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
+    return None
+
+
+def _classify_error(err: Exception) -> Exception:
+    status = _extract_status(err)
+    if status is None:
+        return ExaTransientError(f"Unknown Exa error: {err}")
+    if status == 402:
+        return ExaBudgetError(f"Exa credits exhausted (402): {err}")
+    if status in (400, 401):
+        return ExaConfigError(f"Exa config error ({status}): {err}")
+    if status == 422:
+        return ExaPermanentError(f"Exa unprocessable (422): {err}")
+    if status == 429 or 500 <= status < 600:
+        return ExaTransientError(f"Exa transient error ({status}): {err}")
+    return ExaTransientError(f"Unclassified Exa error ({status}): {err}")
+
+
+def _parse_results(response) -> list[ExaResult]:
+    raw_results = getattr(response, "results", None) or []
+    parsed: list[ExaResult] = []
+    for item in raw_results:
+        parsed.append(
+            ExaResult(
+                url=getattr(item, "url", "") or "",
+                title=getattr(item, "title", "") or "",
+                text=getattr(item, "text", "") or "",
+                highlights=list(getattr(item, "highlights", None) or []),
+                author=getattr(item, "author", None),
+                published_date=getattr(item, "published_date", None),
+                score=float(getattr(item, "score", 0.0) or 0.0),
+            )
+        )
+    return parsed
+
+
+def _call_exa_sync(client: Exa, query: str, config: ResearchConfig):
+    return client.search_and_contents(
+        query=query,
+        type="auto",
+        num_results=config.exa_results_per_query,
+        text={
+            "max_characters": config.exa_max_chars,
+            "verbosity": "full",
+            "exclude_sections": ["navigation", "footer", "sidebar"],
+        },
+        highlights={"max_characters": 2000},
+        livecrawl="always",
+    )
+
+
+async def search(query: str, config: ResearchConfig) -> list[ExaResult]:
+    """Run one Exa search_and_contents call. Returns parsed results."""
+    client = Exa(api_key=config.exa_api_key)
+    loop = asyncio.get_running_loop()
+
+    last_transient: ExaTransientError | None = None
+
+    for attempt in range(MAX_ATTEMPTS):
+        try:
+            response = await loop.run_in_executor(
+                None, _call_exa_sync, client, query, config
+            )
+            return _parse_results(response)
+        except Exception as err:
+            mapped = _classify_error(err)
+            if isinstance(mapped, ExaPermanentError):
+                logger.warning(
+                    "Exa skipped query %r due to permanent error: %s", query, err
+                )
+                return []
+            if isinstance(mapped, (ExaBudgetError, ExaConfigError)):
+                raise mapped from err
+            if isinstance(mapped, ExaTransientError):
+                last_transient = mapped
+                if attempt < MAX_ATTEMPTS - 1:
+                    delay = BACKOFF_DELAYS[attempt]
+                    logger.warning(
+                        "Exa transient error (attempt %d/%d) for %r: %s; retrying in %ss",
+                        attempt + 1,
+                        MAX_ATTEMPTS,
+                        query,
+                        err,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise mapped from err
+            raise mapped from err
+
+    if last_transient is not None:
+        raise last_transient
+    return []

--- a/src/king_context/research/export.py
+++ b/src/king_context/research/export.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from king_context import PROJECT_ROOT
+from king_context.scraper.enrich import EnrichedChunk
+from king_context.scraper.export import _sanitize_path, export_to_json
+from king_context.research.fetch import SourceDoc
+
+log = logging.getLogger(__name__)
+
+RESEARCH_DATA_DIR = PROJECT_ROOT / ".king-context" / "data" / "research"
+
+
+def _slugify(text: str) -> str:
+    s = text.lower().strip()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    s = _sanitize_path(s)
+    return s[:40] or "research"
+
+
+def _parse_authors(author: str | None) -> list[str] | None:
+    if not author:
+        return None
+    author = author.strip()
+    if not author:
+        return None
+    if "," in author:
+        parts = [p.strip() for p in author.split(",")]
+        parts = [p for p in parts if p]
+        return parts or None
+    return [author]
+
+
+def _apply_research_fields(
+    section: dict, sources_by_url: dict[str, SourceDoc]
+) -> None:
+    section["source_type"] = "research"
+    source = sources_by_url.get(section["url"])
+    if source is None:
+        return
+
+    authors = _parse_authors(source.author)
+    if authors:
+        section["authors"] = authors
+
+    if source.published_date:
+        section["published_date"] = source.published_date
+
+    section["domain"] = source.domain
+    section["discovery_iteration"] = source.discovery_iteration
+
+
+def export_research_to_json(
+    enriched: list[EnrichedChunk],
+    sources_by_url: dict[str, SourceDoc],
+    topic_slug: str,
+    topic: str,
+    base_url: str | None = None,
+) -> Path:
+    """Export enriched research chunks to .king-context/data/research/<slug>.json."""
+    slug = _slugify(topic_slug)
+
+    doc = export_to_json(
+        enriched,
+        doc_name=slug,
+        display_name=topic,
+        base_url=base_url or "",
+        version="v1",
+    )
+
+    for section in doc["sections"]:
+        _apply_research_fields(section, sources_by_url)
+
+    RESEARCH_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = RESEARCH_DATA_DIR / f"{slug}.json"
+
+    if output_path.exists():
+        msg = f"Overwriting existing research export: {output_path}"
+        log.warning(msg)
+        print(msg)
+
+    output_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False))
+    return output_path
+
+
+def auto_index(json_path: Path, store_dir: Path | None = None) -> None:
+    """Index the exported research JSON into the kctx file-based store.
+    Logs and swallows failures — never raises. Uses context_cli.STORE_DIR by default."""
+    try:
+        from context_cli import STORE_DIR
+        from context_cli.indexer import index_doc
+
+        target = store_dir if store_dir is not None else STORE_DIR
+        result = index_doc(json_path, target)
+        log.info("Indexed research doc '%s' at %s", result.doc_name, result.store_path)
+    except Exception as exc:
+        log.warning("auto_index failed for %s: %s", json_path, exc)

--- a/src/king_context/research/export.py
+++ b/src/king_context/research/export.py
@@ -90,12 +90,12 @@ def export_research_to_json(
 
 def auto_index(json_path: Path, store_dir: Path | None = None) -> None:
     """Index the exported research JSON into the kctx file-based store.
-    Logs and swallows failures — never raises. Uses context_cli.STORE_DIR by default."""
+    Logs and swallows failures — never raises. Uses context_cli.RESEARCH_STORE_DIR by default."""
     try:
-        from context_cli import STORE_DIR
+        from context_cli import RESEARCH_STORE_DIR
         from context_cli.indexer import index_doc
 
-        target = store_dir if store_dir is not None else STORE_DIR
+        target = store_dir if store_dir is not None else RESEARCH_STORE_DIR
         result = index_doc(json_path, target)
         log.info("Indexed research doc '%s' at %s", result.doc_name, result.store_path)
     except Exception as exc:

--- a/src/king_context/research/fetch.py
+++ b/src/king_context/research/fetch.py
@@ -69,6 +69,13 @@ async def _jina_fallback(
                 "Jina fallback failed for %s: %s", exa_result.url, exc
             )
             return None
+        except Exception as exc:
+            log.warning(
+                "Unexpected Jina fallback failure for %s: %s",
+                exa_result.url,
+                exc,
+            )
+            return None
         return SourceDoc(
             url=exa_result.url,
             title=result.title or exa_result.title,
@@ -109,7 +116,17 @@ async def fetch_for_query(
         _jina_fallback(result, query, iteration, semaphore, jina_client, config)
         for result in short_results
     ]
-    jina_docs = await asyncio.gather(*tasks)
-    fallback_docs = [doc for doc in jina_docs if doc is not None]
+    jina_docs = await asyncio.gather(*tasks, return_exceptions=True)
+    fallback_docs: list[SourceDoc] = []
+    for result, doc in zip(short_results, jina_docs):
+        if isinstance(doc, Exception):
+            log.warning(
+                "Unhandled Jina fallback failure for %s: %s",
+                result.url,
+                doc,
+            )
+            continue
+        if doc is not None:
+            fallback_docs.append(doc)
 
     return direct_docs + fallback_docs

--- a/src/king_context/research/fetch.py
+++ b/src/king_context/research/fetch.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlparse
+
+import httpx
+
+from king_context.research.config import ResearchConfig
+from king_context.research.exa import ExaResult, search as exa_search
+from king_context.research.jina import (
+    JinaDegradedError,
+    JinaPermanentError,
+    JinaTransientError,
+    fetch as jina_fetch,
+)
+
+log = logging.getLogger(__name__)
+
+MIN_CONTENT_CHARS = 600
+
+
+@dataclass
+class SourceDoc:
+    url: str
+    title: str
+    content: str
+    author: str | None
+    published_date: str | None
+    domain: str
+    query: str
+    discovery_iteration: int
+    score: float | None
+    fetch_path: Literal["exa", "jina"]
+
+
+def _build_exa_doc(result: ExaResult, query: str, iteration: int) -> SourceDoc:
+    return SourceDoc(
+        url=result.url,
+        title=result.title,
+        content=result.text,
+        author=result.author,
+        published_date=result.published_date,
+        domain=urlparse(result.url).netloc,
+        query=query,
+        discovery_iteration=iteration,
+        score=result.score,
+        fetch_path="exa",
+    )
+
+
+async def _jina_fallback(
+    exa_result: ExaResult,
+    query: str,
+    iteration: int,
+    semaphore: asyncio.Semaphore,
+    jina_client: httpx.AsyncClient,
+    config: ResearchConfig,
+) -> SourceDoc | None:
+    async with semaphore:
+        try:
+            result = await jina_fetch(
+                exa_result.url, config.jina_api_key, jina_client
+            )
+        except (JinaTransientError, JinaPermanentError, JinaDegradedError) as exc:
+            log.warning(
+                "Jina fallback failed for %s: %s", exa_result.url, exc
+            )
+            return None
+        return SourceDoc(
+            url=exa_result.url,
+            title=result.title or exa_result.title,
+            content=result.content,
+            author=exa_result.author,
+            published_date=exa_result.published_date,
+            domain=urlparse(exa_result.url).netloc,
+            query=query,
+            discovery_iteration=iteration,
+            score=exa_result.score,
+            fetch_path="jina",
+        )
+
+
+async def fetch_for_query(
+    query: str,
+    iteration: int,
+    config: ResearchConfig,
+    jina_client: httpx.AsyncClient,
+) -> list[SourceDoc]:
+    """Run Exa search, keep sufficient results directly, fallback short ones to Jina."""
+    exa_results = await exa_search(query, config)
+
+    direct_docs: list[SourceDoc] = []
+    short_results: list[ExaResult] = []
+
+    for result in exa_results:
+        if len(result.text) >= MIN_CONTENT_CHARS:
+            direct_docs.append(_build_exa_doc(result, query, iteration))
+        else:
+            short_results.append(result)
+
+    if not short_results:
+        return direct_docs
+
+    semaphore = asyncio.Semaphore(config.scraper.concurrency)
+    tasks = [
+        _jina_fallback(result, query, iteration, semaphore, jina_client, config)
+        for result in short_results
+    ]
+    jina_docs = await asyncio.gather(*tasks)
+    fallback_docs = [doc for doc in jina_docs if doc is not None]
+
+    return direct_docs + fallback_docs

--- a/src/king_context/research/jina.py
+++ b/src/king_context/research/jina.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+from typing import Any
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+JINA_BASE_URL = "https://r.jina.ai/"
+WORD_COUNT_THRESHOLD = 50
+_ENGINE_SEQUENCE = ["direct", "browser", "browser"]
+_TIMEOUT_SEQUENCE = [30, 30, 60]
+_RETRY_DELAYS = [2.0, 5.0]
+
+
+class JinaTransientError(Exception):
+    """Retry-able server or network error (429, 5xx, timeouts, connect errors)."""
+
+
+class JinaPermanentError(Exception):
+    """Non-retry-able (400, 401, 403, 404, 422). Skip this URL."""
+
+
+class JinaDegradedError(Exception):
+    """200 OK but content below WORD_COUNT_THRESHOLD. Escalate engine on retry."""
+
+
+@dataclasses.dataclass
+class FetchResult:
+    url: str
+    title: str
+    content: str
+    word_count: int
+
+
+def _build_body(url: str, engine: str, timeout: int) -> dict[str, Any]:
+    return {
+        "url": url,
+        "respondWith": "markdown",
+        "engine": engine,
+        "respondTiming": "network-idle",
+        "retainLinks": "none",
+        "retainImages": "none",
+        "removeSelector": "nav, footer, aside, .ad, .cookie-banner, .sidebar",
+        "timeout": timeout,
+    }
+
+
+def _parse_response(payload: dict[str, Any], url: str) -> FetchResult:
+    data = payload.get("data") or {}
+    if isinstance(data, str):
+        content = data
+        title = ""
+    else:
+        content = data.get("content") or data.get("text") or ""
+        title = data.get("title") or ""
+    word_count = len(content.split())
+    return FetchResult(url=url, title=title, content=content, word_count=word_count)
+
+
+async def _attempt(
+    url: str,
+    api_key: str,
+    client: httpx.AsyncClient,
+    engine: str,
+    jina_timeout: int,
+) -> FetchResult:
+    headers = {
+        "Accept": "application/json",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    body = _build_body(url, engine, jina_timeout)
+    client_timeout = httpx.Timeout(jina_timeout + 5.0)
+
+    try:
+        resp = await client.post(
+            JINA_BASE_URL, json=body, headers=headers, timeout=client_timeout
+        )
+    except httpx.TimeoutException as exc:
+        raise JinaTransientError(f"Client timeout fetching {url}") from exc
+    except httpx.ConnectError as exc:
+        raise JinaTransientError(f"Connection error fetching {url}") from exc
+
+    if resp.status_code == 429 or resp.status_code >= 500:
+        raise JinaTransientError(f"HTTP {resp.status_code} for {url}")
+    if resp.status_code in (400, 401, 403, 404, 422):
+        raise JinaPermanentError(f"HTTP {resp.status_code} for {url}")
+    if resp.status_code != 200:
+        raise JinaTransientError(f"Unexpected HTTP {resp.status_code} for {url}")
+
+    payload: dict[str, Any] = resp.json()
+    result = _parse_response(payload, url)
+
+    if result.word_count < WORD_COUNT_THRESHOLD:
+        raise JinaDegradedError(
+            f"Insufficient content ({result.word_count} words) for {url}"
+        )
+    return result
+
+
+async def fetch(url: str, api_key: str, client: httpx.AsyncClient) -> FetchResult:
+    """Fetch and clean a URL via Jina Reader with retry + engine escalation."""
+    last_exc: Exception = JinaPermanentError("No attempts made")
+
+    for attempt in range(3):
+        engine = _ENGINE_SEQUENCE[attempt]
+        jina_timeout = _TIMEOUT_SEQUENCE[attempt]
+        try:
+            result = await _attempt(url, api_key, client, engine, jina_timeout)
+            log.debug("Jina fetch OK: %s (attempt %d, engine=%s)", url, attempt + 1, engine)
+            return result
+        except JinaPermanentError:
+            raise
+        except (JinaTransientError, JinaDegradedError) as exc:
+            log.warning("Jina attempt %d failed for %s: %s", attempt + 1, url, exc)
+            last_exc = exc
+            if attempt < len(_RETRY_DELAYS):
+                await asyncio.sleep(_RETRY_DELAYS[attempt])
+
+    raise last_exc

--- a/src/king_context/research/pipeline.py
+++ b/src/king_context/research/pipeline.py
@@ -1,0 +1,229 @@
+"""Research pipeline orchestrating the 5-step: generate, search, chunk, enrich, export."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+
+from king_context.research.config import ResearchConfig
+from king_context.research.deepen import run_deepening_loop
+from king_context.research.export import (
+    _slugify,
+    auto_index,
+    export_research_to_json,
+)
+from king_context.research.fetch import SourceDoc
+from king_context.scraper.chunk import Chunk, chunk_page
+from king_context.scraper.config import ConfigError
+from king_context.scraper.discover import TEMP_DOCS_DIR, _update_step
+from king_context.scraper.enrich import EnrichedChunk, enrich_chunks, estimate_cost
+
+log = logging.getLogger(__name__)
+
+RESEARCH_STEPS = ["generate", "search", "chunk", "enrich", "export"]
+
+MANIFEST_KEYS = {
+    "generate": "generate",
+    "search": "search",
+    "chunk": "chunking",
+    "enrich": "enrichment",
+    "export": "export",
+}
+
+
+def _source_slug(url: str) -> str:
+    s = re.sub(r"^https?://", "", url)
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", s).strip("-")
+    return (s[:200] or "page").lower()
+
+
+def _validate_config(config: ResearchConfig) -> None:
+    if not config.exa_api_key:
+        raise ConfigError(
+            "EXA_API_KEY not set — add it to .env or .king-context/.env"
+        )
+    if not config.scraper.openrouter_api_key:
+        raise ConfigError(
+            "OPENROUTER_API_KEY not set — add it to .env or .king-context/.env"
+        )
+
+
+def _write_page_artifacts(source: SourceDoc, pages_dir: Path) -> None:
+    slug = _source_slug(source.url)
+    md_path = pages_dir / f"{slug}.md"
+    json_path = pages_dir / f"{slug}.json"
+    try:
+        md_path.write_text(source.content or "", encoding="utf-8")
+        sidecar = {
+            "url": source.url,
+            "title": source.title,
+            "author": source.author,
+            "published_date": source.published_date,
+            "domain": source.domain,
+            "discovery_iteration": source.discovery_iteration,
+            "query": source.query,
+            "fetch_path": source.fetch_path,
+        }
+        json_path.write_text(
+            json.dumps(sidecar, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        log.warning("Failed to persist page artifacts for %s: %s", source.url, exc)
+
+
+def _write_chunk_checkpoint(
+    source: SourceDoc, page_chunks: list[Chunk], chunks_dir: Path
+) -> None:
+    slug = _source_slug(source.url)
+    try:
+        data = [
+            {
+                "title": c.title,
+                "breadcrumb": c.breadcrumb,
+                "content": c.content,
+                "source_url": c.source_url,
+                "path": c.path,
+                "token_count": c.token_count,
+            }
+            for c in page_chunks
+        ]
+        (chunks_dir / f"{slug}.json").write_text(
+            json.dumps(data, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        log.warning("Failed to write chunk checkpoint for %s: %s", source.url, exc)
+
+
+async def run_pipeline(args: argparse.Namespace, config: ResearchConfig) -> Path:
+    """Orchestrate the 5-step research pipeline and return the exported JSON path."""
+    _validate_config(config)
+
+    slug = args.name or _slugify(args.topic)
+    work_dir = TEMP_DOCS_DIR / "research" / slug
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    target_step = getattr(args, "step", None)
+    stop_after = getattr(args, "stop_after", None)
+
+    if target_step and target_step not in RESEARCH_STEPS:
+        raise ValueError(f"Unknown step: {target_step}")
+    if stop_after and stop_after not in RESEARCH_STEPS:
+        raise ValueError(f"Unknown stop-after step: {stop_after}")
+
+    if target_step:
+        log.warning(
+            "--step=%s requested; resume not implemented in P1, "
+            "earlier steps will be skipped without state rehydration",
+            target_step,
+        )
+
+    sources: list[SourceDoc] = []
+    chunks: list[Chunk] = []
+    enriched: list[EnrichedChunk] = []
+    output_path: Path | None = None
+
+    for step in RESEARCH_STEPS:
+        if target_step and RESEARCH_STEPS.index(step) < RESEARCH_STEPS.index(target_step):
+            continue
+
+        print(f"[{step}] running...")
+
+        if step == "generate":
+            _update_step(
+                work_dir,
+                MANIFEST_KEYS["generate"],
+                {"status": "done", "topic": args.topic, "slug": slug},
+            )
+            log.info("generate: prepared work_dir for topic '%s' (slug=%s)", args.topic, slug)
+
+        elif step == "search":
+            sources = await run_deepening_loop(
+                args.topic, args.effort, config, work_dir
+            )
+            if not sources:
+                raise RuntimeError(
+                    f"No sources found for topic '{args.topic}' — "
+                    "refine the topic and retry."
+                )
+            _update_step(
+                work_dir,
+                MANIFEST_KEYS["search"],
+                {"status": "done", "total_sources": len(sources)},
+            )
+            print(f"  found {len(sources)} sources")
+
+        elif step == "chunk":
+            pages_dir = work_dir / "pages"
+            chunks_dir = work_dir / "chunks"
+            pages_dir.mkdir(parents=True, exist_ok=True)
+            chunks_dir.mkdir(parents=True, exist_ok=True)
+
+            chunks = []
+            for source in sources:
+                _write_page_artifacts(source, pages_dir)
+                page_chunks = chunk_page(
+                    source.content or "", source.url, config.scraper
+                )
+                _write_chunk_checkpoint(source, page_chunks, chunks_dir)
+                chunks.extend(page_chunks)
+
+            _update_step(
+                work_dir,
+                MANIFEST_KEYS["chunk"],
+                {"status": "done", "total_chunks": len(chunks)},
+            )
+            print(f"  created {len(chunks)} chunks")
+
+        elif step == "enrich":
+            cost = estimate_cost(chunks, config.scraper)
+            print(
+                f"Enrichment cost estimate: ${cost['estimated_cost']:.4f} "
+                f"({cost['total_chunks']} chunks, model: {cost['model']})"
+            )
+            if not getattr(args, "yes", False):
+                confirm = input("Proceed? [y/N] ").strip().lower()
+                if confirm != "y":
+                    print("  Enrichment cancelled.")
+                    return work_dir / "manifest.json"
+
+            enriched = await enrich_chunks(
+                chunks, config.scraper, output_dir=work_dir
+            )
+            _update_step(
+                work_dir,
+                MANIFEST_KEYS["enrich"],
+                {"status": "done", "total_enriched": len(enriched)},
+            )
+            print(f"  enriched {len(enriched)} chunks")
+
+        elif step == "export":
+            sources_by_url: dict[str, SourceDoc] = {s.url: s for s in sources}
+            output_path = export_research_to_json(
+                enriched,
+                sources_by_url,
+                slug,
+                args.topic,
+                base_url=None,
+            )
+            if not getattr(args, "no_auto_index", False):
+                auto_index(output_path)
+            _update_step(
+                work_dir,
+                MANIFEST_KEYS["export"],
+                {"status": "done", "output": str(output_path)},
+            )
+            print(f"  exported to {output_path}")
+
+        if stop_after and step == stop_after:
+            print(f"  Stopped after '{step}' as requested.")
+            if output_path is not None:
+                return output_path
+            return work_dir / "manifest.json"
+
+    if output_path is None:
+        return work_dir / "manifest.json"
+    return output_path

--- a/src/king_context/research/pipeline.py
+++ b/src/king_context/research/pipeline.py
@@ -170,6 +170,11 @@ async def run_pipeline(args: argparse.Namespace, config: ResearchConfig) -> Path
                 )
                 _write_chunk_checkpoint(source, page_chunks, chunks_dir)
                 chunks.extend(page_chunks)
+            if not chunks:
+                raise RuntimeError(
+                    f"Chunking produced no sections for topic '{args.topic}' — "
+                    "nothing can be enriched or exported."
+                )
 
             _update_step(
                 work_dir,
@@ -179,6 +184,11 @@ async def run_pipeline(args: argparse.Namespace, config: ResearchConfig) -> Path
             print(f"  created {len(chunks)} chunks")
 
         elif step == "enrich":
+            if not chunks:
+                raise RuntimeError(
+                    f"No chunks available to enrich for topic '{args.topic}' — "
+                    "chunking produced no sections or resume state is missing."
+                )
             cost = estimate_cost(chunks, config.scraper)
             print(
                 f"Enrichment cost estimate: ${cost['estimated_cost']:.4f} "
@@ -193,6 +203,11 @@ async def run_pipeline(args: argparse.Namespace, config: ResearchConfig) -> Path
             enriched = await enrich_chunks(
                 chunks, config.scraper, output_dir=work_dir
             )
+            if not enriched:
+                raise RuntimeError(
+                    f"Enrichment produced no sections for topic '{args.topic}' — "
+                    "aborting before export to avoid overwriting an existing corpus."
+                )
             _update_step(
                 work_dir,
                 MANIFEST_KEYS["enrich"],
@@ -201,6 +216,10 @@ async def run_pipeline(args: argparse.Namespace, config: ResearchConfig) -> Path
             print(f"  enriched {len(enriched)} chunks")
 
         elif step == "export":
+            if not enriched:
+                raise RuntimeError(
+                    f"No enriched sections available to export for topic '{args.topic}'."
+                )
             sources_by_url: dict[str, SourceDoc] = {s.url: s for s in sources}
             output_path = export_research_to_json(
                 enriched,

--- a/src/king_context/research/queries.py
+++ b/src/king_context/research/queries.py
@@ -1,0 +1,260 @@
+"""LLM-backed search query generation for the research pipeline."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import string
+from dataclasses import dataclass
+
+import httpx
+
+from king_context.research.config import ResearchConfig
+
+
+log = logging.getLogger(__name__)
+
+_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+_REQUEST_TIMEOUT = 30.0
+_MAX_ATTEMPTS = 3
+_RETRY_DELAYS: list[float] = [1.0, 2.0]
+_HIGHLIGHT_MAX_CHARS = 240
+
+_SYSTEM_PROMPT = (
+    "You are a research query planner. "
+    'Output STRICTLY a JSON object with a single key "queries" whose value is an '
+    "array of strings. No prose, no explanation."
+)
+
+_WS_RE = re.compile(r"\s+")
+_MD_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```$", re.DOTALL | re.IGNORECASE)
+
+
+class QueryGenerationError(Exception):
+    """LLM call failed or response was unusable."""
+
+
+@dataclass
+class SourceSummary:
+    title: str
+    top_highlight: str
+
+
+def _normalize(query: str) -> str:
+    """Lowercase, collapse whitespace, strip trailing punctuation."""
+    collapsed = _WS_RE.sub(" ", query.strip().lower())
+    return collapsed.rstrip(string.punctuation + " ")
+
+
+def _build_user_prompt(
+    topic: str,
+    count: int,
+    previous_results: list[SourceSummary] | None,
+    previous_queries: list[str] | None,
+) -> str:
+    parts: list[str] = [
+        f"Topic: {topic}",
+        f"Generate {count} distinct search queries that cover complementary "
+        "angles of the topic.",
+    ]
+
+    if previous_queries:
+        parts.append(
+            "Avoid duplicating these queries (any substring or close rewording):"
+        )
+        for q in previous_queries:
+            parts.append(f"- {q}")
+
+    if previous_results:
+        parts.append(
+            "Here is a condensed view of what was already found. Use this to "
+            "emit FOLLOW-UP queries that dig deeper into promising themes — "
+            "not queries that would retrieve the same pages."
+        )
+        for item in previous_results:
+            highlight = (item.top_highlight or "").strip()
+            if len(highlight) > _HIGHLIGHT_MAX_CHARS:
+                highlight = highlight[: _HIGHLIGHT_MAX_CHARS - 1].rstrip() + "…"
+            parts.append(f'- "{item.title}" — {highlight}')
+
+    return "\n".join(parts)
+
+
+def _strip_code_fence(content: str) -> str:
+    stripped = content.strip()
+    match = _MD_FENCE_RE.match(stripped)
+    if match:
+        return match.group(1).strip()
+    return stripped
+
+
+def _extract_queries(raw_content: str) -> list[str]:
+    """Parse the model's content string into a list of query strings."""
+    content = _strip_code_fence(raw_content)
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise QueryGenerationError(
+            f"LLM response was not valid JSON: {exc}"
+        ) from exc
+
+    if isinstance(parsed, list):
+        candidates = parsed
+    elif isinstance(parsed, dict) and isinstance(parsed.get("queries"), list):
+        candidates = parsed["queries"]
+    else:
+        raise QueryGenerationError(
+            "LLM response did not contain a list of queries"
+        )
+
+    queries: list[str] = []
+    for item in candidates:
+        if isinstance(item, str) and item.strip():
+            queries.append(item.strip())
+    return queries
+
+
+def _should_retry(status_code: int) -> bool:
+    return status_code == 429 or status_code >= 500
+
+
+def _is_fatal_client_error(status_code: int) -> bool:
+    return status_code in (400, 401)
+
+
+async def _post_once(
+    client: httpx.AsyncClient,
+    payload: dict,
+    api_key: str,
+) -> httpx.Response:
+    return await client.post(
+        _OPENROUTER_URL,
+        headers={"Authorization": f"Bearer {api_key}"},
+        json=payload,
+    )
+
+
+async def _call_openrouter(
+    system_prompt: str,
+    user_prompt: str,
+    model: str,
+    api_key: str,
+) -> str:
+    """POST to OpenRouter with retries. Returns the raw ``content`` string."""
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "response_format": {"type": "json_object"},
+    }
+
+    last_error: Exception | None = None
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                response = await _post_once(client, payload, api_key)
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_error = exc
+                log.warning(
+                    "OpenRouter transient error on attempt %d: %s", attempt + 1, exc
+                )
+            else:
+                status = response.status_code
+                if status < 400:
+                    data = response.json()
+                    try:
+                        return data["choices"][0]["message"]["content"]
+                    except (KeyError, IndexError, TypeError) as exc:
+                        raise QueryGenerationError(
+                            f"Unexpected OpenRouter response shape: {exc}"
+                        ) from exc
+
+                if _is_fatal_client_error(status):
+                    raise QueryGenerationError(
+                        f"OpenRouter rejected request (status {status}): "
+                        f"{response.text[:200]}"
+                    )
+
+                if not _should_retry(status):
+                    raise QueryGenerationError(
+                        f"OpenRouter returned status {status}: "
+                        f"{response.text[:200]}"
+                    )
+
+                last_error = httpx.HTTPStatusError(
+                    f"status {status}", request=response.request, response=response
+                )
+                log.warning(
+                    "OpenRouter retryable status %d on attempt %d", status, attempt + 1
+                )
+
+            if attempt < len(_RETRY_DELAYS):
+                await asyncio.sleep(_RETRY_DELAYS[attempt])
+
+    raise QueryGenerationError(
+        f"OpenRouter call failed after {_MAX_ATTEMPTS} attempts: {last_error}"
+    )
+
+
+def _dedup(
+    candidates: list[str],
+    previous_queries: list[str] | None,
+    count: int,
+) -> list[str]:
+    seen: set[str] = set()
+    if previous_queries:
+        for q in previous_queries:
+            seen.add(_normalize(q))
+
+    out: list[str] = []
+    for q in candidates:
+        norm = _normalize(q)
+        if not norm:
+            continue
+        if norm in seen:
+            log.info("Skipping duplicate query: %r", q)
+            continue
+        seen.add(norm)
+        out.append(q)
+        if len(out) >= count:
+            break
+
+    return out
+
+
+async def generate_queries(
+    topic: str,
+    count: int,
+    config: ResearchConfig,
+    *,
+    previous_results: list[SourceSummary] | None = None,
+    previous_queries: list[str] | None = None,
+) -> list[str]:
+    """Generate up to ``count`` distinct search queries for ``topic``.
+
+    Initial call: ``previous_results``/``previous_queries`` are ``None`` and the
+    model returns fresh queries for the topic. Follow-up call: pass the prior
+    summaries/queries; the LLM emits follow-ups that dig deeper.
+    """
+    if count <= 0:
+        return []
+
+    model = config.research_model or config.scraper.enrichment_model
+    if not model:
+        raise QueryGenerationError("No model configured for query generation")
+    if not config.scraper.openrouter_api_key:
+        raise QueryGenerationError("OPENROUTER_API_KEY is not configured")
+
+    user_prompt = _build_user_prompt(topic, count, previous_results, previous_queries)
+    raw_content = await _call_openrouter(
+        _SYSTEM_PROMPT,
+        user_prompt,
+        model,
+        config.scraper.openrouter_api_key,
+    )
+
+    candidates = _extract_queries(raw_content)
+    return _dedup(candidates, previous_queries, count)

--- a/src/king_context/scraper/cli.py
+++ b/src/king_context/scraper/cli.py
@@ -314,3 +314,7 @@ def main() -> None:
         filter_llm_fallback=not args.no_llm_filter,
     )
     asyncio.run(run_pipeline(args, config))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/king_context/scraper/config.py
+++ b/src/king_context/scraper/config.py
@@ -1,8 +1,22 @@
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv()
+from king_context import PROJECT_ROOT
+
+
+def _load_env_files(project_root: Path | None = None) -> None:
+    root = project_root if project_root is not None else PROJECT_ROOT
+    installer_env = root / ".king-context" / ".env"
+    if installer_env.exists():
+        load_dotenv(installer_env)
+    developer_env = root / ".env"
+    if developer_env.exists():
+        load_dotenv(developer_env, override=True)
+
+
+_load_env_files()
 
 
 class ConfigError(Exception):

--- a/tests/test_context_cli/test_cli.py
+++ b/tests/test_context_cli/test_cli.py
@@ -13,6 +13,8 @@ def store_with_doc(tmp_path, monkeypatch):
     """Create a .king-context/docs/ store with one indexed doc and patch STORE_DIR."""
     store_dir = tmp_path / ".king-context" / "docs"
     store_dir.mkdir(parents=True)
+    research_store_dir = tmp_path / ".king-context" / "research"
+    research_store_dir.mkdir(parents=True)
 
     # Create source JSON
     source = {
@@ -49,6 +51,7 @@ def store_with_doc(tmp_path, monkeypatch):
 
     import context_cli.cli as cli_mod
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store_dir)
     monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
 
     return store_dir, tmp_path, src_file
@@ -72,15 +75,35 @@ def test_list_json(store_with_doc, monkeypatch, capsys):
     _run_cli(["list", "--json"], monkeypatch)
     out = capsys.readouterr().out
     data = json.loads(out)
+    assert "docs" in data and "research" in data
+    assert len(data["docs"]) == 1
+    assert data["docs"][0]["name"] == "test-api"
+    assert data["research"] == []
+
+
+def test_list_docs_only_json(store_with_doc, monkeypatch, capsys):
+    _run_cli(["list", "docs", "--json"], monkeypatch)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert isinstance(data, list)
     assert len(data) == 1
     assert data[0]["name"] == "test-api"
+
+
+def test_list_research_only_empty(store_with_doc, monkeypatch, capsys):
+    _run_cli(["list", "research"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "No docs indexed" in out
 
 
 def test_list_empty_store(tmp_path, monkeypatch, capsys):
     empty_store = tmp_path / ".king-context" / "docs"
     empty_store.mkdir(parents=True)
+    empty_research = tmp_path / ".king-context" / "research"
+    empty_research.mkdir(parents=True)
     import context_cli.cli as cli_mod
     monkeypatch.setattr(cli_mod, "STORE_DIR", empty_store)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", empty_research)
 
     _run_cli(["list"], monkeypatch)
     out = capsys.readouterr().out
@@ -143,8 +166,10 @@ def test_read_json(store_with_doc, monkeypatch, capsys):
 
 def test_index_single_file(tmp_path, monkeypatch, capsys):
     store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
     import context_cli.cli as cli_mod
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
 
     source = {
         "name": "new-api",
@@ -173,13 +198,49 @@ def test_index_single_file(tmp_path, monkeypatch, capsys):
     assert (store_dir / "new-api" / "index.json").exists()
 
 
+def test_index_auto_detects_research(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
+
+    source = {
+        "name": "my-topic",
+        "display_name": "My Topic",
+        "version": "v1",
+        "base_url": "",
+        "sections": [
+            {
+                "title": "A",
+                "path": "a",
+                "url": "https://ex.com/a",
+                "keywords": ["k"], "use_cases": ["u"], "tags": ["t"],
+                "priority": 5,
+                "content": "hello",
+                "source_type": "research",
+            }
+        ],
+    }
+    src_file = tmp_path / "my-topic.json"
+    src_file.write_text(json.dumps(source))
+
+    _run_cli(["index", str(src_file)], monkeypatch)
+    out = capsys.readouterr().out
+    assert "(research)" in out
+    assert (research_store / "my-topic" / "index.json").exists()
+    assert not (store_dir / "my-topic").exists()
+
+
 def test_index_all(tmp_path, monkeypatch, capsys):
     store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
     data_dir = tmp_path / ".king-context" / "data"
     data_dir.mkdir(parents=True)
 
     import context_cli.cli as cli_mod
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
     monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
 
     for name in ["api-a", "api-b"]:
@@ -200,8 +261,10 @@ def test_index_all(tmp_path, monkeypatch, capsys):
 
 def test_index_file_not_found(tmp_path, monkeypatch):
     store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
     import context_cli.cli as cli_mod
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
 
     with pytest.raises(SystemExit):
         _run_cli(["index", "/nonexistent/file.json"], monkeypatch)

--- a/tests/test_context_cli/test_cli.py
+++ b/tests/test_context_cli/test_cli.py
@@ -164,6 +164,44 @@ def test_read_json(store_with_doc, monkeypatch, capsys):
     assert "content" in data
 
 
+def test_read_requires_explicit_source_when_slug_exists_in_both_stores(
+    store_with_doc, monkeypatch, capsys
+):
+    _, tmp_path, _ = store_with_doc
+    research_source = {
+        "name": "test-api",
+        "display_name": "Test API Research",
+        "version": "v1",
+        "base_url": "",
+        "sections": [
+            {
+                "title": "Research Finding",
+                "path": "finding",
+                "url": "https://example.com/research/finding",
+                "keywords": ["finding"],
+                "use_cases": ["Read a research-only finding"],
+                "tags": ["research"],
+                "priority": 7,
+                "content": "Research-only section content.",
+                "source_type": "research",
+            }
+        ],
+    }
+    research_file = tmp_path / "test-api-research.json"
+    research_file.write_text(json.dumps(research_source))
+
+    import context_cli.cli as cli_mod
+    index_doc(research_file, cli_mod.RESEARCH_STORE_DIR)
+
+    with pytest.raises(SystemExit):
+        _run_cli(["read", "test-api", "finding"], monkeypatch)
+
+    err = capsys.readouterr().err
+    assert "exists in multiple stores" in err
+    assert "--source docs" in err
+    assert "--source research" in err
+
+
 def test_index_single_file(tmp_path, monkeypatch, capsys):
     store_dir = tmp_path / ".king-context" / "docs"
     research_store = tmp_path / ".king-context" / "research"

--- a/tests/test_context_cli/test_formatter.py
+++ b/tests/test_context_cli/test_formatter.py
@@ -109,10 +109,10 @@ def test_format_search_plain():
     ]
     output = format_search(results)
 
-    assert "1. useState" in output
+    assert "1. [docs] useState" in output
     assert "score=0.95" in output
     assert "manage component state" in output
-    assert "2. useEffect" in output
+    assert "2. [docs] useEffect" in output
     assert "score=0.80" in output
     assert "run side effects" in output
 
@@ -124,7 +124,7 @@ def test_format_search_plain_empty():
 def test_format_search_plain_no_use_case():
     results = [_result(use_cases=[])]
     output = format_search(results)
-    assert "1. useState" in output
+    assert "1. [docs] useState" in output
     # No indented use_case line
     assert output.count("\n") == 0
 
@@ -225,7 +225,7 @@ def test_format_grep_plain():
     ]
     output = format_grep(matches)
 
-    assert "## react/useState" in output
+    assert "## [docs] react/useState" in output
     assert "  15: const [count, setCount] = useState(0);" in output
     assert "  20: setCount(prev => prev + 1);" in output
 
@@ -238,8 +238,8 @@ def test_format_grep_plain_multiple_sections():
     ]
     output = format_grep(matches)
 
-    assert "## react/useState" in output
-    assert "## vue/ref" in output
+    assert "## [docs] react/useState" in output
+    assert "## [docs] vue/ref" in output
 
 
 def test_format_grep_plain_empty():

--- a/tests/test_context_cli/test_topics.py
+++ b/tests/test_context_cli/test_topics.py
@@ -174,3 +174,26 @@ def test_topics_doc_not_found(tmp_path, monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "nonexistent-api" in err or "not found" in err.lower()
     assert "other-api" in err
+
+
+def test_topics_requires_explicit_source_when_slug_exists_in_both_stores(
+    tmp_path, monkeypatch, capsys
+):
+    docs_store = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
+    docs_store.mkdir(parents=True)
+    research_store.mkdir(parents=True)
+    _build_doc(docs_store, doc_name="shared-api")
+    _build_doc(research_store, doc_name="shared-api")
+
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", docs_store)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
+
+    with pytest.raises(SystemExit):
+        _run_cli(["topics", "shared-api"], monkeypatch)
+
+    err = capsys.readouterr().err
+    assert "exists in multiple stores" in err
+    assert "--source docs" in err
+    assert "--source research" in err

--- a/tests/test_research/test_cli.py
+++ b/tests/test_research/test_cli.py
@@ -1,0 +1,111 @@
+"""Tests for the king-research CLI parser and effort resolution."""
+
+import pytest
+
+from king_context.research.cli import _build_parser, _resolve_effort
+from king_context.research.config import EffortLevel
+from king_context.research.pipeline import RESEARCH_STEPS
+
+
+def test_default_effort_is_medium():
+    parser = _build_parser()
+    args = parser.parse_args(["some topic"])
+    assert args.effort_flag is None
+    assert _resolve_effort(args) == EffortLevel.MEDIUM
+
+
+def test_basic_flag_sets_basic():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--basic"])
+    assert _resolve_effort(args) == EffortLevel.BASIC
+
+
+def test_high_flag_sets_high():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--high"])
+    assert _resolve_effort(args) == EffortLevel.HIGH
+
+
+def test_extrahigh_flag_sets_extrahigh():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--extrahigh"])
+    assert _resolve_effort(args) == EffortLevel.EXTRAHIGH
+
+
+def test_effort_flags_are_mutually_exclusive():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["topic", "--basic", "--high"])
+
+
+def test_stop_after_accepts_valid_step():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--stop-after", "chunk"])
+    assert args.stop_after == "chunk"
+
+
+def test_stop_after_rejects_invalid_step():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["topic", "--stop-after", "bogus"])
+
+
+def test_step_accepts_valid_step():
+    parser = _build_parser()
+    for step in RESEARCH_STEPS:
+        args = parser.parse_args(["topic", "--step", step])
+        assert args.step == step
+
+
+def test_name_none_by_default():
+    parser = _build_parser()
+    args = parser.parse_args(["topic"])
+    assert args.name is None
+
+
+def test_name_override():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--name", "custom-slug"])
+    assert args.name == "custom-slug"
+
+
+def test_yes_flag_long_form():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--yes"])
+    assert args.yes is True
+
+
+def test_yes_flag_short_form():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "-y"])
+    assert args.yes is True
+
+
+def test_yes_flag_default_false():
+    parser = _build_parser()
+    args = parser.parse_args(["topic"])
+    assert args.yes is False
+
+
+def test_no_filter_sets_flag():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--no-filter"])
+    assert args.no_filter is True
+
+
+def test_no_auto_index_sets_flag():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--no-auto-index"])
+    assert args.no_auto_index is True
+
+
+def test_force_flag_sets_flag():
+    parser = _build_parser()
+    args = parser.parse_args(["topic", "--force"])
+    assert args.force is True
+
+
+def test_topic_is_required():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])

--- a/tests/test_research/test_config.py
+++ b/tests/test_research/test_config.py
@@ -1,0 +1,118 @@
+import pytest
+
+from king_context.research.config import (
+    EffortLevel,
+    EffortProfile,
+    ResearchConfig,
+    effort_profile,
+    load_research_config,
+)
+from king_context.scraper.config import ConfigError
+
+
+def _set_base_env(monkeypatch):
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.setenv("EXA_API_KEY", "exa-test-key")
+
+
+def _clear_research_env(monkeypatch):
+    for name in [
+        "JINA_API_KEY",
+        "OPENROUTER_MODEL_RESEARCH",
+        "RESEARCH_BASIC_QUERIES",
+        "RESEARCH_MEDIUM_QUERIES",
+        "RESEARCH_MEDIUM_ITERATIONS",
+        "RESEARCH_MEDIUM_FOLLOWUPS",
+        "RESEARCH_HIGH_QUERIES",
+        "RESEARCH_HIGH_ITERATIONS",
+        "RESEARCH_HIGH_FOLLOWUPS",
+        "RESEARCH_EXTRAHIGH_QUERIES",
+        "RESEARCH_EXTRAHIGH_ITERATIONS",
+        "RESEARCH_EXTRAHIGH_FOLLOWUPS",
+        "EXA_RESULTS_PER_QUERY",
+        "EXA_MAX_CHARS",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_load_defaults(monkeypatch):
+    _clear_research_env(monkeypatch)
+    _set_base_env(monkeypatch)
+
+    config = load_research_config()
+
+    assert isinstance(config, ResearchConfig)
+    assert config.exa_api_key == "exa-test-key"
+    assert config.jina_api_key == ""
+    assert config.research_model == ""
+    assert config.basic_queries == 3
+    assert config.medium_queries == 5
+    assert config.medium_iterations == 1
+    assert config.medium_followups == 3
+    assert config.high_queries == 8
+    assert config.high_iterations == 2
+    assert config.high_followups == 5
+    assert config.extrahigh_queries == 12
+    assert config.extrahigh_iterations == 3
+    assert config.extrahigh_followups == 8
+    assert config.exa_results_per_query == 10
+    assert config.exa_max_chars == 15000
+    assert config.relevance_threshold == 0.5
+    assert config.scraper.firecrawl_api_key == "fc-test-key"
+    assert config.scraper.openrouter_api_key == "or-test-key"
+
+
+def test_env_override_applies(monkeypatch):
+    _clear_research_env(monkeypatch)
+    _set_base_env(monkeypatch)
+    monkeypatch.setenv("RESEARCH_HIGH_QUERIES", "20")
+
+    config = load_research_config()
+
+    assert config.high_queries == 20
+
+
+def test_missing_exa_key_raises(monkeypatch):
+    _clear_research_env(monkeypatch)
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+
+    with pytest.raises(ConfigError):
+        load_research_config()
+
+
+def test_missing_jina_key_ok(monkeypatch):
+    _clear_research_env(monkeypatch)
+    _set_base_env(monkeypatch)
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+
+    config = load_research_config()
+
+    assert config.jina_api_key == ""
+
+
+def test_effort_profile_medium(monkeypatch):
+    _clear_research_env(monkeypatch)
+    _set_base_env(monkeypatch)
+
+    config = load_research_config()
+    profile = effort_profile(EffortLevel.MEDIUM, config)
+
+    assert isinstance(profile, EffortProfile)
+    assert profile.initial_queries == config.medium_queries
+    assert profile.iterations == config.medium_iterations
+    assert profile.followups_per_iteration == config.medium_followups
+
+
+def test_effort_profile_basic(monkeypatch):
+    _clear_research_env(monkeypatch)
+    _set_base_env(monkeypatch)
+
+    config = load_research_config()
+    profile = effort_profile(EffortLevel.BASIC, config)
+
+    assert profile.initial_queries == config.basic_queries
+    assert profile.iterations == 0
+    assert profile.followups_per_iteration == 0

--- a/tests/test_research/test_deepen.py
+++ b/tests/test_research/test_deepen.py
@@ -1,0 +1,251 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from king_context.research.config import EffortLevel, ResearchConfig
+from king_context.research.deepen import run_deepening_loop
+from king_context.research.fetch import SourceDoc
+from king_context.research.queries import QueryGenerationError
+from king_context.scraper.config import ScraperConfig
+
+
+def make_config(**over) -> ResearchConfig:
+    defaults = dict(
+        basic_queries=3,
+        medium_queries=5,
+        medium_iterations=1,
+        medium_followups=3,
+        high_queries=2,
+        high_iterations=2,
+        high_followups=2,
+    )
+    defaults.update(over)
+    return ResearchConfig(
+        scraper=ScraperConfig(openrouter_api_key="fake", concurrency=3),
+        exa_api_key="exa-fake",
+        **defaults,
+    )
+
+
+def mk_doc(
+    url: str = "https://ex.com/a",
+    query: str = "q",
+    iteration: int = 0,
+    title: str = "T",
+) -> SourceDoc:
+    return SourceDoc(
+        url=url,
+        title=title,
+        content="c" * 700,
+        author=None,
+        published_date=None,
+        domain="ex.com",
+        query=query,
+        discovery_iteration=iteration,
+        score=0.5,
+        fetch_path="exa",
+    )
+
+
+async def test_basic_runs_one_batch_three_queries(tmp_path):
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+        return_value=["q1", "q2", "q3"],
+    ) as gen, patch(
+        "king_context.research.deepen.fetch_fn",
+        new_callable=AsyncMock,
+    ) as fetch:
+        fetch.side_effect = lambda q, i, cfg, client: [
+            mk_doc(url=f"https://ex.com/{q}", query=q, iteration=i)
+        ]
+        docs = await run_deepening_loop(
+            "topic", EffortLevel.BASIC, make_config(), tmp_path
+        )
+
+    assert len(docs) == 3
+    assert gen.call_count == 1
+    assert fetch.call_count == 3
+    assert all(d.discovery_iteration == 0 for d in docs)
+
+
+async def test_medium_runs_initial_plus_one_iteration(tmp_path):
+    queries_iter0 = ["a", "b", "c", "d", "e"]
+    queries_iter1 = ["f", "g", "h"]
+
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+    ) as gen, patch(
+        "king_context.research.deepen.fetch_fn",
+        new_callable=AsyncMock,
+    ) as fetch:
+        gen.side_effect = [queries_iter0, queries_iter1]
+        fetch.side_effect = lambda q, i, cfg, client: [
+            mk_doc(url=f"https://ex.com/{q}", query=q, iteration=i)
+        ]
+        docs = await run_deepening_loop(
+            "topic",
+            EffortLevel.MEDIUM,
+            make_config(
+                medium_queries=5, medium_iterations=1, medium_followups=3
+            ),
+            tmp_path,
+        )
+
+    assert len(docs) == 8
+    assert gen.call_count == 2
+    assert fetch.call_count == 8
+    iter0 = [d for d in docs if d.discovery_iteration == 0]
+    iter1 = [d for d in docs if d.discovery_iteration == 1]
+    assert len(iter0) == 5
+    assert len(iter1) == 3
+
+
+async def test_iteration_returns_zero_new_queries_breaks_loop(tmp_path):
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+    ) as gen, patch(
+        "king_context.research.deepen.fetch_fn",
+        new_callable=AsyncMock,
+    ) as fetch:
+        gen.side_effect = [["q1", "q2", "q3"], []]
+        fetch.side_effect = lambda q, i, cfg, client: [
+            mk_doc(url=f"https://ex.com/{q}", query=q, iteration=i)
+        ]
+        docs = await run_deepening_loop(
+            "topic", EffortLevel.HIGH, make_config(), tmp_path
+        )
+
+    assert gen.call_count == 2
+    assert len(docs) == 3
+    assert all(d.discovery_iteration == 0 for d in docs)
+
+
+async def test_generate_queries_fails_returns_prior_results(tmp_path):
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+    ) as gen, patch(
+        "king_context.research.deepen.fetch_fn",
+        new_callable=AsyncMock,
+    ) as fetch:
+        gen.side_effect = [
+            ["q1", "q2"],
+            QueryGenerationError("LLM blew up"),
+        ]
+        fetch.side_effect = lambda q, i, cfg, client: [
+            mk_doc(url=f"https://ex.com/{q}", query=q, iteration=i)
+        ]
+        docs = await run_deepening_loop(
+            "topic", EffortLevel.MEDIUM, make_config(), tmp_path
+        )
+
+    assert len(docs) == 2
+    assert all(d.discovery_iteration == 0 for d in docs)
+    assert gen.call_count == 2
+
+
+async def test_url_dedup_across_iterations(tmp_path):
+    async def fake_fetch(q, i, cfg, client):
+        if i == 0:
+            return [
+                mk_doc(url="https://ex.com/shared", query=q, iteration=0),
+                mk_doc(url="https://ex.com/only-iter0", query=q, iteration=0),
+            ]
+        return [
+            mk_doc(url="https://ex.com/shared", query=q, iteration=1),
+            mk_doc(url="https://ex.com/only-iter1", query=q, iteration=1),
+        ]
+
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+    ) as gen, patch(
+        "king_context.research.deepen.fetch_fn",
+        side_effect=fake_fetch,
+    ):
+        gen.side_effect = [["q0"], ["q1"]]
+        docs = await run_deepening_loop(
+            "topic",
+            EffortLevel.MEDIUM,
+            make_config(
+                medium_queries=1, medium_iterations=1, medium_followups=1
+            ),
+            tmp_path,
+        )
+
+    urls = [d.url for d in docs]
+    assert len(urls) == len(set(urls))
+    assert "https://ex.com/shared" in urls
+    assert "https://ex.com/only-iter0" in urls
+    assert "https://ex.com/only-iter1" in urls
+    shared = next(d for d in docs if d.url == "https://ex.com/shared")
+    assert shared.discovery_iteration == 0
+
+
+async def test_iteration_json_checkpoint_written(tmp_path):
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+        return_value=["q1", "q2", "q3"],
+    ), patch(
+        "king_context.research.deepen.fetch_fn",
+        new_callable=AsyncMock,
+    ) as fetch:
+        fetch.side_effect = lambda q, i, cfg, client: [
+            mk_doc(url=f"https://ex.com/{q}", query=q, iteration=i)
+        ]
+        await run_deepening_loop(
+            "topic", EffortLevel.BASIC, make_config(), tmp_path
+        )
+
+    checkpoint = tmp_path / "iteration_0.json"
+    assert checkpoint.exists()
+    import json as _json
+
+    data = _json.loads(checkpoint.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 3
+    assert data[0]["fetch_path"] == "exa"
+
+
+async def test_initial_generation_failure_returns_empty(tmp_path):
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+        side_effect=QueryGenerationError("boom"),
+    ), patch(
+        "king_context.research.deepen.fetch_fn",
+        new_callable=AsyncMock,
+    ) as fetch:
+        docs = await run_deepening_loop(
+            "topic", EffortLevel.BASIC, make_config(), tmp_path
+        )
+
+    assert docs == []
+    fetch.assert_not_called()
+
+
+async def test_fetch_exception_does_not_abort_iteration(tmp_path):
+    async def flaky_fetch(q, i, cfg, client):
+        if q == "bad":
+            raise RuntimeError("network down")
+        return [mk_doc(url=f"https://ex.com/{q}", query=q, iteration=i)]
+
+    with patch(
+        "king_context.research.deepen.generate_queries_fn",
+        new_callable=AsyncMock,
+        return_value=["good1", "bad", "good2"],
+    ), patch(
+        "king_context.research.deepen.fetch_fn",
+        side_effect=flaky_fetch,
+    ):
+        docs = await run_deepening_loop(
+            "topic", EffortLevel.BASIC, make_config(), tmp_path
+        )
+
+    assert len(docs) == 2
+    urls = {d.url for d in docs}
+    assert urls == {"https://ex.com/good1", "https://ex.com/good2"}

--- a/tests/test_research/test_exa.py
+++ b/tests/test_research/test_exa.py
@@ -1,0 +1,150 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from king_context.research.config import ResearchConfig
+from king_context.research.exa import (
+    ExaBudgetError,
+    ExaConfigError,
+    ExaResult,
+    ExaTransientError,
+    search,
+)
+from king_context.scraper.config import ScraperConfig
+
+
+class FakeExaError(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}")
+
+
+def make_config() -> ResearchConfig:
+    return ResearchConfig(
+        scraper=ScraperConfig(openrouter_api_key="fake"),
+        exa_api_key="exa-fake",
+    )
+
+
+def make_fake_result(**overrides):
+    mock = MagicMock()
+    mock.url = overrides.get("url", "https://example.com/a")
+    mock.title = overrides.get("title", "Sample")
+    mock.text = overrides.get("text", "Sample content")
+    mock.highlights = overrides.get("highlights", ["highlight"])
+    mock.author = overrides.get("author", "Alice")
+    mock.published_date = overrides.get("published_date", "2024-01-01")
+    mock.score = overrides.get("score", 0.9)
+    return mock
+
+
+def make_fake_response(results):
+    resp = MagicMock()
+    resp.results = results
+    return resp
+
+
+async def test_search_success():
+    config = make_config()
+    results = [
+        make_fake_result(url="https://a.example.com", title="A"),
+        make_fake_result(
+            url="https://b.example.com",
+            title="B",
+            text="Other text",
+            highlights=[],
+            author=None,
+            published_date=None,
+            score=0.5,
+        ),
+    ]
+    fake_response = make_fake_response(results)
+
+    with patch("king_context.research.exa.Exa") as mock_exa_cls:
+        mock_exa_cls.return_value.search_and_contents.return_value = fake_response
+        out = await search("hello world", config)
+
+    assert len(out) == 2
+    assert all(isinstance(r, ExaResult) for r in out)
+    assert out[0].url == "https://a.example.com"
+    assert out[0].title == "A"
+    assert out[0].text == "Sample content"
+    assert out[0].highlights == ["highlight"]
+    assert out[0].author == "Alice"
+    assert out[0].published_date == "2024-01-01"
+    assert out[0].score == 0.9
+    assert out[1].highlights == []
+    assert out[1].author is None
+    assert out[1].published_date is None
+
+
+async def test_search_retries_on_transient_then_succeeds():
+    config = make_config()
+    results = [make_fake_result()]
+    fake_response = make_fake_response(results)
+
+    with patch("king_context.research.exa.Exa") as mock_exa_cls, patch(
+        "king_context.research.exa.asyncio.sleep", AsyncMock()
+    ) as mock_sleep:
+        mock_exa_cls.return_value.search_and_contents.side_effect = [
+            FakeExaError(429),
+            fake_response,
+        ]
+        out = await search("retry test", config)
+
+    assert len(out) == 1
+    assert out[0].url == "https://example.com/a"
+    assert mock_sleep.await_count == 1
+
+
+async def test_search_budget_error_raises():
+    config = make_config()
+    with patch("king_context.research.exa.Exa") as mock_exa_cls, patch(
+        "king_context.research.exa.asyncio.sleep", AsyncMock()
+    ) as mock_sleep:
+        mock_exa_cls.return_value.search_and_contents.side_effect = FakeExaError(402)
+        with pytest.raises(ExaBudgetError):
+            await search("budget test", config)
+        assert mock_sleep.await_count == 0
+        assert mock_exa_cls.return_value.search_and_contents.call_count == 1
+
+
+async def test_search_config_error_raises():
+    config = make_config()
+    with patch("king_context.research.exa.Exa") as mock_exa_cls, patch(
+        "king_context.research.exa.asyncio.sleep", AsyncMock()
+    ):
+        mock_exa_cls.return_value.search_and_contents.side_effect = FakeExaError(401)
+        with pytest.raises(ExaConfigError):
+            await search("config test", config)
+        assert mock_exa_cls.return_value.search_and_contents.call_count == 1
+
+
+async def test_search_unprocessable_returns_empty():
+    config = make_config()
+    with patch("king_context.research.exa.Exa") as mock_exa_cls, patch(
+        "king_context.research.exa.asyncio.sleep", AsyncMock()
+    ):
+        mock_exa_cls.return_value.search_and_contents.side_effect = FakeExaError(422)
+        out = await search("unprocessable test", config)
+
+    assert out == []
+
+
+async def test_search_retries_exhausted_raises_transient():
+    config = make_config()
+    with patch("king_context.research.exa.Exa") as mock_exa_cls, patch(
+        "king_context.research.exa.asyncio.sleep", AsyncMock()
+    ) as mock_sleep:
+        mock_exa_cls.return_value.search_and_contents.side_effect = FakeExaError(503)
+        with pytest.raises(ExaTransientError):
+            await search("exhausted test", config)
+
+    assert mock_sleep.await_count == 2
+    assert mock_exa_cls.return_value.search_and_contents.call_count == 3
+
+
+def test_exa_sdk_importable():
+    import exa_py  # noqa: F401
+
+    assert exa_py is not None

--- a/tests/test_research/test_export.py
+++ b/tests/test_research/test_export.py
@@ -1,0 +1,225 @@
+import json
+import logging
+
+import pytest
+
+from king_context.research import export as research_export
+from king_context.research.fetch import SourceDoc
+from king_context.scraper.enrich import EnrichedChunk
+
+
+def mk_enriched(url="https://ex.com/a", title="T", path="sec/a"):
+    return EnrichedChunk(
+        title=title,
+        path=path,
+        url=url,
+        content="hello",
+        keywords=["k"] * 5,
+        use_cases=["u1", "u2"],
+        tags=["t"],
+        priority=7,
+    )
+
+
+def mk_source(
+    url="https://ex.com/a",
+    author=None,
+    published_date=None,
+    domain="ex.com",
+    discovery_iteration=0,
+):
+    return SourceDoc(
+        url=url,
+        title="T",
+        content="c",
+        author=author,
+        published_date=published_date,
+        domain=domain,
+        query="q",
+        discovery_iteration=discovery_iteration,
+        score=None,
+        fetch_path="exa",
+    )
+
+
+@pytest.fixture
+def patched_data_dir(tmp_path, monkeypatch):
+    target = tmp_path / "research"
+    monkeypatch.setattr(research_export, "RESEARCH_DATA_DIR", target)
+    return target
+
+
+def _load_output(path):
+    return json.loads(path.read_text())
+
+
+def test_single_source_single_section(patched_data_dir):
+    enriched = [mk_enriched()]
+    sources = {"https://ex.com/a": mk_source(author="Alice", domain="ex.com")}
+
+    out = research_export.export_research_to_json(
+        enriched, sources, topic_slug="my-topic", topic="My Topic"
+    )
+
+    assert out.exists()
+    doc = _load_output(out)
+    assert doc["name"] == "my-topic"
+    assert doc["display_name"] == "My Topic"
+    assert len(doc["sections"]) == 1
+
+    section = doc["sections"][0]
+    assert section["source_type"] == "research"
+    assert section["domain"] == "ex.com"
+    assert section["discovery_iteration"] == 0
+    assert section["authors"] == ["Alice"]
+
+
+def test_multiple_chunks_same_url_share_metadata(patched_data_dir):
+    url = "https://ex.com/shared"
+    enriched = [
+        mk_enriched(url=url, title=f"T{i}", path=f"sec/{i}") for i in range(3)
+    ]
+    sources = {
+        url: mk_source(
+            url=url,
+            author="Alice, Bob",
+            published_date="2024-01-01",
+            domain="ex.com",
+            discovery_iteration=2,
+        )
+    }
+
+    out = research_export.export_research_to_json(
+        enriched, sources, topic_slug="topic", topic="Topic"
+    )
+
+    doc = _load_output(out)
+    assert len(doc["sections"]) == 3
+    for section in doc["sections"]:
+        assert section["source_type"] == "research"
+        assert section["authors"] == ["Alice", "Bob"]
+        assert section["published_date"] == "2024-01-01"
+        assert section["domain"] == "ex.com"
+        assert section["discovery_iteration"] == 2
+
+
+def test_missing_author_and_date_omitted(patched_data_dir):
+    enriched = [mk_enriched()]
+    sources = {
+        "https://ex.com/a": mk_source(author=None, published_date=None)
+    }
+
+    out = research_export.export_research_to_json(
+        enriched, sources, topic_slug="topic", topic="Topic"
+    )
+
+    section = _load_output(out)["sections"][0]
+    assert "authors" not in section
+    assert "published_date" not in section
+    assert section["source_type"] == "research"
+    assert section["domain"] == "ex.com"
+    assert section["discovery_iteration"] == 0
+
+
+def test_output_file_exists_on_disk(patched_data_dir):
+    enriched = [mk_enriched()]
+    sources = {"https://ex.com/a": mk_source()}
+
+    out = research_export.export_research_to_json(
+        enriched, sources, topic_slug="topic", topic="Topic"
+    )
+
+    expected = patched_data_dir / "topic.json"
+    assert out == expected
+    assert expected.exists()
+
+
+def test_slug_with_spaces_is_sanitized(patched_data_dir):
+    enriched = [mk_enriched()]
+    sources = {"https://ex.com/a": mk_source()}
+
+    out = research_export.export_research_to_json(
+        enriched,
+        sources,
+        topic_slug="Prompt Engineering!",
+        topic="Prompt Engineering!",
+    )
+
+    assert out.name == "prompt-engineering.json"
+    doc = _load_output(out)
+    assert doc["name"] == "prompt-engineering"
+
+
+def test_unknown_url_still_gets_source_type(patched_data_dir):
+    enriched = [mk_enriched(url="https://unknown.com/x")]
+    sources: dict = {}
+
+    out = research_export.export_research_to_json(
+        enriched, sources, topic_slug="topic", topic="Topic"
+    )
+
+    section = _load_output(out)["sections"][0]
+    assert section["source_type"] == "research"
+    assert "domain" not in section
+    assert "discovery_iteration" not in section
+    assert "authors" not in section
+    assert "published_date" not in section
+
+
+def test_overwrite_warns(patched_data_dir, caplog, capsys):
+    enriched = [mk_enriched()]
+    sources = {"https://ex.com/a": mk_source()}
+
+    research_export.export_research_to_json(
+        enriched, sources, topic_slug="topic", topic="Topic"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="king_context.research.export"):
+        research_export.export_research_to_json(
+            enriched, sources, topic_slug="topic", topic="Topic"
+        )
+
+    assert any("Overwriting" in rec.message for rec in caplog.records)
+    captured = capsys.readouterr()
+    assert "Overwriting" in captured.out
+
+
+def test_auto_index_with_valid_json_populates_store(tmp_path):
+    doc_data = {
+        "name": "my-topic",
+        "display_name": "My Topic",
+        "version": "v1",
+        "base_url": "",
+        "sections": [
+            {
+                "title": "A",
+                "path": "a",
+                "url": "https://ex.com/a",
+                "keywords": ["k"],
+                "use_cases": ["u"],
+                "tags": ["t"],
+                "priority": 5,
+                "content": "hello",
+            }
+        ],
+    }
+    json_path = tmp_path / "research.json"
+    json_path.write_text(json.dumps(doc_data))
+    store_dir = tmp_path / "docs"
+    store_dir.mkdir()
+
+    from king_context.research.export import auto_index
+
+    auto_index(json_path, store_dir=store_dir)
+
+    sections_dir = store_dir / "my-topic" / "sections"
+    assert sections_dir.exists()
+    assert any(sections_dir.iterdir())
+
+
+def test_auto_index_missing_file_logs_and_does_not_raise(tmp_path, caplog):
+    from king_context.research.export import auto_index
+
+    caplog.set_level("WARNING")
+    auto_index(tmp_path / "nope.json", store_dir=tmp_path)
+    assert any("auto_index failed" in r.message for r in caplog.records)

--- a/tests/test_research/test_fetch.py
+++ b/tests/test_research/test_fetch.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -163,3 +164,34 @@ async def test_jina_transient_after_retries_drops_url():
             docs = await fetch_for_query("q", 0, make_config(), client)
 
     assert docs == []
+
+
+async def test_unexpected_jina_failure_isolated_per_url():
+    direct = make_exa_result("https://ex.com/direct", text_len=700)
+    short_bad = make_exa_result("https://ex.com/bad", text_len=50)
+    short_good = make_exa_result("https://ex.com/good", text_len=100)
+    results = [direct, short_bad, short_good]
+
+    async def fetch_side_effect(url, *args, **kwargs):
+        if url == "https://ex.com/bad":
+            raise json.JSONDecodeError("bad json", "{}", 0)
+        return make_jina_result(url, title="Recovered")
+
+    async with httpx.AsyncClient() as client:
+        with patch(
+            "king_context.research.fetch.exa_search",
+            new_callable=AsyncMock,
+            return_value=results,
+        ), patch(
+            "king_context.research.fetch.jina_fetch",
+            side_effect=fetch_side_effect,
+        ):
+            docs = await fetch_for_query("q", 0, make_config(), client)
+
+    urls = {doc.url for doc in docs}
+    assert urls == {"https://ex.com/direct", "https://ex.com/good"}
+    assert any(doc.fetch_path == "exa" for doc in docs)
+    assert any(
+        doc.fetch_path == "jina" and doc.url == "https://ex.com/good"
+        for doc in docs
+    )

--- a/tests/test_research/test_fetch.py
+++ b/tests/test_research/test_fetch.py
@@ -1,0 +1,165 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from king_context.research.config import ResearchConfig
+from king_context.research.exa import ExaResult
+from king_context.research.fetch import (
+    MIN_CONTENT_CHARS,
+    SourceDoc,
+    fetch_for_query,
+)
+from king_context.research.jina import (
+    FetchResult,
+    JinaPermanentError,
+    JinaTransientError,
+)
+from king_context.scraper.config import ScraperConfig
+
+
+def make_config() -> ResearchConfig:
+    return ResearchConfig(
+        scraper=ScraperConfig(openrouter_api_key="fake", concurrency=5),
+        exa_api_key="exa-fake",
+        jina_api_key="jina-fake",
+    )
+
+
+def make_exa_result(url: str, text_len: int = 700) -> ExaResult:
+    return ExaResult(
+        url=url,
+        title="T",
+        text="x" * text_len,
+        highlights=[],
+        author="Alice",
+        published_date="2024-01-01",
+        score=0.9,
+    )
+
+
+def make_jina_result(url: str, title: str = "Jina Title") -> FetchResult:
+    content = "word " * 200
+    return FetchResult(
+        url=url, title=title, content=content, word_count=200
+    )
+
+
+async def test_all_exa_sufficient_no_jina_called():
+    results = [make_exa_result(f"https://ex.com/{i}", 700) for i in range(3)]
+    async with httpx.AsyncClient() as client:
+        with patch(
+            "king_context.research.fetch.exa_search",
+            new_callable=AsyncMock,
+            return_value=results,
+        ), patch(
+            "king_context.research.fetch.jina_fetch", new_callable=AsyncMock
+        ) as mock_jina:
+            docs = await fetch_for_query("q", 0, make_config(), client)
+
+    assert len(docs) == 3
+    assert all(isinstance(d, SourceDoc) for d in docs)
+    assert all(d.fetch_path == "exa" for d in docs)
+    assert all(d.query == "q" for d in docs)
+    assert all(d.discovery_iteration == 0 for d in docs)
+    assert docs[0].domain == "ex.com"
+    mock_jina.assert_not_called()
+
+
+async def test_some_exa_short_jina_called_for_those():
+    long_1 = make_exa_result("https://ex.com/long1", text_len=MIN_CONTENT_CHARS)
+    long_2 = make_exa_result("https://ex.com/long2", text_len=MIN_CONTENT_CHARS + 50)
+    short = make_exa_result("https://ex.com/short", text_len=100)
+    results = [long_1, short, long_2]
+
+    jina_result = make_jina_result("https://ex.com/short", title="Short Page")
+
+    async with httpx.AsyncClient() as client:
+        with patch(
+            "king_context.research.fetch.exa_search",
+            new_callable=AsyncMock,
+            return_value=results,
+        ), patch(
+            "king_context.research.fetch.jina_fetch",
+            new_callable=AsyncMock,
+            return_value=jina_result,
+        ) as mock_jina:
+            docs = await fetch_for_query("query", 1, make_config(), client)
+
+    assert len(docs) == 3
+    mock_jina.assert_called_once()
+    call_args = mock_jina.call_args
+    assert call_args.args[0] == "https://ex.com/short"
+
+    exa_docs = [d for d in docs if d.fetch_path == "exa"]
+    jina_docs = [d for d in docs if d.fetch_path == "jina"]
+    assert len(exa_docs) == 2
+    assert len(jina_docs) == 1
+    assert jina_docs[0].url == "https://ex.com/short"
+    assert jina_docs[0].title == "Short Page"
+    assert jina_docs[0].author == "Alice"
+    assert jina_docs[0].published_date == "2024-01-01"
+    assert jina_docs[0].score == 0.9
+    assert jina_docs[0].discovery_iteration == 1
+
+
+async def test_jina_permanent_failure_drops_url_others_continue():
+    long_1 = make_exa_result("https://ex.com/ok1", text_len=700)
+    long_2 = make_exa_result("https://ex.com/ok2", text_len=800)
+    short = make_exa_result("https://ex.com/bad", text_len=50)
+    results = [long_1, short, long_2]
+
+    async def raising_fetch(*args, **kwargs):
+        raise JinaPermanentError("HTTP 404")
+
+    async with httpx.AsyncClient() as client:
+        with patch(
+            "king_context.research.fetch.exa_search",
+            new_callable=AsyncMock,
+            return_value=results,
+        ), patch(
+            "king_context.research.fetch.jina_fetch",
+            side_effect=raising_fetch,
+        ):
+            docs = await fetch_for_query("q", 0, make_config(), client)
+
+    assert len(docs) == 2
+    assert all(d.fetch_path == "exa" for d in docs)
+    urls = {d.url for d in docs}
+    assert urls == {"https://ex.com/ok1", "https://ex.com/ok2"}
+
+
+async def test_empty_exa_returns_empty_list():
+    async with httpx.AsyncClient() as client:
+        with patch(
+            "king_context.research.fetch.exa_search",
+            new_callable=AsyncMock,
+            return_value=[],
+        ), patch(
+            "king_context.research.fetch.jina_fetch", new_callable=AsyncMock
+        ) as mock_jina:
+            docs = await fetch_for_query("q", 0, make_config(), client)
+
+    assert docs == []
+    mock_jina.assert_not_called()
+
+
+async def test_jina_transient_after_retries_drops_url():
+    short = make_exa_result("https://ex.com/short", text_len=50)
+    results = [short]
+
+    async def raising_fetch(*args, **kwargs):
+        raise JinaTransientError("HTTP 503")
+
+    async with httpx.AsyncClient() as client:
+        with patch(
+            "king_context.research.fetch.exa_search",
+            new_callable=AsyncMock,
+            return_value=results,
+        ), patch(
+            "king_context.research.fetch.jina_fetch",
+            side_effect=raising_fetch,
+        ):
+            docs = await fetch_for_query("q", 0, make_config(), client)
+
+    assert docs == []

--- a/tests/test_research/test_integration.py
+++ b/tests/test_research/test_integration.py
@@ -1,0 +1,313 @@
+"""End-to-end integration test for the research pipeline.
+
+All externals (Exa SDK, Jina httpx, OpenRouter httpx) are mocked. The pipeline,
+chunk, enrich, export, and indexing code paths run for real so we exercise the
+wiring between components.
+"""
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import respx
+
+from king_context.research.config import EffortLevel, ResearchConfig
+from king_context.research.pipeline import run_pipeline
+from king_context.scraper.config import ScraperConfig
+from context_cli.indexer import index_doc
+
+
+skip_no_respx = pytest.mark.skipif(False, reason="")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# Content crafted to produce at least 3 chunks per page.
+# chunk_page splits on h2/h3 boundaries — we emit 4 sections per page,
+# each with enough text (~400+ chars) to sit comfortably above the 100-token
+# minimum and under the 1000-token maximum (merged section stays ~150 tokens).
+_SECTION_TEXT_SUFFIX = " ".join(["word"] * 80)
+
+
+def _build_page_markdown(query: str) -> str:
+    return (
+        f"# {query}\n\n"
+        f"Intro paragraph about {query}. {_SECTION_TEXT_SUFFIX}.\n\n"
+        f"## Overview of {query}\n\n"
+        f"This section introduces {query}. {_SECTION_TEXT_SUFFIX}.\n\n"
+        f"## Implementation details\n\n"
+        f"Implementation details relevant to {query}. {_SECTION_TEXT_SUFFIX}.\n\n"
+        f"## Best practices\n\n"
+        f"Best practices around {query}. {_SECTION_TEXT_SUFFIX}.\n\n"
+        f"## Common pitfalls\n\n"
+        f"Common pitfalls encountered with {query}. {_SECTION_TEXT_SUFFIX}.\n"
+    )
+
+
+def _make_exa_result(url: str, query: str, index: int) -> MagicMock:
+    r = MagicMock()
+    r.url = url
+    r.title = f"{query} article {index}"
+    r.text = _build_page_markdown(query)
+    r.highlights = [f"highlight about {query}"]
+    r.author = "Alice Author" if index == 0 else None
+    r.published_date = "2024-01-01" if index == 0 else None
+    r.score = 0.9 - index * 0.1
+    return r
+
+
+def _make_exa_response(query: str, num_results: int) -> MagicMock:
+    results = []
+    # A predictable URL per (query, index) pair — slugified so dedup works.
+    safe_q = query.replace(" ", "-")
+    for i in range(num_results):
+        url = f"https://example.com/{safe_q}/{i}"
+        results.append(_make_exa_result(url, query, i))
+    resp = MagicMock()
+    resp.results = results
+    return resp
+
+
+def _make_enrichment_response() -> httpx.Response:
+    payload = {
+        "keywords": ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"],
+        "use_cases": ["Use when testing", "Implement when integrating"],
+        "tags": ["research"],
+        "priority": 7,
+    }
+    return httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"content": json.dumps(payload)}}]
+        },
+    )
+
+
+def _make_queries_response(queries: list[str]) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "choices": [
+                {"message": {"content": json.dumps({"queries": queries})}}
+            ]
+        },
+    )
+
+
+def _is_enrichment_request(body: dict) -> bool:
+    """Enrichment uses a single user message; queries uses system+user.
+    Detect by looking for the enrichment prompt's distinctive preamble.
+    """
+    messages = body.get("messages", [])
+    # Enrichment payload is one user message with the ENRICHMENT_PROMPT text.
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, str) and (
+            "documentation metadata specialist" in content
+            or "Documentation section:" in content
+        ):
+            return True
+    return False
+
+
+def _make_config(**overrides) -> ResearchConfig:
+    scraper = ScraperConfig(
+        openrouter_api_key="or-test",
+        firecrawl_api_key="fc-test",
+        concurrency=3,
+        enrichment_model="test-model",
+        enrichment_batch_size=5,
+    )
+    defaults = dict(
+        scraper=scraper,
+        exa_api_key="exa-test",
+        exa_results_per_query=3,
+        basic_queries=3,
+        medium_queries=5,
+        medium_iterations=1,
+        medium_followups=3,
+    )
+    defaults.update(overrides)
+    return ResearchConfig(**defaults)
+
+
+def _make_args(
+    effort: EffortLevel = EffortLevel.BASIC,
+    topic: str = "prompt engineering",
+    name: str | None = None,
+) -> Namespace:
+    return Namespace(
+        topic=topic,
+        effort=effort,
+        name=name,
+        step=None,
+        stop_after=None,
+        no_filter=False,
+        yes=True,
+        no_auto_index=True,
+        force=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@skip_no_respx
+@respx.mock
+async def test_basic_effort_end_to_end(tmp_path, monkeypatch):
+    """Happy path: BASIC effort with all externals mocked.
+
+    Asserts the exported JSON is well-formed, has the research-specific
+    metadata fields, and that the downstream indexer + searcher work on it.
+    """
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path / "_temp"
+    )
+    monkeypatch.setattr(
+        "king_context.research.export.RESEARCH_DATA_DIR",
+        tmp_path / "data" / "research",
+    )
+
+    # ---- Mock OpenRouter ----
+    def openrouter_handler(request):
+        body = json.loads(request.content)
+        if _is_enrichment_request(body):
+            return _make_enrichment_response()
+        return _make_queries_response(["query a", "query b", "query c"])
+
+    respx.post("https://openrouter.ai/api/v1/chat/completions").mock(
+        side_effect=openrouter_handler
+    )
+
+    # ---- Mock Exa ----
+    def fake_search_and_contents(**kwargs):
+        return _make_exa_response(kwargs["query"], num_results=3)
+
+    with patch("king_context.research.exa.Exa") as mock_exa_cls:
+        mock_exa_cls.return_value.search_and_contents.side_effect = (
+            fake_search_and_contents
+        )
+
+        output_path = await run_pipeline(
+            _make_args(
+                effort=EffortLevel.BASIC,
+                topic="prompt engineering",
+                name="prompt-engineering",
+            ),
+            _make_config(),
+        )
+
+    # ---- Assertions on the exported JSON ----
+    assert output_path.exists(), f"Expected output JSON at {output_path}"
+    assert output_path.parent == tmp_path / "data" / "research"
+    assert output_path.name == "prompt-engineering.json"
+
+    data = json.loads(output_path.read_text())
+    sections = data["sections"]
+    assert len(sections) >= 3, f"Expected >= 3 sections, got {len(sections)}"
+
+    for sec in sections:
+        assert sec["source_type"] == "research"
+        assert "domain" in sec
+        assert "discovery_iteration" in sec
+
+    # At least one section from URL index 0 should have authors ("Alice Author").
+    assert any(
+        s.get("authors") == ["Alice Author"] for s in sections
+    ), "expected at least one section with authors populated"
+
+    # ---- Index downstream ----
+    store_dir = tmp_path / "docs"
+    store_dir.mkdir()
+    result = index_doc(output_path, store_dir)
+
+    assert result.doc_name == "prompt-engineering"
+    sections_dir = store_dir / result.doc_name / "sections"
+    assert sections_dir.exists()
+    assert any(sections_dir.iterdir()), "sections directory is empty"
+
+    # ---- Search via context_cli.searcher ----
+    from context_cli.searcher import search as kctx_search
+
+    # Use a keyword we know the enricher assigned ("alpha").
+    hits = kctx_search("alpha", store_dir)
+    assert len(hits) >= 1, "expected at least one search hit for 'alpha'"
+    assert any(h.doc_name == "prompt-engineering" for h in hits)
+
+
+@skip_no_respx
+@respx.mock
+async def test_medium_effort_iteration_sources_present(tmp_path, monkeypatch):
+    """MEDIUM effort: verify the deepening loop ran by checking for sections
+    from both iteration 0 and iteration 1.
+    """
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path / "_temp"
+    )
+    monkeypatch.setattr(
+        "king_context.research.export.RESEARCH_DATA_DIR",
+        tmp_path / "data" / "research",
+    )
+
+    call_count = [0]
+
+    def openrouter_handler(request):
+        body = json.loads(request.content)
+        if _is_enrichment_request(body):
+            return _make_enrichment_response()
+
+        call_count[0] += 1
+        if call_count[0] == 1:
+            qs = ["init a", "init b", "init c", "init d", "init e"]
+        else:
+            qs = ["followup a", "followup b", "followup c"]
+        return _make_queries_response(qs)
+
+    respx.post("https://openrouter.ai/api/v1/chat/completions").mock(
+        side_effect=openrouter_handler
+    )
+
+    def fake_search_and_contents(**kwargs):
+        # Two results per query for a tighter medium run.
+        return _make_exa_response(kwargs["query"], num_results=2)
+
+    with patch("king_context.research.exa.Exa") as mock_exa_cls:
+        mock_exa_cls.return_value.search_and_contents.side_effect = (
+            fake_search_and_contents
+        )
+
+        output_path = await run_pipeline(
+            _make_args(
+                effort=EffortLevel.MEDIUM,
+                topic="cache hierarchies",
+                name="cache-hierarchies",
+            ),
+            _make_config(
+                exa_results_per_query=2,
+                medium_queries=5,
+                medium_iterations=1,
+                medium_followups=3,
+            ),
+        )
+
+    assert output_path.exists()
+    data = json.loads(output_path.read_text())
+    sections = data["sections"]
+
+    iterations = {s.get("discovery_iteration") for s in sections}
+    assert 0 in iterations, (
+        f"expected a section from iteration 0; got iterations={iterations}"
+    )
+    assert 1 in iterations, (
+        f"expected a section from iteration 1 (deepening loop ran); "
+        f"got iterations={iterations}"
+    )

--- a/tests/test_research/test_jina.py
+++ b/tests/test_research/test_jina.py
@@ -1,0 +1,157 @@
+import json
+
+import httpx
+import pytest
+
+from king_context.research.jina import (
+    FetchResult,
+    JinaPermanentError,
+    JinaTransientError,
+    fetch,
+)
+
+
+@pytest.fixture(autouse=True)
+def fast_retries(monkeypatch):
+    monkeypatch.setattr("king_context.research.jina._RETRY_DELAYS", [0.0, 0.0])
+
+
+def _good_content_response(word_count: int = 100, title: str = "T") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"data": {"title": title, "content": " ".join(["word"] * word_count)}},
+    )
+
+
+async def test_fetch_200_with_good_content():
+    responses = [_good_content_response(word_count=100, title="Hello")]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await fetch("https://example.com/a", "", client)
+
+    assert isinstance(result, FetchResult)
+    assert result.url == "https://example.com/a"
+    assert result.title == "Hello"
+    assert result.word_count == 100
+
+
+async def test_fetch_200_degraded_escalates_engine():
+    captured_bodies: list[dict] = []
+    responses = [
+        httpx.Response(
+            200,
+            json={"data": {"title": "T", "content": " ".join(["word"] * 10)}},
+        ),
+        _good_content_response(word_count=100),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_bodies.append(json.loads(request.content.decode()))
+        return responses.pop(0)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await fetch("https://example.com/degraded", "", client)
+
+    assert result.word_count == 100
+    assert len(captured_bodies) == 2
+    assert captured_bodies[0]["engine"] == "direct"
+    assert captured_bodies[1]["engine"] == "browser"
+
+
+async def test_fetch_429_is_transient_retried():
+    responses = [
+        httpx.Response(429, json={"error": "rate limited"}),
+        _good_content_response(word_count=80),
+    ]
+    call_count = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        return responses.pop(0)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await fetch("https://example.com/429", "key", client)
+
+    assert result.word_count == 80
+    assert call_count[0] == 2
+
+
+async def test_fetch_404_is_permanent_no_retry():
+    call_count = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        return httpx.Response(404, json={"error": "not found"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(JinaPermanentError):
+            await fetch("https://example.com/missing", "", client)
+
+    assert call_count[0] == 1
+
+
+async def test_fetch_three_transient_raises_last():
+    call_count = [0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        return httpx.Response(503, json={"error": "server unavailable"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(JinaTransientError):
+            await fetch("https://example.com/down", "", client)
+
+    assert call_count[0] == 3
+
+
+async def test_fetch_data_as_string_parses():
+    markdown = " ".join(["token"] * 60)
+    responses = [httpx.Response(200, json={"data": markdown})]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await fetch("https://example.com/string", "", client)
+
+    assert result.title == ""
+    assert result.word_count == 60
+    assert result.content == markdown
+
+
+async def test_no_auth_header_when_api_key_empty():
+    captured_headers: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.append(request.headers)
+        return _good_content_response(word_count=80)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await fetch("https://example.com/noauth", "", client)
+
+    assert len(captured_headers) == 1
+    assert "authorization" not in captured_headers[0]
+
+
+async def test_auth_header_when_api_key_set():
+    captured_headers: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.append(request.headers)
+        return _good_content_response(word_count=80)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await fetch("https://example.com/auth", "secret-key", client)
+
+    assert captured_headers[0]["authorization"] == "Bearer secret-key"

--- a/tests/test_research/test_pipeline.py
+++ b/tests/test_research/test_pipeline.py
@@ -326,3 +326,59 @@ async def test_no_auto_index_flag_skips_indexing(tmp_path, monkeypatch):
         )
 
     auto_index_mock.assert_not_called()
+
+
+async def test_zero_chunks_raises_and_skips_enrichment_export(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[mk_source("https://ex.com/a")],
+    ) as deepen_mock, patch(
+        "king_context.research.pipeline.chunk_page",
+        return_value=[],
+    ) as chunk_mock, patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+    ) as enrich_mock, patch(
+        "king_context.research.pipeline.export_research_to_json"
+    ) as export_mock:
+        with pytest.raises(RuntimeError, match="Chunking produced no sections"):
+            await run_pipeline(make_args(), make_config())
+
+    deepen_mock.assert_awaited_once()
+    chunk_mock.assert_called_once()
+    enrich_mock.assert_not_called()
+    export_mock.assert_not_called()
+
+
+async def test_empty_enrichment_raises_and_skips_export(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[mk_source("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.chunk_page",
+        return_value=[mk_chunk("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.estimate_cost",
+        return_value=_cost_stub(),
+    ), patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as enrich_mock, patch(
+        "king_context.research.pipeline.export_research_to_json"
+    ) as export_mock:
+        with pytest.raises(RuntimeError, match="Enrichment produced no sections"):
+            await run_pipeline(make_args(), make_config())
+
+    enrich_mock.assert_awaited_once()
+    export_mock.assert_not_called()

--- a/tests/test_research/test_pipeline.py
+++ b/tests/test_research/test_pipeline.py
@@ -1,0 +1,328 @@
+"""Tests for the research pipeline orchestration."""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from king_context.research.config import EffortLevel, ResearchConfig
+from king_context.research.fetch import SourceDoc
+from king_context.research.pipeline import run_pipeline
+from king_context.scraper.chunk import Chunk
+from king_context.scraper.config import ConfigError, ScraperConfig
+from king_context.scraper.enrich import EnrichedChunk
+
+
+def make_config(**over) -> ResearchConfig:
+    defaults = dict(
+        scraper=ScraperConfig(
+            openrouter_api_key="or-k",
+            firecrawl_api_key="fc-k",
+        ),
+        exa_api_key="exa-k",
+    )
+    defaults.update(over)
+    return ResearchConfig(**defaults)
+
+
+def make_args(**over) -> Namespace:
+    defaults = dict(
+        topic="prompt engineering",
+        effort=EffortLevel.BASIC,
+        name=None,
+        step=None,
+        stop_after=None,
+        no_filter=False,
+        yes=True,
+        no_auto_index=False,
+        force=False,
+    )
+    defaults.update(over)
+    return Namespace(**defaults)
+
+
+def mk_source(url: str = "https://ex.com/a") -> SourceDoc:
+    return SourceDoc(
+        url=url,
+        title="T",
+        content="word " * 200,
+        author="A",
+        published_date=None,
+        domain="ex.com",
+        query="q",
+        discovery_iteration=0,
+        score=0.5,
+        fetch_path="exa",
+    )
+
+
+def mk_chunk(url: str = "https://ex.com/a") -> Chunk:
+    return Chunk(
+        title="T",
+        breadcrumb="T",
+        content="chunk content goes here",
+        source_url=url,
+        path="/a/t",
+        token_count=10,
+    )
+
+
+def mk_enriched(url: str = "https://ex.com/a") -> EnrichedChunk:
+    return EnrichedChunk(
+        title="T",
+        path="/a/t",
+        url=url,
+        content="chunk content goes here",
+        keywords=["k1", "k2", "k3", "k4", "k5"],
+        use_cases=["u1", "u2"],
+        tags=["tag"],
+        priority=5,
+    )
+
+
+def _cost_stub() -> dict:
+    return {
+        "total_chunks": 1,
+        "total_batches": 1,
+        "estimated_input_tokens": 100,
+        "estimated_output_tokens": 50,
+        "model": "test-model",
+        "estimated_cost": 0.0001,
+    }
+
+
+async def test_happy_path_runs_all_five_steps(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    output_file = tmp_path / "out.json"
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[mk_source("https://ex.com/a")],
+    ) as deepen_mock, patch(
+        "king_context.research.pipeline.chunk_page",
+        return_value=[mk_chunk("https://ex.com/a")],
+    ) as chunk_mock, patch(
+        "king_context.research.pipeline.estimate_cost",
+        return_value=_cost_stub(),
+    ) as cost_mock, patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+        return_value=[mk_enriched("https://ex.com/a")],
+    ) as enrich_mock, patch(
+        "king_context.research.pipeline.export_research_to_json",
+        return_value=output_file,
+    ) as export_mock, patch(
+        "king_context.research.pipeline.auto_index"
+    ) as auto_index_mock:
+        result = await run_pipeline(make_args(), make_config())
+
+    assert isinstance(result, Path)
+    assert result == output_file
+
+    deepen_mock.assert_awaited_once()
+    chunk_mock.assert_called_once()
+    cost_mock.assert_called_once()
+    enrich_mock.assert_awaited_once()
+    export_mock.assert_called_once()
+    auto_index_mock.assert_called_once_with(output_file)
+
+    export_args, export_kwargs = export_mock.call_args
+    enriched_arg = export_args[0]
+    sources_by_url = export_args[1]
+    slug = export_args[2]
+    topic = export_args[3]
+    assert len(enriched_arg) == 1
+    assert "https://ex.com/a" in sources_by_url
+    assert isinstance(slug, str) and slug
+    assert topic == "prompt engineering"
+
+
+async def test_missing_exa_key_fails_fast(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    config = make_config(
+        scraper=ScraperConfig(
+            openrouter_api_key="or-k", firecrawl_api_key="fc-k"
+        ),
+        exa_api_key="",
+    )
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+    ) as deepen_mock, patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+    ) as enrich_mock, patch(
+        "king_context.research.pipeline.export_research_to_json"
+    ) as export_mock:
+        with pytest.raises(ConfigError, match="EXA_API_KEY"):
+            await run_pipeline(make_args(), config)
+
+    deepen_mock.assert_not_called()
+    enrich_mock.assert_not_called()
+    export_mock.assert_not_called()
+
+
+async def test_missing_openrouter_key_fails_fast(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    config = make_config(
+        scraper=ScraperConfig(openrouter_api_key="", firecrawl_api_key="fc-k"),
+        exa_api_key="exa-k",
+    )
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+    ) as deepen_mock:
+        with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
+            await run_pipeline(make_args(), config)
+
+    deepen_mock.assert_not_called()
+
+
+async def test_zero_sources_raises_user_friendly_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as deepen_mock, patch(
+        "king_context.research.pipeline.chunk_page"
+    ) as chunk_mock, patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+    ) as enrich_mock, patch(
+        "king_context.research.pipeline.export_research_to_json"
+    ) as export_mock:
+        with pytest.raises(RuntimeError, match="No sources"):
+            await run_pipeline(make_args(), make_config())
+
+    deepen_mock.assert_awaited_once()
+    chunk_mock.assert_not_called()
+    enrich_mock.assert_not_called()
+    export_mock.assert_not_called()
+
+
+async def test_existing_work_dir_reused(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    slug = "prompt-engineering"
+    pre_existing = tmp_path / "research" / slug
+    pre_existing.mkdir(parents=True, exist_ok=True)
+    (pre_existing / "manifest.json").write_text('{"existing": {"status": "done"}}')
+    (pre_existing / "scratch.txt").write_text("previous run artifact")
+
+    output_file = tmp_path / "out.json"
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[mk_source("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.chunk_page",
+        return_value=[mk_chunk("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.estimate_cost",
+        return_value=_cost_stub(),
+    ), patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+        return_value=[mk_enriched("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.export_research_to_json",
+        return_value=output_file,
+    ), patch(
+        "king_context.research.pipeline.auto_index"
+    ):
+        result = await run_pipeline(
+            make_args(name=slug), make_config()
+        )
+
+    assert result == output_file
+    assert pre_existing.exists()
+    assert (pre_existing / "scratch.txt").exists()
+
+    import json as _json
+    manifest = _json.loads((pre_existing / "manifest.json").read_text())
+    assert "existing" in manifest
+    assert manifest.get("generate", {}).get("status") == "done"
+    assert manifest.get("search", {}).get("status") == "done"
+    assert manifest.get("export", {}).get("status") == "done"
+
+
+async def test_stop_after_search_does_not_run_later_steps(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[mk_source("https://ex.com/a")],
+    ) as deepen_mock, patch(
+        "king_context.research.pipeline.chunk_page"
+    ) as chunk_mock, patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+    ) as enrich_mock, patch(
+        "king_context.research.pipeline.export_research_to_json"
+    ) as export_mock:
+        result = await run_pipeline(
+            make_args(stop_after="search"), make_config()
+        )
+
+    assert isinstance(result, Path)
+    deepen_mock.assert_awaited_once()
+    chunk_mock.assert_not_called()
+    enrich_mock.assert_not_called()
+    export_mock.assert_not_called()
+
+
+async def test_no_auto_index_flag_skips_indexing(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
+    )
+    output_file = tmp_path / "out.json"
+
+    with patch(
+        "king_context.research.pipeline.run_deepening_loop",
+        new_callable=AsyncMock,
+        return_value=[mk_source("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.chunk_page",
+        return_value=[mk_chunk("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.estimate_cost",
+        return_value=_cost_stub(),
+    ), patch(
+        "king_context.research.pipeline.enrich_chunks",
+        new_callable=AsyncMock,
+        return_value=[mk_enriched("https://ex.com/a")],
+    ), patch(
+        "king_context.research.pipeline.export_research_to_json",
+        return_value=output_file,
+    ), patch(
+        "king_context.research.pipeline.auto_index"
+    ) as auto_index_mock:
+        await run_pipeline(
+            make_args(no_auto_index=True), make_config()
+        )
+
+    auto_index_mock.assert_not_called()

--- a/tests/test_research/test_queries.py
+++ b/tests/test_research/test_queries.py
@@ -1,0 +1,203 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+from king_context.research.config import ResearchConfig
+from king_context.research.queries import (
+    QueryGenerationError,
+    SourceSummary,
+    _RETRY_DELAYS,
+    _normalize,
+    generate_queries,
+)
+from king_context.scraper.config import ScraperConfig
+
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def make_config() -> ResearchConfig:
+    return ResearchConfig(
+        scraper=ScraperConfig(
+            openrouter_api_key="fake-or-key",
+            enrichment_model="test-model",
+        ),
+        exa_api_key="exa-fake",
+    )
+
+
+def openrouter_payload(queries: list[str]) -> dict:
+    return {
+        "choices": [
+            {"message": {"content": json.dumps({"queries": queries})}}
+        ]
+    }
+
+
+def openrouter_raw(content: str) -> dict:
+    return {"choices": [{"message": {"content": content}}]}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_initial_generation_returns_requested_count():
+    config = make_config()
+    respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(
+            200, json=openrouter_payload(["q1", "q2", "q3"])
+        )
+    )
+
+    result = await generate_queries("semantic search", 3, config)
+
+    assert result == ["q1", "q2", "q3"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_followup_dedupes_against_previous_queries():
+    config = make_config()
+    respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=openrouter_payload(
+                ["new angle A", "Semantic Search Basics.", "new angle B"]
+            ),
+        )
+    )
+
+    previous = ["semantic search basics"]
+    result = await generate_queries(
+        "semantic search",
+        5,
+        config,
+        previous_queries=previous,
+    )
+
+    assert "new angle A" in result
+    assert "new angle B" in result
+    assert len(result) == 2
+    for r in result:
+        assert _normalize(r) != "semantic search basics"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_malformed_llm_output_raises():
+    config = make_config()
+    respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(200, json=openrouter_raw("not-json {"))
+    )
+
+    with pytest.raises(QueryGenerationError):
+        await generate_queries("topic", 3, config)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_retries_on_429_then_succeeds(monkeypatch):
+    monkeypatch.setattr(
+        "king_context.research.queries._RETRY_DELAYS", [0.0, 0.0]
+    )
+    config = make_config()
+
+    route = respx.post(OPENROUTER_URL).mock(
+        side_effect=[
+            httpx.Response(429, json={"error": "rate limited"}),
+            httpx.Response(200, json=openrouter_payload(["a", "b"])),
+        ]
+    )
+
+    result = await generate_queries("topic", 2, config)
+
+    assert result == ["a", "b"]
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fails_fast_on_401():
+    config = make_config()
+    route = respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(401, json={"error": "unauthorized"})
+    )
+
+    with pytest.raises(QueryGenerationError):
+        await generate_queries("topic", 3, config)
+
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_handles_markdown_wrapped_json():
+    config = make_config()
+    wrapped = "```json\n" + json.dumps({"queries": ["x", "y"]}) + "\n```"
+    respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(200, json=openrouter_raw(wrapped))
+    )
+
+    result = await generate_queries("topic", 2, config)
+
+    assert result == ["x", "y"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_bare_list_response_accepted():
+    config = make_config()
+    respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(
+            200, json=openrouter_raw(json.dumps(["only", "list"]))
+        )
+    )
+
+    result = await generate_queries("topic", 5, config)
+
+    assert result == ["only", "list"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_caps_returned_list_to_count():
+    config = make_config()
+    respx.post(OPENROUTER_URL).mock(
+        return_value=httpx.Response(
+            200, json=openrouter_payload(["a", "b", "c", "d", "e"])
+        )
+    )
+
+    result = await generate_queries("topic", 2, config)
+
+    assert result == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_previous_results_included_in_prompt():
+    config = make_config()
+    captured: dict = {}
+
+    def capture(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json=openrouter_payload(["followup1"]))
+
+    respx.post(OPENROUTER_URL).mock(side_effect=capture)
+
+    summaries = [
+        SourceSummary(title="Paper A", top_highlight="Key insight about X"),
+    ]
+    result = await generate_queries(
+        "topic", 1, config, previous_results=summaries
+    )
+
+    assert result == ["followup1"]
+    user_msg = captured["body"]["messages"][-1]["content"]
+    assert "Paper A" in user_msg
+    assert "Key insight about X" in user_msg
+
+
+def test_retry_delays_module_constant_exists():
+    assert _RETRY_DELAYS == [1.0, 2.0]

--- a/tests/test_scraper/test_config.py
+++ b/tests/test_scraper/test_config.py
@@ -1,5 +1,12 @@
 import pytest
-from king_context.scraper.config import ScraperConfig, load_config, ConfigError, get_firecrawl_key, get_openrouter_key
+from king_context.scraper.config import (
+    ScraperConfig,
+    load_config,
+    ConfigError,
+    get_firecrawl_key,
+    get_openrouter_key,
+    _load_env_files,
+)
 
 
 def test_load_config_with_env_vars(monkeypatch):
@@ -45,3 +52,51 @@ def test_config_defaults():
     assert config.chunk_min_tokens == 100
     assert config.concurrency == 5
     assert config.filter_llm_fallback is True
+
+
+def test_load_env_files_only_root_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_TEST_ROOT_ONLY", raising=False)
+    monkeypatch.delenv("KING_TEST_INSTALLER_ONLY", raising=False)
+
+    (tmp_path / ".env").write_text("KING_TEST_ROOT_ONLY=root-value\n")
+
+    _load_env_files(project_root=tmp_path)
+
+    import os
+    assert os.environ.get("KING_TEST_ROOT_ONLY") == "root-value"
+
+
+def test_load_env_files_only_installer_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_TEST_INSTALLER_VAR", raising=False)
+
+    installer_dir = tmp_path / ".king-context"
+    installer_dir.mkdir()
+    (installer_dir / ".env").write_text("KING_TEST_INSTALLER_VAR=installer-value\n")
+
+    _load_env_files(project_root=tmp_path)
+
+    import os
+    assert os.environ.get("KING_TEST_INSTALLER_VAR") == "installer-value"
+
+
+def test_load_env_files_root_overrides_installer(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_TEST_SHARED_VAR", raising=False)
+
+    installer_dir = tmp_path / ".king-context"
+    installer_dir.mkdir()
+    (installer_dir / ".env").write_text("KING_TEST_SHARED_VAR=installer-value\n")
+    (tmp_path / ".env").write_text("KING_TEST_SHARED_VAR=root-value\n")
+
+    _load_env_files(project_root=tmp_path)
+
+    import os
+    assert os.environ.get("KING_TEST_SHARED_VAR") == "root-value"
+
+
+def test_load_env_files_neither_exists(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_TEST_NEITHER_VAR", raising=False)
+
+    _load_env_files(project_root=tmp_path)
+
+    import os
+    assert os.environ.get("KING_TEST_NEITHER_VAR") is None


### PR DESCRIPTION
## Summary

Adds `king-research <topic>` — a new CLI that turns a topic into a curated, locally-indexed research corpus — and splits the file-based store so scraped documentation and research corpora live side by side without colliding.

## Why?

King Context today only indexes documentation from known URLs (`king-scrape`). Users who want to research broader topics — papers, techniques, threads, tutorials — have to collect sources manually, which defeats the point of a local-first semantic index. This introduces a topic-driven producer with the same output shape as `king-scrape`, so both flow into `kctx` unchanged on the consumer side.

Storing research output in the same `.king-context/docs/` directory as scraped docs made listings confusing; separating the stores is the right long-term shape and keeps `kctx` source-aware.

## What changed

- **`king-research` CLI** — topic → OpenRouter query gen → Exa search (+ Jina fallback) → iterative deepening → chunk → enrich → export → auto-index. Four effort levels (`--basic`, `--medium`, `--high`, `--extrahigh`) scale depth/cost predictably. Wires into `pyproject.toml` as `king-research`.
- **Store separation** — research output now lands in `.king-context/research/`; scrape output stays in `.king-context/docs/`. `auto_index` defaults to the research store.
- **Source-aware `kctx`** — `kctx list [docs|research]`, `--source docs|research|all` on `search`/`grep`/`read`/`topics`, auto-detect on `kctx index` via `section.source_type`, `[docs]`/`[research]` prefix on every hit.
- **Dual-location `.env` loader** in `scraper/config.py` (installer baseline + dev override).
- **King Context skill** updated in both `.claude/skills/` and `installer/templates/skills/` so agents know the new filters and commands.
- **Tests**: 79 new tests in `tests/test_research/` (unit + integration), 3 new in `tests/test_context_cli/`, updated formatter assertions. 370 passing overall (24 pre-existing failures in `tests/test_server.py` are MCP-legacy, deprecated in the v2 pivot).

## How to test

1. `pip install -e .` then `king-research "prompt engineering" --basic --yes` (requires `EXA_API_KEY` + `OPENROUTER_API_KEY` in `.env`).
2. Verify the output lands in `.king-context/research/<slug>/` and `kctx list research` shows it.
3. `kctx search "<term>"` — confirm hits are tagged `[docs]` or `[research]`.
4. `kctx search "<term>" --source research` / `--source docs` — confirm filtering isolates each store.
5. `kctx search "<term>" --doc <name>` — confirm single-doc scoping.
6. `pytest tests/test_research tests/test_context_cli` — 177 passing.

## Checklist

- [x] Self-review done
- [x] No debug code left
- [x] Tests passing (177/177 in touched suites; 370 total, 24 pre-existing failures unrelated)
- [x] Skill documentation updated to reflect new filters