### PR TITLE
feat(skills): add Codex-compatible king-context and king-research skills

### DIFF
--- a/.agents/skills/king-context/SKILL.md
+++ b/.agents/skills/king-context/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: king-context
+description: Search indexed documentation and research corpora efficiently via the `.king-context/bin/kctx` CLI (list, search, read, topics, grep). Trigger when the user wants to query content that is already indexed locally — "search the docs / our research", "how to use library X", "what's the API for Y", "what do we have on topic Z", "find in indexed content". Do NOT trigger when the user asks to scrape a new doc site (use scraper-workflow) or to run a new open-web research pipeline (use king-research). Prefer this skill over raw web search whenever a local corpus may contain the answer.
+---
+
+# King Context — Documentation Search Skill
+
+Search indexed documentation and research corpora efficiently using `.king-context/bin/kctx`. Find the right section in ≤3 calls.
+
+---
+
+## Two Stores, One CLI
+
+King Context keeps two separate stores:
+
+| Store | Populated by | What's in it |
+|---|---|---|
+| `docs` | `.king-context/bin/king-scrape <url>` | Scraped product/API documentation |
+| `research` | `.king-context/bin/king-research <topic>` | Topic-driven research corpora from the open web |
+
+Every `kctx` command is source-aware:
+- Default: searches **both** stores, merged by score.
+- `--source docs|research` scopes to one store.
+- `--doc <name>` scopes to a single doc (works across stores — most precise filter).
+
+Every search/grep hit is prefixed `[docs]` or `[research]` so you can tell the source at a glance.
+
+---
+
+## Search Strategy
+
+```
+1. Check _learned/                           →  known shortcut?  → .king-context/bin/kctx read <doc> <path>  → DONE
+2. .king-context/bin/kctx list               →  which doc + which store?
+3. .king-context/bin/kctx search "query"     →  find section     → got it?
+4. .king-context/bin/kctx read --preview     →  assess relevance → right section?
+5. .king-context/bin/kctx read               →  full content     → DONE
+6. Save discovery to _learned/
+```
+
+**Rules**:
+- ALWAYS check `_learned/` FIRST — costs ~100 tokens, saves thousands.
+- ALWAYS verify learned paths still exist before using them (`.king-context/bin/kctx read` errors if stale).
+- Prefer `.king-context/bin/kctx search` over `.king-context/bin/kctx grep` — metadata search is faster and cheaper.
+- Use `--preview` before full read — assess relevance before paying full token cost.
+- Use `.king-context/bin/kctx grep` only for exact code patterns, API names, or error strings.
+- **Scope aggressively**: `--doc <name>` > `--source <store>` > unfiltered.
+- NEVER read all sections — search narrows, preview confirms, then read only what's needed.
+
+---
+
+## Picking a Filter (decision tree)
+
+```
+User asks about a specific library/product/SDK?  → --doc <name>
+User asks about a research topic you scraped?    → --doc <research-slug>
+User asks something generic, unsure which doc?   → --source docs or --source research
+User asks "is it anywhere in our indexed stuff?" → no filter (search both)
+```
+
+`--doc` is the sharpest tool. Run `.king-context/bin/kctx list` once if you don't know the name.
+
+---
+
+## Query Decomposition
+
+Transform user intent into efficient CLI queries:
+
+| User asks | CLI query |
+|-----------|-----------|
+| "How to stream audio with ElevenLabs" | `.king-context/bin/kctx search "streaming" --doc elevenlabs-api` |
+| "Authentication for the Exa API" | `.king-context/bin/kctx search "auth api-key" --doc exa` |
+| "What does our research say on Chain of Thought" | `.king-context/bin/kctx search "chain of thought" --source research` |
+| "Compare ToT vs CoT — anything indexed?" | `.king-context/bin/kctx search "tree of thoughts" --source research --top 5` |
+| "Is rate limiting documented anywhere?" | `.king-context/bin/kctx search "rate limit"` (both stores) |
+| "Find where `Client(` is used in httpx" | `.king-context/bin/kctx grep "Client\\(" --doc httpx` |
+| "What topics does the docs cover" | `.king-context/bin/kctx topics elevenlabs-api` |
+| "Show only our research corpora" | `.king-context/bin/kctx list research` |
+
+**Tips**:
+- Use 1–2 specific keywords, not full sentences.
+- Scope to `--doc` when you know which doc.
+- Use `--top 3` to reduce output tokens.
+- Keywords match exact terms; use_cases match substrings — "stream" matches "How to stream audio".
+
+---
+
+## CLI Command Reference
+
+### List indexed content
+```bash
+.king-context/bin/kctx list                    # both stores with == Docs == / == Research == headers
+.king-context/bin/kctx list docs               # only scraped docs
+.king-context/bin/kctx list research           # only research corpora
+.king-context/bin/kctx list --json             # JSON (grouped dict when "all", flat list when filtered)
+```
+
+### Search by metadata (keywords, use_cases, tags)
+```bash
+.king-context/bin/kctx search "query"                              # cross-store, top 5, merged by score
+.king-context/bin/kctx search "streaming" --doc elevenlabs-api     # scoped to a single doc (auto-resolves store)
+.king-context/bin/kctx search "reasoning" --source research        # only research corpora
+.king-context/bin/kctx search "livecrawl" --source docs            # only scraped docs
+.king-context/bin/kctx search "auth" --top 3                       # limit results
+.king-context/bin/kctx search "query" --json                       # JSON output
+```
+Output tags every hit with `[docs]` or `[research]`. Returns title, path, score, first use_case. **No content** — metadata only.
+
+### Read a section
+```bash
+.king-context/bin/kctx read <doc> <section-path>             # full content (auto-finds the store)
+.king-context/bin/kctx read <doc> <section-path> --preview   # first ~200 tokens + total estimate
+.king-context/bin/kctx read <doc> <section-path> --source research   # force store (rarely needed)
+.king-context/bin/kctx read <doc> <section-path> --json      # JSON output
+```
+If the doc name isn't unique, pass `--source`. If section not found, suggests similar paths.
+
+### Browse by topic
+```bash
+.king-context/bin/kctx topics <doc>                          # all tags with sections
+.king-context/bin/kctx topics <doc> --tag api-reference      # filter to one tag
+.king-context/bin/kctx topics <doc> --source research        # disambiguate if needed
+.king-context/bin/kctx topics <doc> --json                   # JSON output
+```
+
+### Grep content
+```bash
+.king-context/bin/kctx grep "pattern"                        # regex across both stores
+.king-context/bin/kctx grep "Client\\(" --doc httpx          # scoped to one doc
+.king-context/bin/kctx grep "livecrawl" --source docs        # scoped to docs store
+.king-context/bin/kctx grep "pattern" --context 3            # surrounding lines
+.king-context/bin/kctx grep "pattern" --json                 # JSON output
+```
+
+### Index / re-index
+```bash
+.king-context/bin/kctx index .king-context/data/example.json         # auto-detects via section.source_type
+.king-context/bin/kctx index .king-context/data/research/topic.json  # also auto-detected as research
+.king-context/bin/kctx index <path> --source research                # force-route to research store
+.king-context/bin/kctx index --all                                   # walks data/*.json + data/research/*.json
+```
+
+---
+
+## Generating New Content
+
+Two producers feed the stores:
+
+```bash
+# Scrape a product/API doc site → .king-context/docs/<name>/
+.king-context/bin/king-scrape https://docs.example.com
+
+# Research a topic from the open web → .king-context/research/<slug>/
+.king-context/bin/king-research "prompt engineering techniques" --basic     # 3 queries, no deepening
+.king-context/bin/king-research "retrieval augmented generation" --medium   # 5 queries + 1 deepening iteration
+.king-context/bin/king-research "mixture of experts" --high                 # 8 + 2 iterations
+.king-context/bin/king-research "<topic>" --extrahigh                       # 12 + 3 iterations (most thorough)
+```
+
+Both auto-index on completion — the new doc is immediately searchable via `kctx`. `king-research` outputs are tagged `source_type: "research"` in every section so `--source research` and the `[research]` prefix work automatically.
+
+---
+
+## Self-Learning
+
+After finding a useful section, save a shortcut for future sessions.
+
+### When to save
+- You found the right section after searching.
+- You discovered a gotcha or non-obvious behavior.
+- You found a pattern that would help answer similar questions.
+
+### How to save
+Write to `.king-context/_learned/<doc-name>.md`:
+
+```markdown
+# <Doc Name> - Learned Shortcuts
+
+## <Topic>
+- **<What>** → `<section-path>` section
+- Store: docs | research
+- Gotcha: <non-obvious behavior>
+- Related: `<other-section>` for <reason>
+
+---
+Last updated: <date>
+```
+
+Tracking the store lets you skip `kctx list` on the next lookup.
+
+### Reading learned shortcuts
+Before any search:
+1. Read `.king-context/_learned/<doc-name>.md`.
+2. If a shortcut matches the current query, use it directly: `.king-context/bin/kctx read <doc> <path>`.
+3. If the path no longer exists (stale), fall back to normal search and update the learned file.
+
+---
+
+## Good vs Bad Search Strategies
+
+### Good (3 calls, ~400 tokens)
+```
+.king-context/bin/kctx search "streaming" --doc elevenlabs-api --top 3
+→ 1. [docs] WebSocket Streaming (elevenlabs-api/websocket-streaming) score=8.50
+
+.king-context/bin/kctx read elevenlabs-api websocket-streaming --preview
+→ "# WebSocket Streaming\n\nConnect to ws://..." Tokens: 450
+
+.king-context/bin/kctx read elevenlabs-api websocket-streaming
+→ Full content
+```
+
+### Good (research-scoped, 2 calls)
+```
+.king-context/bin/kctx search "zero shot cot" --source research --top 3
+→ 1. [research] Zero-Shot CoT (prompt-engineering-techniques/ai-prompt-engineering-...) score=12.50
+
+.king-context/bin/kctx read prompt-engineering-techniques ai-prompt-engineering-patterns-cot-react-tot-zero-shot-cot
+→ Full content
+```
+
+### Bad (wasteful, ~3000+ tokens)
+```
+.king-context/bin/kctx list
+.king-context/bin/kctx topics elevenlabs-api
+.king-context/bin/kctx read elevenlabs-api getting-started              # wrong section
+.king-context/bin/kctx read elevenlabs-api text-to-speech               # still wrong
+.king-context/bin/kctx search "websocket streaming audio real-time"     # too many terms
+.king-context/bin/kctx read elevenlabs-api websocket-streaming          # finally found it
+```

--- a/.agents/skills/king-research/SKILL.md
+++ b/.agents/skills/king-research/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: king-research
+description: Build an open-web research corpus on a topic using the king-research pipeline (generate → search → chunk → enrich → export) and auto-index it for later search. Trigger when the user asks to research / pesquisar / build a corpus / find sources / survey state-of-the-art on a general topic (papers, blog posts, discussions, comparisons). Do NOT trigger when the user points to a specific product documentation site — use the scraper-workflow skill for that. Do NOT trigger when the user wants to query already-indexed content — use the king-context skill (`kctx search`) for that.
+---
+
+# King Research — Topic Research Skill
+
+Invoke `king-research` to build a research corpus on any topic. The user describes what they want; you extract the topic, pick the effort mode, and run the pipeline.
+
+---
+
+## When to use this skill
+
+| User wants... | Use |
+|---|---|
+| Sources on an open-web topic (papers, blog posts, discussions) | **king-research** (this skill) |
+| A specific product/API doc site scraped | **scraper-workflow** (`king-scrape`) |
+| To query already-indexed content | **king-context** (`kctx search`) |
+
+If the user already mentions a URL or a specific product's docs, hand off to `scraper-workflow`.
+
+---
+
+## Step 1: Extract the topic
+
+Pull the topic from the user's message as a concise phrase (2–6 words).
+
+**Rules**:
+- Strip filler: "please", "por favor", "pode fazer", "quero que", "me faça".
+- Keep semantic qualifiers: "for RAG pipelines", "in production", "2025".
+- Prefer the user's wording over paraphrase.
+- Quote multi-word topics when passing to the CLI.
+
+If the topic is vague (e.g. "faz um research aí", "pesquise algo"), ask ONE clarifying question before running: **"What topic?"**
+
+---
+
+## Step 2: Pick the effort mode
+
+### Explicit signals (override inference)
+
+| Signal in the user's message | Mode |
+|---|---|
+| "rápido", "quick", "basic", "só uma ideia", "overview", "simples" | `--basic` |
+| (no qualifier) | `--medium` (default) |
+| "detalhado", "aprofundado", "profundo", "detailed", "in-depth", "completo" | `--high` |
+| "exaustivo", "estado da arte", "thorough", "comprehensive", "state of the art", "máximo", "tudo que tiver" | `--extrahigh` |
+
+### Inferred from complexity (when no explicit signal)
+
+| Topic shape | Mode |
+|---|---|
+| Narrow, well-known (e.g. "httpx timeouts") | `--basic` |
+| Standard technical topic (e.g. "prompt caching strategies") | `--medium` (default) |
+| Broad or comparative (e.g. "RAG vs fine-tuning") | `--high` |
+| Bleeding-edge / multi-domain survey (e.g. "mixture of experts state of the art 2025") | `--extrahigh` |
+
+### Cost & time budget
+
+| Mode | Initial queries | Deepening iterations | ~Time | API cost |
+|---|---|---|---|---|
+| `--basic` | 3 | 0 | ~30s | minimal |
+| `--medium` | 5 | 1 | ~2 min | low |
+| `--high` | 8 | 2 | ~5 min | medium |
+| `--extrahigh` | 12 | 3 | ~10 min | high |
+
+For `--high` or `--extrahigh`, state the expected time before running so the user isn't surprised. No need to ask permission — just warn.
+
+---
+
+## Step 3: Run the pipeline
+
+```bash
+.king-context/bin/king-research "<topic>" --<mode> --yes
+```
+
+**Flags to remember**:
+- `--yes` / `-y` — skip the enrichment cost prompt (default ON from this skill; the user invoked us to do the work, not to be interrupted).
+- `--name <slug>` — override the auto-generated slug (rarely needed; only if the user explicitly names it).
+- `--no-auto-index` — don't auto-index into `.king-context/research/` (rarely; only if the user explicitly asks for JSON-only output).
+- `--step <stage>` / `--stop-after <stage>` — resume or partial-run (only for debugging; don't use proactively).
+
+**Pipeline stages** (for reference when resuming): `generate → search → chunk → enrich → export`.
+
+---
+
+## Step 4: Report + hand off to search
+
+After the pipeline finishes, report concisely:
+
+1. The slug it was saved under (auto-indexed in `.king-context/research/<slug>/`).
+2. Section count.
+3. Example commands to search it.
+
+Template:
+```
+Indexed "<slug>" — N sections. Try:
+  kctx search "<keyword>" --doc <slug>
+  kctx topics <slug>
+  kctx list research
+```
+
+Don't dump the full topic tree or section titles — let the user drive the search.
+
+---
+
+## Error handling
+
+| Error | Action |
+|---|---|
+| `EXA_API_KEY is not set` | "Set `EXA_API_KEY` in `.king-context/.env` or `./.env`, then retry." |
+| `OPENROUTER_API_KEY` missing | Same — both are required (query generation + enrichment). |
+| Zero results from Exa | Topic may be too niche or mis-spelled. Suggest rephrasing or adding context. |
+| Pipeline fails with "no chunks" or "no enriched sections" | Report which stage; usually means the topic returned no fetchable pages. Try broadening the topic. |
+| User hit a high/extrahigh run by mistake | Remind them `Ctrl+C` cancels; partial progress in `.king-context/_temp/research/<slug>/` is kept for resume via `--step`. |
+
+---
+
+## Examples
+
+### Implicit mode (inferred from complexity)
+```
+User: "pesquise sobre chain of thought prompting"
+→ Topic: "chain of thought prompting"
+→ Standard technical topic → --medium
+→ .king-context/bin/king-research "chain of thought prompting" --medium --yes
+→ "Indexed chain-of-thought-prompting — 14 sections."
+```
+
+### Explicit mode — quick
+```
+User: "faz um research rápido sobre retry backoff"
+→ Topic: "retry backoff"
+→ Signal "rápido" → --basic
+→ .king-context/bin/king-research "retry backoff" --basic --yes
+```
+
+### Explicit mode — exhaustive
+```
+User: "quero tudo sobre mixture of experts, estado da arte"
+→ Topic: "mixture of experts"
+→ Signal "estado da arte" → --extrahigh
+→ Warn: "~10 minutes and higher API cost — proceeding"
+→ .king-context/bin/king-research "mixture of experts" --extrahigh --yes
+```
+
+### Comparative (inferred high)
+```
+User: "compare RAG vs fine-tuning for code assistants"
+→ Topic: "RAG vs fine-tuning code assistants"
+→ Comparative, broad → --high
+→ .king-context/bin/king-research "RAG vs fine-tuning code assistants" --high --yes
+```
+
+### Vague topic (ask first)
+```
+User: "faz um research aí"
+→ Ask: "What topic?"
+→ (wait for reply, then resume from Step 1)
+```
+
+### User provides a URL — hand off
+```
+User: "research stripe docs"
+→ This is a doc site, not an open-web topic.
+→ Hand off to scraper-workflow: king-scrape https://docs.stripe.com
+```

--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,11 @@ commit-create/
 data/
 
 .claude/skills/tlc-spec-driven/
-.agents/
 .cursor/
 .specs/
 .king-context/
 .claude/projects/
+
+# Codex: ignore everything except skills/
+.agents/*
+!.agents/skills/


### PR DESCRIPTION
## Summary
- Mirror the `king-context` and `king-research` skills under `.agents/skills/` so Codex picks them up from the same repo.
- Fix `.gitignore`: the prior `.agents/` + `!.agents/skills/` pair did not work (Git cannot re-include paths under an ignored parent). Replaced with `.agents/*` + `!.agents/skills/` so `.DS_Store` and `.skill-lock.json*` stay ignored while `skills/` is tracked.

## Scope
- Only the two skills that already have Claude Code parity are included. A Codex mirror of the scraper skill (`scraper-workflow`) is pending and will land in a follow-up before the public release.

## Test plan
- [x] `git check-ignore -v .agents/.DS_Store` → ignored
- [x] `git check-ignore -v .agents/skills/king-context/SKILL.md` → not ignored
- [x] `git ls-files .agents/` shows only the two `SKILL.md` files
- [x] Codex picks up both skills from `.agents/skills/`