### PR TITLE
fix(installer): add Windows-aware Python and wrapper handling

### DIFF
--- a/installer/lib/doctor.js
+++ b/installer/lib/doctor.js
@@ -4,8 +4,16 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const ui = require('./ui');
+const { detectPython, getVenvPython } = require('./python');
 const { expectedDirPaths } = require('./scaffold');
 const { expectedSkillPaths } = require('./skills');
+
+function getWrapperPaths(projectDir, name) {
+  const binDir = path.join(projectDir, '.king-context', 'bin');
+  return process.platform === 'win32'
+    ? [path.join(binDir, `${name}.cmd`), path.join(binDir, name)]
+    : [path.join(binDir, name)];
+}
 
 /**
  * Run a single diagnostic check.
@@ -13,62 +21,43 @@ const { expectedSkillPaths } = require('./skills');
  */
 function checkPython() {
   try {
-    const raw = execSync('python3 --version', { stdio: 'pipe' }).toString().trim();
-    return { status: 'ok', label: `Python: ${raw}` };
-  } catch {
-    return { status: 'fail', label: 'Python: python3 not found' };
+    const python = detectPython();
+    return { status: 'ok', label: `Python: ${python.version} (${python.display || python.cmd})` };
+  } catch (err) {
+    return { status: 'fail', label: `Python: ${err.message.split('\n')[0]}` };
   }
 }
 
 function checkVenv(projectDir) {
-  const venvPython = path.join(projectDir, '.king-context', 'core', 'venv', 'bin', 'python');
+  const venvPython = getVenvPython(projectDir);
   if (fs.existsSync(venvPython)) {
-    return { status: 'ok', label: 'Venv: .king-context/core/venv/bin/python exists' };
+    return { status: 'ok', label: `Venv: ${path.relative(projectDir, venvPython)} exists` };
   }
   return { status: 'fail', label: 'Venv: virtual environment not found' };
 }
 
 function checkCliTools(projectDir) {
   const results = [];
-  const binDir = path.join(projectDir, '.king-context', 'bin');
 
-  // Check kctx
-  const kctxPath = path.join(binDir, 'kctx');
-  try {
-    if (fs.existsSync(kctxPath)) {
-      execSync(`"${kctxPath}" --version`, { stdio: 'pipe', timeout: 10000 });
-      results.push({ status: 'ok', label: 'CLI: kctx is working' });
-    } else {
-      results.push({ status: 'fail', label: 'CLI: kctx not found' });
-    }
-  } catch {
-    results.push({ status: 'warn', label: 'CLI: kctx found but returned an error' });
-  }
+  const tools = [
+    { name: 'kctx', args: '--help' },
+    { name: 'king-scrape', args: '--help' },
+    { name: 'king-research', args: '--help' },
+  ];
 
-  // Check king-scrape
-  const scrapePath = path.join(binDir, 'king-scrape');
-  try {
-    if (fs.existsSync(scrapePath)) {
-      execSync(`"${scrapePath}" --help`, { stdio: 'pipe', timeout: 10000 });
-      results.push({ status: 'ok', label: 'CLI: king-scrape is working' });
-    } else {
-      results.push({ status: 'fail', label: 'CLI: king-scrape not found' });
-    }
-  } catch {
-    results.push({ status: 'warn', label: 'CLI: king-scrape found but returned an error' });
-  }
+  for (const tool of tools) {
+    const wrapperPath = getWrapperPaths(projectDir, tool.name).find((candidate) => fs.existsSync(candidate));
 
-  // Check king-research
-  const researchPath = path.join(binDir, 'king-research');
-  try {
-    if (fs.existsSync(researchPath)) {
-      execSync(`"${researchPath}" --help`, { stdio: 'pipe', timeout: 10000 });
-      results.push({ status: 'ok', label: 'CLI: king-research is working' });
-    } else {
-      results.push({ status: 'fail', label: 'CLI: king-research not found' });
+    try {
+      if (wrapperPath) {
+        execSync(`"${wrapperPath}" ${tool.args}`, { stdio: 'pipe', timeout: 10000 });
+        results.push({ status: 'ok', label: `CLI: ${tool.name} is working` });
+      } else {
+        results.push({ status: 'fail', label: `CLI: ${tool.name} not found` });
+      }
+    } catch {
+      results.push({ status: 'warn', label: `CLI: ${tool.name} found but returned an error` });
     }
-  } catch {
-    results.push({ status: 'warn', label: 'CLI: king-research found but returned an error' });
   }
 
   return results;

--- a/installer/lib/init.js
+++ b/installer/lib/init.js
@@ -6,6 +6,12 @@ const { detectPython, createVenv, installPackage } = require('./python');
 const { createDirs, writeWrappers, writeEnvExample } = require('./scaffold');
 const { installSkills, mergeSettings, updateClaudeMd, updateGitignore } = require('./skills');
 
+function shellCopyCommand() {
+  return process.platform === 'win32'
+    ? 'Copy-Item .king-context/.env.example .env'
+    : 'cp .king-context/.env.example .env';
+}
+
 async function run() {
   const projectDir = process.cwd();
 
@@ -16,7 +22,7 @@ async function run() {
   try {
     ui.step('Detecting Python...');
     pythonInfo = detectPython();
-    ui.stepDone(`Python ${pythonInfo.version} found (${pythonInfo.cmd})`);
+    ui.stepDone(`Python ${pythonInfo.version} found (${pythonInfo.display || pythonInfo.cmd})`);
   } catch (err) {
     ui.stepFail('Python not found');
     console.error();
@@ -122,7 +128,7 @@ async function run() {
   ui.header('Next Steps');
   console.log('  1. Copy .king-context/.env.example to .env and add your API keys:');
   console.log();
-  console.log('       cp .king-context/.env.example .env');
+  console.log(`       ${shellCopyCommand()}`);
   console.log();
   console.log('  2. Run the doctor to verify your installation:');
   console.log();

--- a/installer/lib/python.js
+++ b/installer/lib/python.js
@@ -1,34 +1,72 @@
 'use strict';
 
-const { execSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const path = require('path');
-const fs = require('fs');
+
+function getVenvPath(projectDir) {
+  return path.join(projectDir, '.king-context', 'core', 'venv');
+}
+
+function getVenvBinDir(projectDir) {
+  return path.join(getVenvPath(projectDir), process.platform === 'win32' ? 'Scripts' : 'bin');
+}
+
+function getVenvPython(projectDir) {
+  return path.join(getVenvBinDir(projectDir), process.platform === 'win32' ? 'python.exe' : 'python');
+}
+
+function getPythonCandidates() {
+  return process.platform === 'win32'
+    ? [
+        { cmd: 'py', args: ['-3'], display: 'py -3' },
+        { cmd: 'python', args: [], display: 'python' },
+        { cmd: 'python3', args: [], display: 'python3' },
+      ]
+    : [
+        { cmd: 'python3', args: [], display: 'python3' },
+        { cmd: 'python', args: [], display: 'python' },
+        { cmd: 'py', args: ['-3'], display: 'py -3' },
+      ];
+}
+
+function parsePythonVersion(raw) {
+  const match = String(raw || '').match(/Python\s+(\d+\.\d+(?:\.\d+)?)/);
+  return match ? match[1] : null;
+}
 
 /**
  * Detect a usable Python installation (>= 3.10).
- * Tries python3 first, then python.
+ * Tries platform-appropriate Python launchers in priority order.
  * Returns { cmd, version } or throws with install instructions.
  */
 function detectPython() {
-  const candidates = ['python3', 'python'];
+  for (const candidate of getPythonCandidates()) {
+    const result = spawnSync(candidate.cmd, [...candidate.args, '--version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
 
-  for (const cmd of candidates) {
-    try {
-      const raw = execSync(`${cmd} --version`, { stdio: 'pipe' }).toString().trim();
-      const match = raw.match(/Python\s+(\d+\.\d+\.\d+)/);
-      if (!match) continue;
-
-      const version = match[1];
-      const [major, minor] = version.split('.').map(Number);
-
-      if (major < 3 || (major === 3 && minor < 10)) {
-        continue;
-      }
-
-      return { cmd, version };
-    } catch {
-      // command not found, try next
+    if (result.error || result.status !== 0) {
+      continue;
     }
+
+    const version = parsePythonVersion(`${result.stdout || ''}${result.stderr || ''}`.trim());
+    if (!version) {
+      continue;
+    }
+
+    const [major, minor] = version.split('.').map(Number);
+    if (major < 3 || (major === 3 && minor < 10)) {
+      continue;
+    }
+
+    return {
+      cmd: candidate.cmd,
+      args: candidate.args,
+      display: candidate.display,
+      version,
+    };
   }
 
   throw new Error(
@@ -37,7 +75,8 @@ function detectPython() {
     '  or via your package manager:\n' +
     '    macOS:  brew install python@3.12\n' +
     '    Ubuntu: sudo apt install python3\n' +
-    '    Fedora: sudo dnf install python3'
+    '    Fedora: sudo dnf install python3\n' +
+    '    Windows: winget install Python.Python.3.12'
   );
 }
 
@@ -45,21 +84,25 @@ function detectPython() {
  * Create a virtual environment inside .king-context/core/venv.
  */
 function createVenv(projectDir) {
-  const { cmd } = detectPython();
-  const venvPath = path.join(projectDir, '.king-context', 'core', 'venv');
+  const { cmd, args } = detectPython();
+  const venvPath = getVenvPath(projectDir);
 
-  execSync(`${cmd} -m venv "${venvPath}"`, { stdio: 'pipe' });
+  execFileSync(cmd, [...args, '-m', 'venv', venvPath], {
+    stdio: 'pipe',
+    windowsHide: true,
+  });
 }
 
 /**
  * Install king-context package into the project venv.
  */
 function installPackage(projectDir) {
-  const pip = path.join(projectDir, '.king-context', 'core', 'venv', 'bin', 'pip');
+  const python = getVenvPython(projectDir);
 
-  execSync(
-    `"${pip}" install --no-cache-dir git+https://github.com/deandevz/king-context.git`,
-    { stdio: 'pipe', timeout: 300000 }
+  execFileSync(
+    python,
+    ['-m', 'pip', 'install', '--no-cache-dir', 'git+https://github.com/deandevz/king-context.git'],
+    { stdio: 'pipe', timeout: 300000, windowsHide: true }
   );
 }
 
@@ -67,12 +110,32 @@ function installPackage(projectDir) {
  * Upgrade king-context package in the project venv.
  */
 function upgradePackage(projectDir) {
-  const pip = path.join(projectDir, '.king-context', 'core', 'venv', 'bin', 'pip');
+  const python = getVenvPython(projectDir);
 
-  execSync(
-    `"${pip}" install --upgrade --force-reinstall --no-deps --no-cache-dir git+https://github.com/deandevz/king-context.git`,
-    { stdio: 'pipe', timeout: 300000 }
+  execFileSync(
+    python,
+    [
+      '-m',
+      'pip',
+      'install',
+      '--upgrade',
+      '--force-reinstall',
+      '--no-deps',
+      '--no-cache-dir',
+      'git+https://github.com/deandevz/king-context.git',
+    ],
+    { stdio: 'pipe', timeout: 300000, windowsHide: true }
   );
 }
 
-module.exports = { detectPython, createVenv, installPackage, upgradePackage };
+module.exports = {
+  detectPython,
+  createVenv,
+  getVenvBinDir,
+  getPythonCandidates,
+  getVenvPath,
+  getVenvPython,
+  installPackage,
+  parsePythonVersion,
+  upgradePackage,
+};

--- a/installer/lib/scaffold.js
+++ b/installer/lib/scaffold.js
@@ -33,23 +33,28 @@ function createDirs(projectDir) {
  * Makes them executable (mode 0o755).
  */
 function writeWrappers(projectDir) {
-  const templatesDir = path.join(__dirname, '..', 'templates');
   const binDir = path.join(projectDir, '.king-context', 'bin');
 
   fs.mkdirSync(binDir, { recursive: true });
 
   const wrappers = [
-    { template: 'wrapper-kctx.sh', target: 'kctx' },
-    { template: 'wrapper-scrape.sh', target: 'king-scrape' },
-    { template: 'wrapper-research.sh', target: 'king-research' },
+    { module: 'context_cli.cli', target: 'kctx' },
+    { module: 'king_context.scraper.cli', target: 'king-scrape' },
+    { module: 'king_context.research.cli', target: 'king-research' },
   ];
 
-  for (const { template, target } of wrappers) {
-    const src = path.join(templatesDir, template);
-    const dest = path.join(binDir, target);
+  for (const { module, target } of wrappers) {
+    const shellPath = path.join(binDir, target);
+    const shellContent = process.platform === 'win32'
+      ? `#!/bin/sh\nSCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexec "$SCRIPT_DIR/../core/venv/Scripts/python.exe" -m ${module} "$@"\n`
+      : `#!/bin/sh\nSCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexec "$SCRIPT_DIR/../core/venv/bin/python" -m ${module} "$@"\n`;
+    fs.writeFileSync(shellPath, shellContent, { mode: 0o755 });
 
-    const content = fs.readFileSync(src, 'utf8');
-    fs.writeFileSync(dest, content, { mode: 0o755 });
+    if (process.platform === 'win32') {
+      const cmdPath = path.join(binDir, `${target}.cmd`);
+      const cmdContent = `@echo off\r\nset SCRIPT_DIR=%~dp0\r\n"%SCRIPT_DIR%..\\core\\venv\\Scripts\\python.exe" -m ${module} %*\r\n`;
+      fs.writeFileSync(cmdPath, cmdContent);
+    }
   }
 }
 

--- a/installer/templates/wrapper-kctx.sh
+++ b/installer/templates/wrapper-kctx.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/kctx" "$@"
+#!/bin/sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/python" -m context_cli.cli "$@"

--- a/installer/templates/wrapper-research.sh
+++ b/installer/templates/wrapper-research.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/king-research" "$@"
+#!/bin/sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/python" -m king_context.research.cli "$@"

--- a/installer/templates/wrapper-scrape.sh
+++ b/installer/templates/wrapper-scrape.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/king-scrape" "$@"
+#!/bin/sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/python" -m king_context.scraper.cli "$@"

--- a/src/king_context/scraper/export.py
+++ b/src/king_context/scraper/export.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-from king_context import seed_data
 from king_context.scraper.enrich import EnrichedChunk
 
 
@@ -48,4 +47,6 @@ def save_and_index(doc_data: dict, output_path: Path, auto_seed: bool = True) ->
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(doc_data, indent=2, ensure_ascii=False))
     if auto_seed:
+        from king_context import seed_data
+
         seed_data.seed_one(output_path)

--- a/tests/test_installer_scaffold.py
+++ b/tests/test_installer_scaffold.py
@@ -215,3 +215,14 @@ def test_doctor_uses_shared_python_detection_contract():
     assert "detectPython" in doctor
     assert "getVenvPython" in doctor
     assert "python3 --version" not in doctor
+
+
+def test_scraper_export_does_not_eagerly_import_seed_data():
+    export_source = Path("src/king_context/scraper/export.py").read_text(encoding="utf-8")
+
+    first_lines = "\n".join(export_source.splitlines()[:8])
+    assert "from king_context import seed_data" not in first_lines
+
+    save_index_pos = export_source.index("def save_and_index")
+    lazy_import_pos = export_source.index("from king_context import seed_data")
+    assert lazy_import_pos > save_index_pos

--- a/tests/test_installer_scaffold.py
+++ b/tests/test_installer_scaffold.py
@@ -104,3 +104,114 @@ Promise.resolve(require(path.join(repoRoot, 'installer/lib/update.js')).run()).c
         "_temp",
     ]:
         assert (king_dir / dirname).is_dir()
+
+
+def test_write_wrappers_uses_python_modules_on_unix(tmp_path):
+    script = """
+const path = require('path');
+const { writeWrappers } = require('./installer/lib/scaffold');
+process.chdir(process.argv[1]);
+writeWrappers(process.argv[1]);
+"""
+
+    subprocess.run(
+        ["node", "-e", script, str(tmp_path)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    kctx = (tmp_path / ".king-context" / "bin" / "kctx").read_text(encoding="utf-8")
+    scrape = (tmp_path / ".king-context" / "bin" / "king-scrape").read_text(encoding="utf-8")
+    research = (tmp_path / ".king-context" / "bin" / "king-research").read_text(encoding="utf-8")
+
+    assert "-m context_cli.cli" in kctx
+    assert "../core/venv/bin/python" in kctx
+    assert "-m king_context.scraper.cli" in scrape
+    assert "-m king_context.research.cli" in research
+
+
+def test_write_wrappers_creates_cmd_shims_on_windows(tmp_path):
+    script = """
+const path = require('path');
+Object.defineProperty(process, 'platform', { value: 'win32' });
+const { writeWrappers } = require('./installer/lib/scaffold');
+process.chdir(process.argv[1]);
+writeWrappers(process.argv[1]);
+"""
+
+    subprocess.run(
+        ["node", "-e", script, str(tmp_path)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    shell_wrapper = (tmp_path / ".king-context" / "bin" / "kctx").read_text(encoding="utf-8")
+    cmd_wrapper = (tmp_path / ".king-context" / "bin" / "kctx.cmd").read_text(encoding="utf-8")
+
+    assert "../core/venv/Scripts/python.exe" in shell_wrapper
+    assert "python.exe" in cmd_wrapper
+    assert "-m context_cli.cli" in cmd_wrapper
+
+
+def test_python_helpers_resolve_platform_specific_venv_paths():
+    script = """
+const path = require('path');
+Object.defineProperty(process, 'platform', { value: 'win32' });
+const { getVenvPath, getVenvBinDir, getVenvPython } = require('./installer/lib/python');
+const projectDir = process.argv[1];
+console.log(JSON.stringify({
+  venv: getVenvPath(projectDir),
+  bin: getVenvBinDir(projectDir),
+  python: getVenvPython(projectDir),
+}));
+"""
+
+    result = subprocess.run(
+        ["node", "-e", script, str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    data = json.loads(result.stdout)
+    assert data["venv"].endswith(".king-context\\core\\venv")
+    assert data["bin"].endswith(".king-context\\core\\venv\\Scripts")
+    assert data["python"].endswith(".king-context\\core\\venv\\Scripts\\python.exe")
+
+
+def test_detect_python_supports_windows_py_launcher():
+    script = """
+const childProcess = require('child_process');
+Object.defineProperty(process, 'platform', { value: 'win32' });
+childProcess.spawnSync = (cmd, args) => {
+  if (cmd === 'py' && args.join(' ') === '-3 --version') {
+    return { status: 0, stdout: '', stderr: 'Python 3.12.4\\n' };
+  }
+  return { status: 1, stdout: '', stderr: '' };
+};
+const { detectPython } = require('./installer/lib/python');
+console.log(JSON.stringify(detectPython()));
+"""
+
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    data = json.loads(result.stdout)
+    assert data["cmd"] == "py"
+    assert data["args"] == ["-3"]
+    assert data["display"] == "py -3"
+    assert data["version"] == "3.12.4"
+
+
+def test_doctor_uses_shared_python_detection_contract():
+    doctor = Path("installer/lib/doctor.js").read_text(encoding="utf-8")
+
+    assert "detectPython" in doctor
+    assert "getVenvPython" in doctor
+    assert "python3 --version" not in doctor

--- a/tests/test_installer_scaffold.py
+++ b/tests/test_installer_scaffold.py
@@ -108,7 +108,7 @@ Promise.resolve(require(path.join(repoRoot, 'installer/lib/update.js')).run()).c
 
 def test_write_wrappers_uses_python_modules_on_unix(tmp_path):
     script = """
-const path = require('path');
+Object.defineProperty(process, 'platform', { value: 'linux' });
 const { writeWrappers } = require('./installer/lib/scaffold');
 process.chdir(process.argv[1]);
 writeWrappers(process.argv[1]);


### PR DESCRIPTION
## Title

`fix(installer): add Windows-aware Python and wrapper handling`

## Summary

This PR adds first-class Windows support to the installer flow used by `king-context`.

The main goal is to stop assuming a Unix-only environment during install, update, and doctor checks. In practice, this means:

- detecting Python using Windows-friendly launchers such as `py -3`;
- resolving virtualenv executables from `Scripts/` on Windows instead of `bin/`;
- invoking `pip` through `python -m pip` instead of hardcoded Unix paths;
- generating `.cmd` wrappers for CLI entrypoints on Windows;
- making the installer and doctor commands use the same Python/runtime contract.

This addresses issue #19, where the installer failed on Windows because parts of the flow assumed a macOS/Linux layout.

It also includes a small follow-up improvement to reduce `king-scrape` CLI startup cost during health checks by lazy-loading indexing code only when export/indexing is actually requested.

## What Changed

### 1. Python detection is now platform-aware

Updated `installer/lib/python.js` so the installer can:

- try `py -3` first on Windows;
- fall back to `python` and `python3` when appropriate;
- validate Python version consistently (`>= 3.10`);
- show Windows install guidance with `winget install Python.Python.3.12`.

### 2. Virtualenv path handling works on Windows

Added shared helpers for:

- `.king-context/core/venv`
- `.king-context/core/venv/Scripts`
- `.king-context/core/venv/Scripts/python.exe`

and preserved the existing Unix behavior using `bin/python`.

These helpers are now reused by installer and doctor logic instead of duplicating path assumptions.

### 3. Installer/update package operations no longer depend on Unix-only binaries

Changed install/upgrade steps to use:

- `python -m pip install ...`
- `python -m pip install --upgrade ...`

instead of directly calling a hardcoded `venv/bin/pip` path.

This makes the flow work across platforms and is also safer for paths containing spaces.

### 4. CLI wrappers are now Windows-aware

Updated wrapper generation in `installer/lib/scaffold.js` so:

- Unix still gets shell wrappers;
- Windows now also gets `.cmd` shims for:
  - `kctx`
  - `king-scrape`
  - `king-research`

The wrappers call the appropriate Python module using the project virtualenv.

### 5. Doctor now validates the same runtime contract used by install

Updated `installer/lib/doctor.js` to:

- use shared Python detection instead of hardcoded `python3 --version`;
- verify the venv using the platform-aware Python path helper;
- prefer `.cmd` wrappers on Windows when checking CLI health.

### 6. Next-step messaging is friendlier on Windows

Updated `installer/lib/init.js` so the post-install instructions use:

- `Copy-Item .king-context/.env.example .env` on Windows
- `cp .king-context/.env.example .env` on Unix

instead of always showing the Unix command.

### 7. `king-scrape` startup is lighter during doctor checks

Updated `src/king_context/scraper/export.py` so `seed_data` is imported lazily inside `save_and_index()`.

This avoids loading indexing/database dependencies during a simple `king-scrape --help`, which reduces startup time and makes the health check path more reliable.

## Testing

Added/updated installer tests in `tests/test_installer_scaffold.py` to cover:

- Unix wrapper generation using Python modules;
- Windows `.cmd` wrapper generation;
- Windows virtualenv path resolution;
- Python detection through the Windows `py -3` launcher;
- doctor using the shared Python detection contract.
- scraper export keeping `seed_data` lazy-loaded.

Test result on Windows:

- `pytest tests/test_installer_scaffold.py -q`
- `9 passed in 0.27s`

## Manual Validation

I also manually validated the core behavior locally by:

- generating wrappers and confirming `kctx.cmd` points to `...\\venv\\Scripts\\python.exe`;
- exercising the `detectPython()` flow with a Windows-style `py -3` response;
- confirming the updated installer paths and wrapper targets are consistent across modules.
- running the installer locally on Windows from a clean test project and verifying `init` + `doctor`.
- measuring `python -m king_context.scraper.cli --help` against the local branch code and confirming startup dropped from ~6.6s to ~0.74s after the lazy import change.

## Notes / Scope

- This PR is intentionally focused on installer/runtime compatibility and does not change the behavior of the core retrieval/search features.
- Existing Unix behavior is preserved.
- Shell wrapper templates were also updated to reflect the module-based invocation style.
