### PR TITLE
Add LICENSE and complete pyproject.toml metadata for PyPI publish

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 deandevz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,34 @@
 name = "king-context"
 version = "0.1.0"
 description = "Local-first, token-efficient documentation server for LLM context injection"
+readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.10"
+authors = [
+    { name = "deandevz", email = "bruucetscontact@gmail.com" },
+]
+keywords = [
+    "mcp",
+    "llm",
+    "documentation",
+    "search",
+    "context",
+    "claude",
+    "ai-agents",
+    "rag",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "fastmcp>=0.4.0",
     "sentence-transformers>=2.2.0",
@@ -25,6 +52,11 @@ king-context = "king_context.server:main"
 king-scrape = "king_context.scraper.cli:main"
 king-research = "king_context.research.cli:main"
 kctx = "context_cli.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/deandevz/king-context"
+Repository = "https://github.com/deandevz/king-context"
+Issues = "https://github.com/deandevz/king-context/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Picks up the metadata work we discussed in the issue, ahead of the first PyPI publish.

What's in here:

  - LICENSE file at the repo root (MIT, copyright 2026 deandevz)
  - pyproject.toml: added readme, license, authors, keywords, classifiers, and a [project.urls] block

  Verification I ran locally:

  - `python -m build` produces sdist + wheel
  - `twine check dist/*` → PASSED on both
  - `pytest` → 399/399 passing
  
  Closes #9.