### PR TITLE
Rename Python MCP entry point to king-context-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Renamed the Python MCP server console script from `king-context` to
+  `king-context-server`. The `king-context` name is reserved for the npm
+  installer (`@king-context/cli`), which is the user facing entry point.
+  Users with a Claude Code or Claude Desktop MCP config that points at
+  `king-context` should update it to `king-context-server`. The
+  `python -m king_context.server` invocation is unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ King Context is a local-first, token-efficient documentation server for LLM cont
 pip install -e .
 
 # Run MCP server
-king-context                         # via console script
+king-context-server                  # via console script
 python -m king_context.server        # via module
 
 # Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
 ]
 
 [project.scripts]
-king-context = "king_context.server:main"
+king-context-server = "king_context.server:main"
 king-scrape = "king_context.scraper.cli:main"
 king-research = "king_context.research.cli:main"
 kctx = "context_cli.cli:main"


### PR DESCRIPTION
Renames the Python MCP server console script from king-context to king-context-server so the king-context name stays reserved for the npm installer `(@king-context/cli)`.

  Changes:

  - `pyproject.toml`: rename the entry in `[project.scripts]`
  - `CLAUDE.md`: update the Commands section
  - `CHANGELOG.md`: new file with an `[Unreleased]` note so anyone updating their MCP config knows what to change

  `python -m king_context.server` still works as before.

  Independent of #9 happy to rebase once the metadata PR merges. Closes #10.