### PR TITLE
feat(cli): ingest local user-provided content into searchable corpora

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -186,30 +186,24 @@ keywords, use cases, and tags.
 
 ## Ingest local user content
 
-Use `kctx ingest` to turn your own local files into a searchable corpus.
+Use `kctx ingest` to turn your own local Markdown files into a searchable corpus.
 
 This is the recommended workflow for:
 
 - personal notes and knowledge banks
 - Markdown guides you wrote yourself
-- plain text archives
-- transcript files such as `.srt` and `.vtt`
+- curated Markdown references you want to query through `kctx`
 
 The current implementation supports:
 
 - `.md`
-- `.txt`
-- `.srt`
-- `.vtt`
-- `.pdf` when `pypdf` is installed in the active Python environment
 
 Examples:
 
 ```bash
 kctx ingest ./notes --name my-bank
-kctx ingest ./transcripts --name youtube-bank
 kctx ingest ./notes/agent-memory.md --name agent-memory-notes
-kctx ingest ./dropbox --source research --name custom-research-bank
+kctx ingest ./notes/research.md --source research --name custom-research-bank
 kctx ingest ./notes --name my-bank --no-auto-index
 ```
 
@@ -219,10 +213,6 @@ Flags:
 - `--name <slug>`: override the corpus slug.
 - `--display-name <name>`: override the display name.
 - `--source docs|research`: choose the target store. The default is `docs`.
-- `--chunk-max-tokens N`: maximum section size before subdivision. The default
-  is `800`.
-- `--chunk-min-tokens N`: minimum chunk size before merging. The default is
-  `50`.
 - `--no-auto-index`: export JSON only, without indexing it into the store.
 
 `kctx ingest` writes JSON to:
@@ -234,22 +224,24 @@ By default it also indexes the generated corpus immediately, so it becomes
 searchable through `kctx search`, `kctx read`, `kctx grep`, and `kctx topics`
 right away.
 
+`kctx ingest` reuses the same enrichment pipeline as `king-scrape`, so
+generated sections get search-friendly keywords, use cases, tags, and
+priority scores from the existing metadata model. This means
+`OPENROUTER_API_KEY` must be available before ingesting content.
+
 Each generated section keeps source metadata such as:
 
 - `source_type`
 - `source_file`
-- `source_format`
-- `source_collection`
-- `source_kind`
 
-This makes user-provided corpora easier to inspect, debug, and extend later in
-the UI or other retrieval flows.
+This keeps user-provided corpora easy to inspect while preserving the same
+search quality expectations as scraped documentation.
 
 When you ingest a directory, the command also applies a few safe defaults:
 
-- ignores hidden files such as `.draft.txt`
+- ignores hidden files such as `.draft.md`
 - ignores common heavy directories such as `.git`, `node_modules`, and `.venv`
-- ignores clearly unsupported binary files such as `.png`, `.zip`, and `.mp4`
+- ignores unsupported files such as `.txt`, `.pdf`, and `.png`
 
 The CLI prints a short ingestion summary so you can see:
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -195,12 +195,13 @@ This is the recommended workflow for:
 - plain text archives
 - transcript files such as `.srt` and `.vtt`
 
-The MVP supports:
+The current implementation supports:
 
 - `.md`
 - `.txt`
 - `.srt`
 - `.vtt`
+- `.pdf` when `pypdf` is installed in the active Python environment
 
 Examples:
 
@@ -232,6 +233,30 @@ Flags:
 By default it also indexes the generated corpus immediately, so it becomes
 searchable through `kctx search`, `kctx read`, `kctx grep`, and `kctx topics`
 right away.
+
+Each generated section keeps source metadata such as:
+
+- `source_type`
+- `source_file`
+- `source_format`
+- `source_collection`
+- `source_kind`
+
+This makes user-provided corpora easier to inspect, debug, and extend later in
+the UI or other retrieval flows.
+
+When you ingest a directory, the command also applies a few safe defaults:
+
+- ignores hidden files such as `.draft.txt`
+- ignores common heavy directories such as `.git`, `node_modules`, and `.venv`
+- ignores clearly unsupported binary files such as `.png`, `.zip`, and `.mp4`
+
+The CLI prints a short ingestion summary so you can see:
+
+- how many files were scanned
+- how many supported files were ingested
+- how many files were ignored
+- which unsupported extensions were skipped
 
 ## Manage architectural decisions
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -184,6 +184,55 @@ Flags:
 The indexer writes one directory per corpus and builds reverse indexes for
 keywords, use cases, and tags.
 
+## Ingest local user content
+
+Use `kctx ingest` to turn your own local files into a searchable corpus.
+
+This is the recommended workflow for:
+
+- personal notes and knowledge banks
+- Markdown guides you wrote yourself
+- plain text archives
+- transcript files such as `.srt` and `.vtt`
+
+The MVP supports:
+
+- `.md`
+- `.txt`
+- `.srt`
+- `.vtt`
+
+Examples:
+
+```bash
+kctx ingest ./notes --name my-bank
+kctx ingest ./transcripts --name youtube-bank
+kctx ingest ./notes/agent-memory.md --name agent-memory-notes
+kctx ingest ./dropbox --source research --name custom-research-bank
+kctx ingest ./notes --name my-bank --no-auto-index
+```
+
+Flags:
+
+- `path`: file or directory to ingest.
+- `--name <slug>`: override the corpus slug.
+- `--display-name <name>`: override the display name.
+- `--source docs|research`: choose the target store. The default is `docs`.
+- `--chunk-max-tokens N`: maximum section size before subdivision. The default
+  is `800`.
+- `--chunk-min-tokens N`: minimum chunk size before merging. The default is
+  `50`.
+- `--no-auto-index`: export JSON only, without indexing it into the store.
+
+`kctx ingest` writes JSON to:
+
+- `.king-context/data/<name>.json` for `docs`
+- `.king-context/data/research/<name>.json` for `research`
+
+By default it also indexes the generated corpus immediately, so it becomes
+searchable through `kctx search`, `kctx read`, `kctx grep`, and `kctx topics`
+right away.
+
 ## Manage architectural decisions
 
 Use `kctx adr` to record and retrieve architectural decision records. ADRs are

--- a/installer/templates/claude-md-snippet.md
+++ b/installer/templates/claude-md-snippet.md
@@ -18,7 +18,7 @@ Documentation search and scraping tools are available in this project.
 # Index documentation
 .king-context/bin/kctx index .king-context/data/<file>.json   # index one doc
 .king-context/bin/kctx index --all                            # index all docs
-.king-context/bin/kctx ingest ./notes --name my-bank          # ingest local notes, transcripts, or PDFs
+.king-context/bin/kctx ingest ./notes --name my-bank          # ingest local Markdown notes
 
 # Scrape new documentation
 .king-context/bin/king-scrape <url>                      # full pipeline
@@ -30,7 +30,7 @@ Documentation search and scraping tools are available in this project.
 
 - API keys: copy `.king-context/.env.example` to `.env` and fill in your keys
 - `FIRECRAWL_API_KEY` (required for scraping)
-- `OPENROUTER_API_KEY` (optional, for automated enrichment)
+- `OPENROUTER_API_KEY` (required for scraping enrichment and kctx ingest)
 
 ### Directory Structure
 

--- a/installer/templates/claude-md-snippet.md
+++ b/installer/templates/claude-md-snippet.md
@@ -18,7 +18,7 @@ Documentation search and scraping tools are available in this project.
 # Index documentation
 .king-context/bin/kctx index .king-context/data/<file>.json   # index one doc
 .king-context/bin/kctx index --all                            # index all docs
-.king-context/bin/kctx ingest ./notes --name my-bank          # ingest local notes/transcripts
+.king-context/bin/kctx ingest ./notes --name my-bank          # ingest local notes, transcripts, or PDFs
 
 # Scrape new documentation
 .king-context/bin/king-scrape <url>                      # full pipeline

--- a/installer/templates/claude-md-snippet.md
+++ b/installer/templates/claude-md-snippet.md
@@ -18,6 +18,7 @@ Documentation search and scraping tools are available in this project.
 # Index documentation
 .king-context/bin/kctx index .king-context/data/<file>.json   # index one doc
 .king-context/bin/kctx index --all                            # index all docs
+.king-context/bin/kctx ingest ./notes --name my-bank          # ingest local notes/transcripts
 
 # Scrape new documentation
 .king-context/bin/king-scrape <url>                      # full pipeline

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -258,19 +258,16 @@ def _cmd_ingest(args: argparse.Namespace) -> None:
         print(f"Path not found: {args.path}", file=sys.stderr)
         sys.exit(1)
 
-    ingest_mod.PROJECT_ROOT = PROJECT_ROOT
-    ingest_mod.STORE_DIR = STORE_DIR
-    ingest_mod.RESEARCH_STORE_DIR = RESEARCH_STORE_DIR
-
     try:
         result = ingest_mod.ingest_path(
             input_path,
             name=args.name,
             display_name=args.display_name,
             source=args.source,
-            chunk_max_tokens=args.chunk_max_tokens,
-            chunk_min_tokens=args.chunk_min_tokens,
             auto_index=not args.no_auto_index,
+            project_root=PROJECT_ROOT,
+            store_dir=STORE_DIR,
+            research_store_dir=RESEARCH_STORE_DIR,
         )
     except (FileNotFoundError, RuntimeError) as exc:
         print(str(exc), file=sys.stderr)
@@ -384,20 +381,6 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("docs", "research"),
         default="docs",
         help="Target store for the ingested corpus (default: docs)",
-    )
-    p_ingest.add_argument(
-        "--chunk-max-tokens",
-        dest="chunk_max_tokens",
-        type=int,
-        default=800,
-        help="Maximum tokens per generated section (default: 800)",
-    )
-    p_ingest.add_argument(
-        "--chunk-min-tokens",
-        dest="chunk_min_tokens",
-        type=int,
-        default=50,
-        help="Minimum chunk size before merging (default: 50)",
     )
     p_ingest.add_argument(
         "--no-auto-index",

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -262,19 +262,32 @@ def _cmd_ingest(args: argparse.Namespace) -> None:
     ingest_mod.STORE_DIR = STORE_DIR
     ingest_mod.RESEARCH_STORE_DIR = RESEARCH_STORE_DIR
 
-    result = ingest_mod.ingest_path(
-        input_path,
-        name=args.name,
-        display_name=args.display_name,
-        source=args.source,
-        chunk_max_tokens=args.chunk_max_tokens,
-        chunk_min_tokens=args.chunk_min_tokens,
-        auto_index=not args.no_auto_index,
-    )
+    try:
+        result = ingest_mod.ingest_path(
+            input_path,
+            name=args.name,
+            display_name=args.display_name,
+            source=args.source,
+            chunk_max_tokens=args.chunk_max_tokens,
+            chunk_min_tokens=args.chunk_min_tokens,
+            auto_index=not args.no_auto_index,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
     status = "and indexed" if result.indexed else "without indexing"
     print(
         f"Ingested {result.doc_name} ({result.store_label}): "
         f"{result.section_count} sections from {result.source_file_count} file(s) {status}"
+    )
+    print(
+        f"Scanned {result.discovered_file_count} file(s); "
+        f"ignored {result.ignored_file_count}"
+        + (
+            f" ({', '.join(result.ignored_extensions)})"
+            if result.ignored_extensions
+            else ""
+        )
     )
     print(f"Saved JSON: {result.json_path}")
 
@@ -361,7 +374,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # ingest
     p_ingest = subparsers.add_parser(
         "ingest",
-        help="Ingest local user-provided text content into a searchable corpus",
+        help="Ingest local user-provided files into a searchable corpus",
     )
     p_ingest.add_argument("path", help="Path to a file or directory")
     p_ingest.add_argument("--name", default=None, help="Corpus slug override")

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from context_cli import PROJECT_ROOT, RESEARCH_STORE_DIR, STORE_DIR
 from context_cli import adr
+import context_cli.ingest as ingest_mod
 from context_cli.formatter import (
     format_grep,
     format_list,
@@ -251,6 +252,33 @@ def _cmd_index(args: argparse.Namespace) -> None:
         print(f"Indexed {result.doc_name} ({label}): {result.section_count} sections")
 
 
+def _cmd_ingest(args: argparse.Namespace) -> None:
+    input_path = Path(args.path)
+    if not input_path.exists():
+        print(f"Path not found: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    ingest_mod.PROJECT_ROOT = PROJECT_ROOT
+    ingest_mod.STORE_DIR = STORE_DIR
+    ingest_mod.RESEARCH_STORE_DIR = RESEARCH_STORE_DIR
+
+    result = ingest_mod.ingest_path(
+        input_path,
+        name=args.name,
+        display_name=args.display_name,
+        source=args.source,
+        chunk_max_tokens=args.chunk_max_tokens,
+        chunk_min_tokens=args.chunk_min_tokens,
+        auto_index=not args.no_auto_index,
+    )
+    status = "and indexed" if result.indexed else "without indexing"
+    print(
+        f"Ingested {result.doc_name} ({result.store_label}): "
+        f"{result.section_count} sections from {result.source_file_count} file(s) {status}"
+    )
+    print(f"Saved JSON: {result.json_path}")
+
+
 def _add_source_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--source",
@@ -329,6 +357,42 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Force routing to a specific store (default: auto-detect from source_type)",
     )
     p_index.set_defaults(func=_cmd_index)
+
+    # ingest
+    p_ingest = subparsers.add_parser(
+        "ingest",
+        help="Ingest local user-provided text content into a searchable corpus",
+    )
+    p_ingest.add_argument("path", help="Path to a file or directory")
+    p_ingest.add_argument("--name", default=None, help="Corpus slug override")
+    p_ingest.add_argument("--display-name", default=None, help="Display name override")
+    p_ingest.add_argument(
+        "--source",
+        choices=("docs", "research"),
+        default="docs",
+        help="Target store for the ingested corpus (default: docs)",
+    )
+    p_ingest.add_argument(
+        "--chunk-max-tokens",
+        dest="chunk_max_tokens",
+        type=int,
+        default=800,
+        help="Maximum tokens per generated section (default: 800)",
+    )
+    p_ingest.add_argument(
+        "--chunk-min-tokens",
+        dest="chunk_min_tokens",
+        type=int,
+        default=50,
+        help="Minimum chunk size before merging (default: 50)",
+    )
+    p_ingest.add_argument(
+        "--no-auto-index",
+        dest="no_auto_index",
+        action="store_true",
+        help="Export JSON only, without indexing into the local store",
+    )
+    p_ingest.set_defaults(func=_cmd_ingest)
 
     adr.add_subparser(subparsers)
 

--- a/src/context_cli/indexer.py
+++ b/src/context_cli/indexer.py
@@ -65,6 +65,15 @@ def index_doc(json_path: Path, store_dir: Path) -> IndexResult:
             "content": content,
             "token_estimate": _estimate_tokens(content),
         }
+        for key in (
+            "source_type",
+            "source_file",
+            "source_format",
+            "source_collection",
+            "source_kind",
+        ):
+            if key in section:
+                section_data[key] = section[key]
         (sections_dir / f"{path}.json").write_text(
             json.dumps(section_data, indent=2)
         )

--- a/src/context_cli/indexer.py
+++ b/src/context_cli/indexer.py
@@ -65,13 +65,7 @@ def index_doc(json_path: Path, store_dir: Path) -> IndexResult:
             "content": content,
             "token_estimate": _estimate_tokens(content),
         }
-        for key in (
-            "source_type",
-            "source_file",
-            "source_format",
-            "source_collection",
-            "source_kind",
-        ):
+        for key in ("source_type", "source_file"):
             if key in section:
                 section_data[key] = section[key]
         (sections_dir / f"{path}.json").write_text(

--- a/src/context_cli/ingest.py
+++ b/src/context_cli/ingest.py
@@ -1,0 +1,321 @@
+"""Ingest local user-provided text content into King Context JSON corpora."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from context_cli import PROJECT_ROOT, RESEARCH_STORE_DIR, STORE_DIR
+from context_cli.indexer import index_doc
+
+
+SUPPORTED_EXTENSIONS = {".md", ".txt", ".srt", ".vtt"}
+TRANSCRIPT_EXTENSIONS = {".srt", ".vtt"}
+
+
+@dataclass
+class IngestResult:
+    doc_name: str
+    display_name: str
+    json_path: Path
+    store_label: str
+    source_file_count: int
+    section_count: int
+    indexed: bool
+
+
+def _slugify(text: str) -> str:
+    slug = text.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug or "content"
+
+
+def _titleize_slug(slug: str) -> str:
+    return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part)
+
+
+def _read_text_file(path: Path) -> str:
+    for encoding in ("utf-8", "utf-8-sig", "latin-1"):
+        try:
+            return path.read_text(encoding=encoding)
+        except UnicodeDecodeError:
+            continue
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def _supported_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path] if path.suffix.lower() in SUPPORTED_EXTENSIONS else []
+
+    if not path.is_dir():
+        return []
+
+    files = [
+        candidate
+        for candidate in sorted(path.rglob("*"))
+        if candidate.is_file() and candidate.suffix.lower() in SUPPORTED_EXTENSIONS
+    ]
+    return files
+
+
+def _relative_label(base_path: Path, file_path: Path) -> str:
+    if base_path.is_dir():
+        rel = file_path.relative_to(base_path)
+    else:
+        rel = Path(file_path.name)
+    return rel.as_posix()
+
+
+def _file_title(file_path: Path, relative_label: str) -> str:
+    stem = Path(relative_label).stem.replace("_", " ").replace("-", " ").strip()
+    if stem:
+        return " ".join(word.capitalize() for word in stem.split())
+    return file_path.stem or "Content"
+
+
+def _build_markdown(ext: str, title: str, content: str) -> str:
+    if ext == ".md":
+        return content
+    return f"## {title}\n\n{content.strip()}\n"
+
+
+def _tags_for_extension(ext: str) -> list[str]:
+    if ext == ".md":
+        return ["user-content", "markdown"]
+    if ext in TRANSCRIPT_EXTENSIONS:
+        return ["user-content", "transcript"]
+    return ["user-content", "text"]
+
+
+def _keywords_for_chunk(relative_label: str, title: str, ext: str) -> list[str]:
+    raw_parts = [relative_label, title, ext.lstrip(".")]
+    text = " ".join(raw_parts).lower()
+    words = re.findall(r"[a-z0-9]{3,}", text)
+    seen: list[str] = []
+    for word in words:
+        if word not in seen:
+            seen.append(word)
+    return seen[:12] or ["content"]
+
+
+def _use_case_for_file(relative_label: str) -> list[str]:
+    return [f"Reference user-provided content from {relative_label}"]
+
+
+def _estimate_tokens(text: str) -> int:
+    return int(len(text.split()) * 1.33)
+
+
+def _split_paragraphs(content: str) -> list[str]:
+    return [part.strip() for part in re.split(r"\n\s*\n+", content) if part.strip()]
+
+
+def _split_markdown_sections(markdown: str, fallback_title: str) -> list[tuple[str, str]]:
+    lines = markdown.splitlines()
+    splits: list[tuple[int, str]] = []
+    in_code_block = False
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+        if in_code_block:
+            continue
+        if line.startswith("### "):
+            splits.append((idx, line[4:].strip()))
+        elif line.startswith("## "):
+            splits.append((idx, line[3:].strip()))
+
+    if not splits:
+        content = markdown.strip()
+        return [(fallback_title, content)] if content else []
+
+    sections: list[tuple[str, str]] = []
+    for idx, (start_line, title) in enumerate(splits):
+        end_line = splits[idx + 1][0] if idx + 1 < len(splits) else len(lines)
+        content = "\n".join(lines[start_line + 1:end_line]).strip()
+        if content:
+            sections.append((title or fallback_title, content))
+    return sections
+
+
+def _subdivide_content(title: str, content: str, chunk_max_tokens: int) -> list[tuple[str, str]]:
+    if _estimate_tokens(content) <= chunk_max_tokens:
+        return [(title, content)]
+
+    paragraphs = _split_paragraphs(content)
+    if len(paragraphs) <= 1:
+        return [(title, content)]
+
+    parts: list[tuple[str, str]] = []
+    current = ""
+
+    for paragraph in paragraphs:
+        candidate = f"{current}\n\n{paragraph}".strip() if current else paragraph
+        if _estimate_tokens(candidate) > chunk_max_tokens and current:
+            parts.append((title, current.strip()))
+            current = paragraph
+        else:
+            current = candidate
+
+    if current.strip():
+        parts.append((title, current.strip()))
+    return parts or [(title, content)]
+
+
+def _merge_small_sections(
+    sections: list[tuple[str, str]],
+    chunk_min_tokens: int,
+) -> list[tuple[str, str]]:
+    merged: list[tuple[str, str]] = []
+    for title, content in sections:
+        if _estimate_tokens(content) < chunk_min_tokens and merged:
+            prev_title, prev_content = merged[-1]
+            merged[-1] = (prev_title, f"{prev_content}\n\n{content}".strip())
+        else:
+            merged.append((title, content))
+    return merged
+
+
+def _sections_from_file(
+    file_path: Path,
+    base_path: Path,
+    chunk_max_tokens: int,
+    chunk_min_tokens: int,
+) -> list[dict]:
+    relative_label = _relative_label(base_path, file_path)
+    title = _file_title(file_path, relative_label)
+    content = _read_text_file(file_path).strip()
+    if not content:
+        return []
+
+    markdown = _build_markdown(file_path.suffix.lower(), title, content)
+    raw_sections = _split_markdown_sections(markdown, title)
+    sized_sections: list[tuple[str, str]] = []
+    for section_title, section_content in raw_sections:
+        sized_sections.extend(_subdivide_content(section_title, section_content, chunk_max_tokens))
+    chunks = _merge_small_sections(sized_sections, chunk_min_tokens)
+
+    if not chunks:
+        return []
+
+    file_slug = _slugify(Path(relative_label).with_suffix("").as_posix())
+    tags = _tags_for_extension(file_path.suffix.lower())
+    use_cases = _use_case_for_file(relative_label)
+
+    sections: list[dict] = []
+    used_paths: set[str] = set()
+
+    for idx, (section_title, section_content) in enumerate(chunks, 1):
+        section_slug = _slugify(section_title)
+        path = file_slug if len(chunks) == 1 else f"{file_slug}-{section_slug}"
+        if path in used_paths:
+            path = f"{path}-{idx}"
+        used_paths.add(path)
+
+        sections.append(
+            {
+                "title": section_title,
+                "path": path,
+                "url": relative_label,
+                "keywords": _keywords_for_chunk(relative_label, section_title, file_path.suffix.lower()),
+                "use_cases": use_cases,
+                "tags": tags,
+                "priority": 5,
+                "content": section_content.strip(),
+            }
+        )
+
+    return sections
+
+
+def build_user_corpus(
+    input_path: Path,
+    *,
+    name: str | None = None,
+    display_name: str | None = None,
+    source: str = "docs",
+    chunk_max_tokens: int = 800,
+    chunk_min_tokens: int = 50,
+) -> tuple[dict, int]:
+    files = _supported_files(input_path)
+    if not files:
+        raise FileNotFoundError(
+            f"No supported files found under {input_path}. "
+            "Supported extensions: .md, .txt, .srt, .vtt"
+        )
+
+    doc_name = name or _slugify(input_path.stem if input_path.is_file() else input_path.name)
+    doc_display_name = display_name or _titleize_slug(doc_name)
+
+    sections: list[dict] = []
+    for file_path in files:
+        sections.extend(
+            _sections_from_file(
+                file_path,
+                base_path=input_path,
+                chunk_max_tokens=chunk_max_tokens,
+                chunk_min_tokens=chunk_min_tokens,
+            )
+        )
+
+    if source == "research":
+        for section in sections:
+            section["source_type"] = "research"
+
+    data = {
+        "name": doc_name,
+        "display_name": doc_display_name,
+        "version": "v1",
+        "base_url": "",
+        "sections": sections,
+    }
+    return data, len(files)
+
+
+def ingest_path(
+    input_path: Path,
+    *,
+    name: str | None = None,
+    display_name: str | None = None,
+    source: str = "docs",
+    chunk_max_tokens: int = 800,
+    chunk_min_tokens: int = 50,
+    auto_index: bool = True,
+) -> IngestResult:
+    source = "research" if source == "research" else "docs"
+    doc_data, file_count = build_user_corpus(
+        input_path,
+        name=name,
+        display_name=display_name,
+        source=source,
+        chunk_max_tokens=chunk_max_tokens,
+        chunk_min_tokens=chunk_min_tokens,
+    )
+
+    if source == "research":
+        json_path = PROJECT_ROOT / ".king-context" / "data" / "research" / f"{doc_data['name']}.json"
+        store_dir = RESEARCH_STORE_DIR
+    else:
+        json_path = PROJECT_ROOT / ".king-context" / "data" / f"{doc_data['name']}.json"
+        store_dir = STORE_DIR
+
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(doc_data, indent=2, ensure_ascii=False))
+
+    if auto_index:
+        store_dir.mkdir(parents=True, exist_ok=True)
+        index_doc(json_path, store_dir)
+
+    return IngestResult(
+        doc_name=doc_data["name"],
+        display_name=doc_data["display_name"],
+        json_path=json_path,
+        store_label=source,
+        source_file_count=file_count,
+        section_count=len(doc_data["sections"]),
+        indexed=auto_index,
+    )

--- a/src/context_cli/ingest.py
+++ b/src/context_cli/ingest.py
@@ -1,8 +1,9 @@
-"""Ingest local user-provided text content into King Context JSON corpora."""
+"""Ingest local user-provided content into King Context JSON corpora."""
 
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,8 +12,54 @@ from context_cli import PROJECT_ROOT, RESEARCH_STORE_DIR, STORE_DIR
 from context_cli.indexer import index_doc
 
 
-SUPPORTED_EXTENSIONS = {".md", ".txt", ".srt", ".vtt"}
+SUPPORTED_EXTENSIONS = {".md", ".txt", ".srt", ".vtt", ".pdf"}
 TRANSCRIPT_EXTENSIONS = {".srt", ".vtt"}
+IGNORED_DIR_NAMES = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "dist",
+    "build",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+IGNORED_FILE_PREFIXES = (".", "~$")
+BINARY_EXTENSIONS = {
+    ".7z",
+    ".bin",
+    ".class",
+    ".dll",
+    ".dylib",
+    ".exe",
+    ".gif",
+    ".gz",
+    ".ico",
+    ".jar",
+    ".jpeg",
+    ".jpg",
+    ".mp3",
+    ".mp4",
+    ".mov",
+    ".png",
+    ".pyc",
+    ".so",
+    ".tar",
+    ".wav",
+    ".webm",
+    ".zip",
+}
+
+
+@dataclass
+class FileDiscovery:
+    files: list[Path]
+    discovered_count: int
+    ignored_count: int
+    ignored_extensions: list[str]
 
 
 @dataclass
@@ -22,6 +69,9 @@ class IngestResult:
     json_path: Path
     store_label: str
     source_file_count: int
+    discovered_file_count: int
+    ignored_file_count: int
+    ignored_extensions: list[str]
     section_count: int
     indexed: bool
 
@@ -46,19 +96,92 @@ def _read_text_file(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
-def _supported_files(path: Path) -> list[Path]:
+def _read_pdf_file(path: Path) -> str:
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:
+        raise RuntimeError(
+            "PDF ingestion requires the 'pypdf' package. "
+            "Install a build of king-context with PDF support, or run: pip install pypdf"
+        ) from exc
+
+    reader = PdfReader(str(path))
+    pages: list[str] = []
+    for page in reader.pages:
+        text = (page.extract_text() or "").strip()
+        if text:
+            pages.append(text)
+    return "\n\n".join(pages)
+
+
+def _read_file_content(path: Path) -> str:
+    if path.suffix.lower() == ".pdf":
+        return _read_pdf_file(path)
+    return _read_text_file(path)
+
+
+def _classify_extension(ext: str) -> str:
+    if ext == ".md":
+        return "markdown"
+    if ext in TRANSCRIPT_EXTENSIONS:
+        return "transcript"
+    if ext == ".pdf":
+        return "pdf"
+    return "text"
+
+
+def _should_ignore_file_name(file_name: str) -> bool:
+    return file_name.startswith(IGNORED_FILE_PREFIXES)
+
+
+def _supported_files(path: Path) -> FileDiscovery:
     if path.is_file():
-        return [path] if path.suffix.lower() in SUPPORTED_EXTENSIONS else []
+        ext = path.suffix.lower()
+        if ext in SUPPORTED_EXTENSIONS:
+            return FileDiscovery(files=[path], discovered_count=1, ignored_count=0, ignored_extensions=[])
+        return FileDiscovery(files=[], discovered_count=1, ignored_count=1, ignored_extensions=[ext or "<none>"])
 
     if not path.is_dir():
-        return []
+        return FileDiscovery(files=[], discovered_count=0, ignored_count=0, ignored_extensions=[])
 
-    files = [
-        candidate
-        for candidate in sorted(path.rglob("*"))
-        if candidate.is_file() and candidate.suffix.lower() in SUPPORTED_EXTENSIONS
-    ]
-    return files
+    files: list[Path] = []
+    discovered_count = 0
+    ignored_count = 0
+    ignored_extensions: set[str] = set()
+
+    for root, dir_names, file_names in os.walk(path, topdown=True):
+        dir_names[:] = [
+            name
+            for name in dir_names
+            if name not in IGNORED_DIR_NAMES and not name.startswith(".")
+        ]
+
+        root_path = Path(root)
+        for file_name in sorted(file_names):
+            discovered_count += 1
+            if _should_ignore_file_name(file_name):
+                ignored_count += 1
+                ignored_extensions.add("<hidden>")
+                continue
+
+            candidate = root_path / file_name
+            ext = candidate.suffix.lower()
+            if ext in SUPPORTED_EXTENSIONS:
+                files.append(candidate)
+                continue
+
+            ignored_count += 1
+            if ext in BINARY_EXTENSIONS:
+                ignored_extensions.add(ext)
+            else:
+                ignored_extensions.add(ext or "<none>")
+
+    return FileDiscovery(
+        files=sorted(files),
+        discovered_count=discovered_count,
+        ignored_count=ignored_count,
+        ignored_extensions=sorted(ignored_extensions),
+    )
 
 
 def _relative_label(base_path: Path, file_path: Path) -> str:
@@ -83,11 +206,10 @@ def _build_markdown(ext: str, title: str, content: str) -> str:
 
 
 def _tags_for_extension(ext: str) -> list[str]:
-    if ext == ".md":
-        return ["user-content", "markdown"]
-    if ext in TRANSCRIPT_EXTENSIONS:
+    kind = _classify_extension(ext)
+    if kind == "transcript":
         return ["user-content", "transcript"]
-    return ["user-content", "text"]
+    return ["user-content", kind]
 
 
 def _keywords_for_chunk(relative_label: str, title: str, ext: str) -> list[str]:
@@ -182,17 +304,22 @@ def _merge_small_sections(
 
 def _sections_from_file(
     file_path: Path,
+    *,
     base_path: Path,
+    collection_name: str,
+    source: str,
     chunk_max_tokens: int,
     chunk_min_tokens: int,
 ) -> list[dict]:
     relative_label = _relative_label(base_path, file_path)
     title = _file_title(file_path, relative_label)
-    content = _read_text_file(file_path).strip()
+    content = _read_file_content(file_path).strip()
     if not content:
         return []
 
-    markdown = _build_markdown(file_path.suffix.lower(), title, content)
+    ext = file_path.suffix.lower()
+    source_kind = _classify_extension(ext)
+    markdown = _build_markdown(ext, title, content)
     raw_sections = _split_markdown_sections(markdown, title)
     sized_sections: list[tuple[str, str]] = []
     for section_title, section_content in raw_sections:
@@ -203,7 +330,7 @@ def _sections_from_file(
         return []
 
     file_slug = _slugify(Path(relative_label).with_suffix("").as_posix())
-    tags = _tags_for_extension(file_path.suffix.lower())
+    tags = _tags_for_extension(ext)
     use_cases = _use_case_for_file(relative_label)
 
     sections: list[dict] = []
@@ -221,11 +348,16 @@ def _sections_from_file(
                 "title": section_title,
                 "path": path,
                 "url": relative_label,
-                "keywords": _keywords_for_chunk(relative_label, section_title, file_path.suffix.lower()),
+                "keywords": _keywords_for_chunk(relative_label, section_title, ext),
                 "use_cases": use_cases,
                 "tags": tags,
                 "priority": 5,
                 "content": section_content.strip(),
+                "source_type": "research" if source == "research" else "user-content",
+                "source_file": relative_label,
+                "source_format": ext.lstrip(".") or "text",
+                "source_collection": collection_name,
+                "source_kind": source_kind,
             }
         )
 
@@ -240,31 +372,29 @@ def build_user_corpus(
     source: str = "docs",
     chunk_max_tokens: int = 800,
     chunk_min_tokens: int = 50,
-) -> tuple[dict, int]:
-    files = _supported_files(input_path)
-    if not files:
+) -> tuple[dict, FileDiscovery]:
+    discovery = _supported_files(input_path)
+    if not discovery.files:
         raise FileNotFoundError(
             f"No supported files found under {input_path}. "
-            "Supported extensions: .md, .txt, .srt, .vtt"
+            "Supported extensions: .md, .txt, .srt, .vtt, .pdf"
         )
 
     doc_name = name or _slugify(input_path.stem if input_path.is_file() else input_path.name)
     doc_display_name = display_name or _titleize_slug(doc_name)
 
     sections: list[dict] = []
-    for file_path in files:
+    for file_path in discovery.files:
         sections.extend(
             _sections_from_file(
                 file_path,
                 base_path=input_path,
+                collection_name=doc_name,
+                source=source,
                 chunk_max_tokens=chunk_max_tokens,
                 chunk_min_tokens=chunk_min_tokens,
             )
         )
-
-    if source == "research":
-        for section in sections:
-            section["source_type"] = "research"
 
     data = {
         "name": doc_name,
@@ -273,7 +403,7 @@ def build_user_corpus(
         "base_url": "",
         "sections": sections,
     }
-    return data, len(files)
+    return data, discovery
 
 
 def ingest_path(
@@ -287,7 +417,7 @@ def ingest_path(
     auto_index: bool = True,
 ) -> IngestResult:
     source = "research" if source == "research" else "docs"
-    doc_data, file_count = build_user_corpus(
+    doc_data, discovery = build_user_corpus(
         input_path,
         name=name,
         display_name=display_name,
@@ -315,7 +445,10 @@ def ingest_path(
         display_name=doc_data["display_name"],
         json_path=json_path,
         store_label=source,
-        source_file_count=file_count,
+        source_file_count=len(discovery.files),
+        discovered_file_count=discovery.discovered_count,
+        ignored_file_count=discovery.ignored_count,
+        ignored_extensions=discovery.ignored_extensions,
         section_count=len(doc_data["sections"]),
         indexed=auto_index,
     )

--- a/src/context_cli/ingest.py
+++ b/src/context_cli/ingest.py
@@ -1,7 +1,8 @@
-"""Ingest local user-provided content into King Context JSON corpora."""
+"""Ingest local Markdown content into King Context JSON corpora."""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -10,10 +11,10 @@ from pathlib import Path
 
 from context_cli import PROJECT_ROOT, RESEARCH_STORE_DIR, STORE_DIR
 from context_cli.indexer import index_doc
+from king_context.scraper.config import load_config
 
 
-SUPPORTED_EXTENSIONS = {".md", ".txt", ".srt", ".vtt", ".pdf"}
-TRANSCRIPT_EXTENSIONS = {".srt", ".vtt"}
+SUPPORTED_EXTENSIONS = {".md"}
 IGNORED_DIR_NAMES = {
     ".git",
     ".hg",
@@ -28,30 +29,6 @@ IGNORED_DIR_NAMES = {
     ".pytest_cache",
 }
 IGNORED_FILE_PREFIXES = (".", "~$")
-BINARY_EXTENSIONS = {
-    ".7z",
-    ".bin",
-    ".class",
-    ".dll",
-    ".dylib",
-    ".exe",
-    ".gif",
-    ".gz",
-    ".ico",
-    ".jar",
-    ".jpeg",
-    ".jpg",
-    ".mp3",
-    ".mp4",
-    ".mov",
-    ".png",
-    ".pyc",
-    ".so",
-    ".tar",
-    ".wav",
-    ".webm",
-    ".zip",
-}
 
 
 @dataclass
@@ -83,10 +60,6 @@ def _slugify(text: str) -> str:
     return slug or "content"
 
 
-def _titleize_slug(slug: str) -> str:
-    return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part)
-
-
 def _read_text_file(path: Path) -> str:
     for encoding in ("utf-8", "utf-8-sig", "latin-1"):
         try:
@@ -96,50 +69,13 @@ def _read_text_file(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
-def _read_pdf_file(path: Path) -> str:
-    try:
-        from pypdf import PdfReader
-    except ImportError as exc:
-        raise RuntimeError(
-            "PDF ingestion requires the 'pypdf' package. "
-            "Install a build of king-context with PDF support, or run: pip install pypdf"
-        ) from exc
-
-    reader = PdfReader(str(path))
-    pages: list[str] = []
-    for page in reader.pages:
-        text = (page.extract_text() or "").strip()
-        if text:
-            pages.append(text)
-    return "\n\n".join(pages)
-
-
-def _read_file_content(path: Path) -> str:
-    if path.suffix.lower() == ".pdf":
-        return _read_pdf_file(path)
-    return _read_text_file(path)
-
-
-def _classify_extension(ext: str) -> str:
-    if ext == ".md":
-        return "markdown"
-    if ext in TRANSCRIPT_EXTENSIONS:
-        return "transcript"
-    if ext == ".pdf":
-        return "pdf"
-    return "text"
-
-
-def _should_ignore_file_name(file_name: str) -> bool:
-    return file_name.startswith(IGNORED_FILE_PREFIXES)
-
-
 def _supported_files(path: Path) -> FileDiscovery:
     if path.is_file():
         ext = path.suffix.lower()
-        if ext in SUPPORTED_EXTENSIONS:
+        if ext in SUPPORTED_EXTENSIONS and not path.name.startswith(IGNORED_FILE_PREFIXES):
             return FileDiscovery(files=[path], discovered_count=1, ignored_count=0, ignored_extensions=[])
-        return FileDiscovery(files=[], discovered_count=1, ignored_count=1, ignored_extensions=[ext or "<none>"])
+        ignored_ext = "<hidden>" if path.name.startswith(IGNORED_FILE_PREFIXES) else (ext or "<none>")
+        return FileDiscovery(files=[], discovered_count=1, ignored_count=1, ignored_extensions=[ignored_ext])
 
     if not path.is_dir():
         return FileDiscovery(files=[], discovered_count=0, ignored_count=0, ignored_extensions=[])
@@ -159,7 +95,7 @@ def _supported_files(path: Path) -> FileDiscovery:
         root_path = Path(root)
         for file_name in sorted(file_names):
             discovered_count += 1
-            if _should_ignore_file_name(file_name):
+            if file_name.startswith(IGNORED_FILE_PREFIXES):
                 ignored_count += 1
                 ignored_extensions.add("<hidden>")
                 continue
@@ -171,10 +107,7 @@ def _supported_files(path: Path) -> FileDiscovery:
                 continue
 
             ignored_count += 1
-            if ext in BINARY_EXTENSIONS:
-                ignored_extensions.add(ext)
-            else:
-                ignored_extensions.add(ext or "<none>")
+            ignored_extensions.add(ext or "<none>")
 
     return FileDiscovery(
         files=sorted(files),
@@ -183,185 +116,50 @@ def _supported_files(path: Path) -> FileDiscovery:
         ignored_extensions=sorted(ignored_extensions),
     )
 
+def _build_chunks(input_path: Path, files: list[Path]) -> tuple[list["Chunk"], list[str]]:
+    from king_context.scraper.chunk import Chunk
 
-def _relative_label(base_path: Path, file_path: Path) -> str:
-    if base_path.is_dir():
-        rel = file_path.relative_to(base_path)
-    else:
-        rel = Path(file_path.name)
-    return rel.as_posix()
+    chunks: list[Chunk] = []
+    relative_labels: list[str] = []
 
-
-def _file_title(file_path: Path, relative_label: str) -> str:
-    stem = Path(relative_label).stem.replace("_", " ").replace("-", " ").strip()
-    if stem:
-        return " ".join(word.capitalize() for word in stem.split())
-    return file_path.stem or "Content"
-
-
-def _build_markdown(ext: str, title: str, content: str) -> str:
-    if ext == ".md":
-        return content
-    return f"## {title}\n\n{content.strip()}\n"
-
-
-def _tags_for_extension(ext: str) -> list[str]:
-    kind = _classify_extension(ext)
-    if kind == "transcript":
-        return ["user-content", "transcript"]
-    return ["user-content", kind]
-
-
-def _keywords_for_chunk(relative_label: str, title: str, ext: str) -> list[str]:
-    raw_parts = [relative_label, title, ext.lstrip(".")]
-    text = " ".join(raw_parts).lower()
-    words = re.findall(r"[a-z0-9]{3,}", text)
-    seen: list[str] = []
-    for word in words:
-        if word not in seen:
-            seen.append(word)
-    return seen[:12] or ["content"]
-
-
-def _use_case_for_file(relative_label: str) -> list[str]:
-    return [f"Reference user-provided content from {relative_label}"]
-
-
-def _estimate_tokens(text: str) -> int:
-    return int(len(text.split()) * 1.33)
-
-
-def _split_paragraphs(content: str) -> list[str]:
-    return [part.strip() for part in re.split(r"\n\s*\n+", content) if part.strip()]
-
-
-def _split_markdown_sections(markdown: str, fallback_title: str) -> list[tuple[str, str]]:
-    lines = markdown.splitlines()
-    splits: list[tuple[int, str]] = []
-    in_code_block = False
-
-    for idx, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("```"):
-            in_code_block = not in_code_block
-        if in_code_block:
+    for file_path in files:
+        content = _read_text_file(file_path).strip()
+        if not content:
             continue
-        if line.startswith("### "):
-            splits.append((idx, line[4:].strip()))
-        elif line.startswith("## "):
-            splits.append((idx, line[3:].strip()))
 
-    if not splits:
-        content = markdown.strip()
-        return [(fallback_title, content)] if content else []
-
-    sections: list[tuple[str, str]] = []
-    for idx, (start_line, title) in enumerate(splits):
-        end_line = splits[idx + 1][0] if idx + 1 < len(splits) else len(lines)
-        content = "\n".join(lines[start_line + 1:end_line]).strip()
-        if content:
-            sections.append((title or fallback_title, content))
-    return sections
-
-
-def _subdivide_content(title: str, content: str, chunk_max_tokens: int) -> list[tuple[str, str]]:
-    if _estimate_tokens(content) <= chunk_max_tokens:
-        return [(title, content)]
-
-    paragraphs = _split_paragraphs(content)
-    if len(paragraphs) <= 1:
-        return [(title, content)]
-
-    parts: list[tuple[str, str]] = []
-    current = ""
-
-    for paragraph in paragraphs:
-        candidate = f"{current}\n\n{paragraph}".strip() if current else paragraph
-        if _estimate_tokens(candidate) > chunk_max_tokens and current:
-            parts.append((title, current.strip()))
-            current = paragraph
+        if input_path.is_dir():
+            relative_label = file_path.relative_to(input_path).as_posix()
         else:
-            current = candidate
+            relative_label = file_path.name
 
-    if current.strip():
-        parts.append((title, current.strip()))
-    return parts or [(title, content)]
+        stem = Path(relative_label).stem.replace("_", " ").replace("-", " ").strip()
+        title = " ".join(word.capitalize() for word in stem.split()) if stem else (file_path.stem or "Content")
+        slug = _slugify(Path(relative_label).with_suffix("").as_posix())
 
-
-def _merge_small_sections(
-    sections: list[tuple[str, str]],
-    chunk_min_tokens: int,
-) -> list[tuple[str, str]]:
-    merged: list[tuple[str, str]] = []
-    for title, content in sections:
-        if _estimate_tokens(content) < chunk_min_tokens and merged:
-            prev_title, prev_content = merged[-1]
-            merged[-1] = (prev_title, f"{prev_content}\n\n{content}".strip())
-        else:
-            merged.append((title, content))
-    return merged
-
-
-def _sections_from_file(
-    file_path: Path,
-    *,
-    base_path: Path,
-    collection_name: str,
-    source: str,
-    chunk_max_tokens: int,
-    chunk_min_tokens: int,
-) -> list[dict]:
-    relative_label = _relative_label(base_path, file_path)
-    title = _file_title(file_path, relative_label)
-    content = _read_file_content(file_path).strip()
-    if not content:
-        return []
-
-    ext = file_path.suffix.lower()
-    source_kind = _classify_extension(ext)
-    markdown = _build_markdown(ext, title, content)
-    raw_sections = _split_markdown_sections(markdown, title)
-    sized_sections: list[tuple[str, str]] = []
-    for section_title, section_content in raw_sections:
-        sized_sections.extend(_subdivide_content(section_title, section_content, chunk_max_tokens))
-    chunks = _merge_small_sections(sized_sections, chunk_min_tokens)
-
-    if not chunks:
-        return []
-
-    file_slug = _slugify(Path(relative_label).with_suffix("").as_posix())
-    tags = _tags_for_extension(ext)
-    use_cases = _use_case_for_file(relative_label)
-
-    sections: list[dict] = []
-    used_paths: set[str] = set()
-
-    for idx, (section_title, section_content) in enumerate(chunks, 1):
-        section_slug = _slugify(section_title)
-        path = file_slug if len(chunks) == 1 else f"{file_slug}-{section_slug}"
-        if path in used_paths:
-            path = f"{path}-{idx}"
-        used_paths.add(path)
-
-        sections.append(
-            {
-                "title": section_title,
-                "path": path,
-                "url": relative_label,
-                "keywords": _keywords_for_chunk(relative_label, section_title, ext),
-                "use_cases": use_cases,
-                "tags": tags,
-                "priority": 5,
-                "content": section_content.strip(),
-                "source_type": "research" if source == "research" else "user-content",
-                "source_file": relative_label,
-                "source_format": ext.lstrip(".") or "text",
-                "source_collection": collection_name,
-                "source_kind": source_kind,
-            }
+        chunks.append(
+            Chunk(
+                title=title,
+                breadcrumb=title,
+                content=content,
+                source_url=relative_label,
+                path=slug,
+                token_count=int(len(content.split()) * 1.33),
+            )
         )
+        relative_labels.append(relative_label)
 
-    return sections
+    return chunks, relative_labels
+
+
+def _enrich_markdown_chunks(chunks: list["Chunk"]) -> list:
+    config = load_config()
+    if not config.openrouter_api_key:
+        raise RuntimeError(
+            "OPENROUTER_API_KEY is required for kctx ingest. "
+            "Add it to .env or .king-context/.env before ingesting content."
+        )
+    from king_context.scraper.enrich import enrich_chunks
+    return asyncio.run(enrich_chunks(chunks, config))
 
 
 def build_user_corpus(
@@ -370,40 +168,55 @@ def build_user_corpus(
     name: str | None = None,
     display_name: str | None = None,
     source: str = "docs",
-    chunk_max_tokens: int = 800,
-    chunk_min_tokens: int = 50,
 ) -> tuple[dict, FileDiscovery]:
     discovery = _supported_files(input_path)
     if not discovery.files:
         raise FileNotFoundError(
-            f"No supported files found under {input_path}. "
-            "Supported extensions: .md, .txt, .srt, .vtt, .pdf"
+            f"No supported files found under {input_path}. Supported extensions: .md"
         )
 
     doc_name = name or _slugify(input_path.stem if input_path.is_file() else input_path.name)
-    doc_display_name = display_name or _titleize_slug(doc_name)
+    doc_display_name = display_name or " ".join(
+        part.capitalize() for part in doc_name.replace("_", "-").split("-") if part
+    )
 
-    sections: list[dict] = []
-    for file_path in discovery.files:
-        sections.extend(
-            _sections_from_file(
-                file_path,
-                base_path=input_path,
-                collection_name=doc_name,
-                source=source,
-                chunk_max_tokens=chunk_max_tokens,
-                chunk_min_tokens=chunk_min_tokens,
-            )
+    chunks, relative_labels = _build_chunks(input_path, discovery.files)
+    if not chunks:
+        raise FileNotFoundError(f"No readable Markdown content found under {input_path}.")
+
+    enriched_chunks = _enrich_markdown_chunks(chunks)
+    if len(enriched_chunks) != len(relative_labels):
+        raise RuntimeError(
+            "Failed to enrich one or more Markdown files during kctx ingest. "
+            "Please try again after checking your OPENROUTER_API_KEY and network access."
+        )
+    source_type = "research" if source == "research" else "user-content"
+    sections = []
+    for chunk, relative_label in zip(enriched_chunks, relative_labels, strict=True):
+        sections.append(
+            {
+                "title": chunk.title,
+                "path": chunk.path,
+                "url": chunk.url,
+                "keywords": chunk.keywords,
+                "use_cases": chunk.use_cases,
+                "tags": chunk.tags,
+                "priority": chunk.priority,
+                "content": chunk.content,
+                "source_type": source_type,
+                "source_file": relative_label,
+            }
         )
 
-    data = {
+    doc_data = {
         "name": doc_name,
         "display_name": doc_display_name,
         "version": "v1",
         "base_url": "",
         "sections": sections,
     }
-    return data, discovery
+
+    return doc_data, discovery
 
 
 def ingest_path(
@@ -412,9 +225,10 @@ def ingest_path(
     name: str | None = None,
     display_name: str | None = None,
     source: str = "docs",
-    chunk_max_tokens: int = 800,
-    chunk_min_tokens: int = 50,
     auto_index: bool = True,
+    project_root: Path = PROJECT_ROOT,
+    store_dir: Path = STORE_DIR,
+    research_store_dir: Path = RESEARCH_STORE_DIR,
 ) -> IngestResult:
     source = "research" if source == "research" else "docs"
     doc_data, discovery = build_user_corpus(
@@ -422,30 +236,28 @@ def ingest_path(
         name=name,
         display_name=display_name,
         source=source,
-        chunk_max_tokens=chunk_max_tokens,
-        chunk_min_tokens=chunk_min_tokens,
     )
 
     if source == "research":
-        json_path = PROJECT_ROOT / ".king-context" / "data" / "research" / f"{doc_data['name']}.json"
-        store_dir = RESEARCH_STORE_DIR
+        json_path = project_root / ".king-context" / "data" / "research" / f"{doc_data['name']}.json"
+        target_store = research_store_dir
     else:
-        json_path = PROJECT_ROOT / ".king-context" / "data" / f"{doc_data['name']}.json"
-        store_dir = STORE_DIR
+        json_path = project_root / ".king-context" / "data" / f"{doc_data['name']}.json"
+        target_store = store_dir
 
     json_path.parent.mkdir(parents=True, exist_ok=True)
     json_path.write_text(json.dumps(doc_data, indent=2, ensure_ascii=False))
 
     if auto_index:
-        store_dir.mkdir(parents=True, exist_ok=True)
-        index_doc(json_path, store_dir)
+        target_store.mkdir(parents=True, exist_ok=True)
+        index_doc(json_path, target_store)
 
     return IngestResult(
         doc_name=doc_data["name"],
         display_name=doc_data["display_name"],
         json_path=json_path,
         store_label=source,
-        source_file_count=len(discovery.files),
+        source_file_count=len(doc_data["sections"]),
         discovered_file_count=discovery.discovered_count,
         ignored_file_count=discovery.ignored_count,
         ignored_extensions=discovery.ignored_extensions,

--- a/src/king_context/scraper/__init__.py
+++ b/src/king_context/scraper/__init__.py
@@ -1,10 +1,6 @@
-from king_context.scraper.config import ScraperConfig, load_config, ConfigError
-from king_context.scraper.discover import discover_urls, DiscoveryResult
-from king_context.scraper.filter import filter_urls, FilterResult
-from king_context.scraper.fetch import fetch_pages, FetchResult, PageResult
-from king_context.scraper.chunk import chunk_page, chunk_pages, Chunk
-from king_context.scraper.enrich import enrich_chunks, EnrichedChunk, validate_enrichment, estimate_cost
-from king_context.scraper.export import export_to_json, save_and_index
+from importlib import import_module
+
+from king_context.scraper.config import ConfigError, ScraperConfig, load_config
 
 __all__ = [
     "ScraperConfig", "load_config", "ConfigError",
@@ -15,3 +11,33 @@ __all__ = [
     "enrich_chunks", "EnrichedChunk", "validate_enrichment", "estimate_cost",
     "export_to_json", "save_and_index",
 ]
+
+
+_EXPORT_MAP = {
+    "discover_urls": ("king_context.scraper.discover", "discover_urls"),
+    "DiscoveryResult": ("king_context.scraper.discover", "DiscoveryResult"),
+    "filter_urls": ("king_context.scraper.filter", "filter_urls"),
+    "FilterResult": ("king_context.scraper.filter", "FilterResult"),
+    "fetch_pages": ("king_context.scraper.fetch", "fetch_pages"),
+    "FetchResult": ("king_context.scraper.fetch", "FetchResult"),
+    "PageResult": ("king_context.scraper.fetch", "PageResult"),
+    "chunk_page": ("king_context.scraper.chunk", "chunk_page"),
+    "chunk_pages": ("king_context.scraper.chunk", "chunk_pages"),
+    "Chunk": ("king_context.scraper.chunk", "Chunk"),
+    "enrich_chunks": ("king_context.scraper.enrich", "enrich_chunks"),
+    "EnrichedChunk": ("king_context.scraper.enrich", "EnrichedChunk"),
+    "validate_enrichment": ("king_context.scraper.enrich", "validate_enrichment"),
+    "estimate_cost": ("king_context.scraper.enrich", "estimate_cost"),
+    "export_to_json": ("king_context.scraper.export", "export_to_json"),
+    "save_and_index": ("king_context.scraper.export", "save_and_index"),
+}
+
+
+def __getattr__(name: str):
+    if name not in _EXPORT_MAP:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = _EXPORT_MAP[name]
+    module = import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/tests/test_context_cli/test_cli.py
+++ b/tests/test_context_cli/test_cli.py
@@ -1,11 +1,25 @@
 """Integration tests for context_cli.cli module."""
 
+import asyncio
 import json
 import sys
+from dataclasses import dataclass
 
 import pytest
 
 from context_cli.indexer import index_doc
+
+
+@dataclass
+class FakeEnrichedChunk:
+    title: str
+    path: str
+    url: str
+    content: str
+    keywords: list[str]
+    use_cases: list[str]
+    tags: list[str]
+    priority: int
 
 
 @pytest.fixture
@@ -62,6 +76,26 @@ def _run_cli(args, monkeypatch):
     from context_cli.cli import main
     monkeypatch.setattr(sys, "argv", ["kctx"] + args)
     main()
+
+
+async def _fake_ingest_enrich(chunks, config, output_dir=None):
+    return [
+        FakeEnrichedChunk(
+            title=chunk.title,
+            path=chunk.path,
+            url=chunk.source_url,
+            content=chunk.content,
+            keywords=["agent", "memory", "retrieval", "context", "notes"],
+            use_cases=["Use when studying agent memory", "Reference when retrieving context"],
+            tags=["notes"],
+            priority=6,
+        )
+        for chunk in chunks
+    ]
+
+
+def _fake_ingest_pipeline(chunks):
+    return asyncio.run(_fake_ingest_enrich(chunks, None))
 
 
 def test_list_shows_docs(store_with_doc, monkeypatch, capsys):
@@ -315,20 +349,41 @@ def test_ingest_directory_into_docs_store(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
     monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
     monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod.ingest_mod, "_enrich_markdown_chunks", _fake_ingest_pipeline)
 
     notes_dir = tmp_path / "notes"
     notes_dir.mkdir()
-    (notes_dir / "guide.md").write_text("## Intro\n\nWelcome to the notes.", encoding="utf-8")
-    (notes_dir / "summary.txt").write_text("Short transcript summary.", encoding="utf-8")
-    (notes_dir / ".draft.txt").write_text("ignore me", encoding="utf-8")
-    (notes_dir / "diagram.png").write_bytes(b"png")
+    (notes_dir / "guide.md").write_text("# Agent Memory\n\nWelcome to the notes.", encoding="utf-8")
+    (notes_dir / "reference.md").write_text("# Retrieval\n\nReference memory flows.", encoding="utf-8")
+    (notes_dir / ".draft.md").write_text("# Hidden\n\nignore me", encoding="utf-8")
+    (notes_dir / "summary.txt").write_text("ignored", encoding="utf-8")
 
     _run_cli(["ingest", str(notes_dir), "--name", "my-bank"], monkeypatch)
     out = capsys.readouterr().out
     assert "Ingested my-bank (docs)" in out
     assert "Scanned 4 file(s); ignored 2" in out
-    assert ".png" in out
+    assert ".txt" in out
     assert (store_dir / "my-bank" / "index.json").exists()
+
+
+def test_ingest_followed_by_search_returns_enriched_results(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
+    monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod.ingest_mod, "_enrich_markdown_chunks", _fake_ingest_pipeline)
+
+    note = tmp_path / "agent-memory.md"
+    note.write_text("# Agent Memory\n\nKeep retrieval notes here.", encoding="utf-8")
+
+    _run_cli(["ingest", str(note), "--name", "memory-bank"], monkeypatch)
+    _run_cli(["search", "memory", "--doc", "memory-bank"], monkeypatch)
+
+    out = capsys.readouterr().out
+    assert "Agent Memory" in out
+    assert "memory-bank" in out
 
 
 def test_ingest_can_target_research_store(tmp_path, monkeypatch, capsys):
@@ -338,9 +393,10 @@ def test_ingest_can_target_research_store(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
     monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
     monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod.ingest_mod, "_enrich_markdown_chunks", _fake_ingest_pipeline)
 
-    transcript = tmp_path / "episode.txt"
-    transcript.write_text("This episode covers agent memory.", encoding="utf-8")
+    transcript = tmp_path / "episode.md"
+    transcript.write_text("# Episode Notes\n\nThis episode covers agent memory.", encoding="utf-8")
 
     _run_cli(["ingest", str(transcript), "--source", "research", "--name", "agent-memory-bank"], monkeypatch)
     out = capsys.readouterr().out
@@ -356,16 +412,29 @@ def test_ingest_reports_runtime_errors_cleanly(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
     monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
     monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
-    monkeypatch.setattr(cli_mod.ingest_mod, "ingest_path", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("PDF ingestion requires the 'pypdf' package.")))
+    monkeypatch.setattr(
+        cli_mod.ingest_mod,
+        "ingest_path",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("OPENROUTER_API_KEY is required for kctx ingest.")),
+    )
 
-    pdf_file = tmp_path / "notes.pdf"
-    pdf_file.write_bytes(b"%PDF-1.4")
+    md_file = tmp_path / "notes.md"
+    md_file.write_text("# Notes\n\nBody", encoding="utf-8")
 
     with pytest.raises(SystemExit):
-        _run_cli(["ingest", str(pdf_file), "--name", "pdf-bank"], monkeypatch)
+        _run_cli(["ingest", str(md_file), "--name", "notes-bank"], monkeypatch)
 
     err = capsys.readouterr().err
-    assert "pypdf" in err
+    assert "OPENROUTER_API_KEY" in err
+
+
+def test_ingest_help_no_longer_exposes_chunk_flags(monkeypatch, capsys):
+    with pytest.raises(SystemExit):
+        _run_cli(["ingest", "--help"], monkeypatch)
+
+    out = capsys.readouterr().out
+    assert "--chunk-max-tokens" not in out
+    assert "--chunk-min-tokens" not in out
 
 
 def test_help_shows_subcommands(monkeypatch, capsys):

--- a/tests/test_context_cli/test_cli.py
+++ b/tests/test_context_cli/test_cli.py
@@ -320,10 +320,14 @@ def test_ingest_directory_into_docs_store(tmp_path, monkeypatch, capsys):
     notes_dir.mkdir()
     (notes_dir / "guide.md").write_text("## Intro\n\nWelcome to the notes.", encoding="utf-8")
     (notes_dir / "summary.txt").write_text("Short transcript summary.", encoding="utf-8")
+    (notes_dir / ".draft.txt").write_text("ignore me", encoding="utf-8")
+    (notes_dir / "diagram.png").write_bytes(b"png")
 
     _run_cli(["ingest", str(notes_dir), "--name", "my-bank"], monkeypatch)
     out = capsys.readouterr().out
     assert "Ingested my-bank (docs)" in out
+    assert "Scanned 4 file(s); ignored 2" in out
+    assert ".png" in out
     assert (store_dir / "my-bank" / "index.json").exists()
 
 
@@ -341,7 +345,27 @@ def test_ingest_can_target_research_store(tmp_path, monkeypatch, capsys):
     _run_cli(["ingest", str(transcript), "--source", "research", "--name", "agent-memory-bank"], monkeypatch)
     out = capsys.readouterr().out
     assert "Ingested agent-memory-bank (research)" in out
+    assert "Scanned 1 file(s); ignored 0" in out
     assert (research_store / "agent-memory-bank" / "index.json").exists()
+
+
+def test_ingest_reports_runtime_errors_cleanly(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
+    monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod.ingest_mod, "ingest_path", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("PDF ingestion requires the 'pypdf' package.")))
+
+    pdf_file = tmp_path / "notes.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    with pytest.raises(SystemExit):
+        _run_cli(["ingest", str(pdf_file), "--name", "pdf-bank"], monkeypatch)
+
+    err = capsys.readouterr().err
+    assert "pypdf" in err
 
 
 def test_help_shows_subcommands(monkeypatch, capsys):

--- a/tests/test_context_cli/test_cli.py
+++ b/tests/test_context_cli/test_cli.py
@@ -308,6 +308,42 @@ def test_index_file_not_found(tmp_path, monkeypatch):
         _run_cli(["index", "/nonexistent/file.json"], monkeypatch)
 
 
+def test_ingest_directory_into_docs_store(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
+    monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "guide.md").write_text("## Intro\n\nWelcome to the notes.", encoding="utf-8")
+    (notes_dir / "summary.txt").write_text("Short transcript summary.", encoding="utf-8")
+
+    _run_cli(["ingest", str(notes_dir), "--name", "my-bank"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Ingested my-bank (docs)" in out
+    assert (store_dir / "my-bank" / "index.json").exists()
+
+
+def test_ingest_can_target_research_store(tmp_path, monkeypatch, capsys):
+    store_dir = tmp_path / ".king-context" / "docs"
+    research_store = tmp_path / ".king-context" / "research"
+    import context_cli.cli as cli_mod
+    monkeypatch.setattr(cli_mod, "STORE_DIR", store_dir)
+    monkeypatch.setattr(cli_mod, "RESEARCH_STORE_DIR", research_store)
+    monkeypatch.setattr(cli_mod, "PROJECT_ROOT", tmp_path)
+
+    transcript = tmp_path / "episode.txt"
+    transcript.write_text("This episode covers agent memory.", encoding="utf-8")
+
+    _run_cli(["ingest", str(transcript), "--source", "research", "--name", "agent-memory-bank"], monkeypatch)
+    out = capsys.readouterr().out
+    assert "Ingested agent-memory-bank (research)" in out
+    assert (research_store / "agent-memory-bank" / "index.json").exists()
+
+
 def test_help_shows_subcommands(monkeypatch, capsys):
     _run_cli([], monkeypatch)
     out = capsys.readouterr().out
@@ -315,3 +351,4 @@ def test_help_shows_subcommands(monkeypatch, capsys):
     assert "search" in out
     assert "read" in out
     assert "index" in out
+    assert "ingest" in out

--- a/tests/test_context_cli/test_ingest.py
+++ b/tests/test_context_cli/test_ingest.py
@@ -1,0 +1,83 @@
+"""Tests for local user-content ingestion."""
+
+import json
+
+from context_cli.ingest import build_user_corpus, ingest_path
+
+
+def test_build_user_corpus_supports_markdown_directory(tmp_path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "guide.md").write_text(
+        "## Authentication\n\nUse an API key.\n\n### OAuth\n\nUse OAuth for user sessions.\n",
+        encoding="utf-8",
+    )
+    (notes_dir / "summary.txt").write_text(
+        "This is a plain text summary of the system behavior.",
+        encoding="utf-8",
+    )
+
+    data, file_count = build_user_corpus(
+        notes_dir,
+        name="custom-bank",
+        chunk_min_tokens=1,
+    )
+
+    assert file_count == 2
+    assert data["name"] == "custom-bank"
+    assert len(data["sections"]) >= 3
+
+    titles = {section["title"] for section in data["sections"]}
+    assert "Authentication" in titles
+    assert "OAuth" in titles
+    assert any("Summary" in title for title in titles)
+
+
+def test_build_user_corpus_marks_research_sections_when_requested(tmp_path):
+    transcript = tmp_path / "video-notes.txt"
+    transcript.write_text("Line one.\n\nLine two.", encoding="utf-8")
+
+    data, _ = build_user_corpus(transcript, source="research")
+
+    assert data["sections"]
+    assert all(section["source_type"] == "research" for section in data["sections"])
+
+
+def test_ingest_path_writes_json_and_indexes_docs_store(tmp_path, monkeypatch):
+    src_dir = tmp_path / "dropbox"
+    src_dir.mkdir()
+    (src_dir / "notes.txt").write_text("Operational runbook for the service.", encoding="utf-8")
+
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(ingest_mod, "STORE_DIR", tmp_path / ".king-context" / "docs")
+    monkeypatch.setattr(ingest_mod, "RESEARCH_STORE_DIR", tmp_path / ".king-context" / "research")
+
+    result = ingest_path(src_dir, name="ops-notes")
+
+    assert result.doc_name == "ops-notes"
+    assert result.indexed is True
+    assert result.store_label == "docs"
+    assert result.json_path.exists()
+    assert (tmp_path / ".king-context" / "docs" / "ops-notes" / "index.json").exists()
+
+    payload = json.loads(result.json_path.read_text(encoding="utf-8"))
+    assert payload["name"] == "ops-notes"
+
+
+def test_ingest_path_writes_research_json_when_requested(tmp_path, monkeypatch):
+    transcript = tmp_path / "youtube.vtt"
+    transcript.write_text("WEBVTT\n\n00:00.000 --> 00:01.000\nHello world", encoding="utf-8")
+
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(ingest_mod, "STORE_DIR", tmp_path / ".king-context" / "docs")
+    monkeypatch.setattr(ingest_mod, "RESEARCH_STORE_DIR", tmp_path / ".king-context" / "research")
+
+    result = ingest_path(transcript, source="research", auto_index=False)
+
+    assert result.store_label == "research"
+    assert result.indexed is False
+    assert result.json_path.parent.name == "research"
+    payload = json.loads(result.json_path.read_text(encoding="utf-8"))
+    assert payload["sections"][0]["source_type"] == "research"

--- a/tests/test_context_cli/test_ingest.py
+++ b/tests/test_context_cli/test_ingest.py
@@ -1,63 +1,110 @@
-"""Tests for local user-content ingestion."""
+"""Tests for local Markdown ingestion."""
 
+import asyncio
 import json
+from dataclasses import dataclass
+from types import SimpleNamespace
 
 from context_cli.ingest import build_user_corpus, ingest_path
 
 
-def test_build_user_corpus_supports_markdown_directory(tmp_path):
+@dataclass
+class FakeEnrichedChunk:
+    title: str
+    path: str
+    url: str
+    content: str
+    keywords: list[str]
+    use_cases: list[str]
+    tags: list[str]
+    priority: int
+
+
+async def _fake_enrich(chunks, config, output_dir=None):
+    return [
+        FakeEnrichedChunk(
+            title=chunk.title,
+            path=chunk.path,
+            url=chunk.source_url,
+            content=chunk.content,
+            keywords=["authentication", "oauth", "sessions", "api", "guide"],
+            use_cases=["Use when authenticating requests", "Configure when enabling OAuth"],
+            tags=["authentication"],
+            priority=7,
+        )
+        for chunk in chunks
+    ]
+
+
+def test_build_user_corpus_uses_enrichment_pipeline_for_markdown(monkeypatch, tmp_path):
     notes_dir = tmp_path / "notes"
     notes_dir.mkdir()
-    (notes_dir / "guide.md").write_text(
-        "## Authentication\n\nUse an API key.\n\n### OAuth\n\nUse OAuth for user sessions.\n",
-        encoding="utf-8",
-    )
-    (notes_dir / "summary.txt").write_text(
-        "This is a plain text summary of the system behavior.",
+    (notes_dir / "agent-memory.md").write_text(
+        "# Agent Memory\n\nUse this note to explain retrieval and memory flows.\n",
         encoding="utf-8",
     )
 
-    data, discovery = build_user_corpus(
-        notes_dir,
-        name="custom-bank",
-        chunk_min_tokens=1,
-    )
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "_enrich_markdown_chunks", lambda chunks: asyncio.run(_fake_enrich(chunks, None)))
 
-    assert discovery.discovered_count == 2
-    assert len(discovery.files) == 2
+    data, discovery = build_user_corpus(notes_dir, name="custom-bank")
+
+    assert discovery.discovered_count == 1
+    assert len(discovery.files) == 1
     assert data["name"] == "custom-bank"
-    assert len(data["sections"]) >= 3
+    assert len(data["sections"]) == 1
 
-    titles = {section["title"] for section in data["sections"]}
-    assert "Authentication" in titles
-    assert "OAuth" in titles
-    assert any("Summary" in title for title in titles)
-    auth_section = next(section for section in data["sections"] if section["title"] == "Authentication")
-    assert auth_section["source_type"] == "user-content"
-    assert auth_section["source_format"] == "md"
-    assert auth_section["source_collection"] == "custom-bank"
-    assert auth_section["source_file"] == "guide.md"
+    section = data["sections"][0]
+    assert section["title"] == "Agent Memory"
+    assert section["path"] == "agent-memory"
+    assert section["source_type"] == "user-content"
+    assert section["source_file"] == "agent-memory.md"
+    assert section["keywords"] == ["authentication", "oauth", "sessions", "api", "guide"]
+    assert "retrieval and memory flows" in section["content"]
 
 
-def test_build_user_corpus_marks_research_sections_when_requested(tmp_path):
-    transcript = tmp_path / "video-notes.txt"
-    transcript.write_text("Line one.\n\nLine two.", encoding="utf-8")
+def test_build_user_corpus_marks_research_sections_when_requested(monkeypatch, tmp_path):
+    note = tmp_path / "research-note.md"
+    note.write_text("# Research Note\n\nTrack findings here.\n", encoding="utf-8")
 
-    data, _ = build_user_corpus(transcript, source="research")
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "_enrich_markdown_chunks", lambda chunks: asyncio.run(_fake_enrich(chunks, None)))
+
+    data, _ = build_user_corpus(note, source="research")
 
     assert data["sections"]
     assert all(section["source_type"] == "research" for section in data["sections"])
-    assert all(section["source_kind"] == "text" for section in data["sections"])
 
 
-def test_build_user_corpus_ignores_hidden_and_binary_files(tmp_path):
+def test_build_user_corpus_keeps_one_section_per_markdown_file(monkeypatch, tmp_path):
     notes_dir = tmp_path / "notes"
     notes_dir.mkdir()
-    (notes_dir / "guide.md").write_text("## Intro\n\nVisible content.", encoding="utf-8")
-    (notes_dir / ".secret.txt").write_text("ignore me", encoding="utf-8")
-    (notes_dir / "diagram.png").write_bytes(b"png")
+    (notes_dir / "deep-dive.md").write_text(
+        "# Deep Dive\n\n## Part One\n\nAlpha.\n\n### Part Two\n\nBeta.\n",
+        encoding="utf-8",
+    )
+
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "_enrich_markdown_chunks", lambda chunks: asyncio.run(_fake_enrich(chunks, None)))
+
+    data, _ = build_user_corpus(notes_dir)
+
+    assert len(data["sections"]) == 1
+    assert "## Part One" in data["sections"][0]["content"]
+    assert "### Part Two" in data["sections"][0]["content"]
+
+
+def test_build_user_corpus_ignores_hidden_and_non_markdown_files(monkeypatch, tmp_path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "guide.md").write_text("# Intro\n\nVisible content.", encoding="utf-8")
+    (notes_dir / ".secret.md").write_text("# Secret\n\nignore me", encoding="utf-8")
+    (notes_dir / "summary.txt").write_text("ignored", encoding="utf-8")
     (notes_dir / "node_modules").mkdir()
-    (notes_dir / "node_modules" / "package.txt").write_text("ignored", encoding="utf-8")
+    (notes_dir / "node_modules" / "package.md").write_text("# Ignored\n\nNope", encoding="utf-8")
+
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "_enrich_markdown_chunks", lambda chunks: asyncio.run(_fake_enrich(chunks, None)))
 
     data, discovery = build_user_corpus(notes_dir)
 
@@ -65,21 +112,25 @@ def test_build_user_corpus_ignores_hidden_and_binary_files(tmp_path):
     assert discovery.discovered_count == 3
     assert discovery.ignored_count == 2
     assert "<hidden>" in discovery.ignored_extensions
-    assert ".png" in discovery.ignored_extensions
+    assert ".txt" in discovery.ignored_extensions
     assert len(data["sections"]) == 1
 
 
-def test_ingest_path_writes_json_and_indexes_docs_store(tmp_path, monkeypatch):
+def test_ingest_path_writes_json_and_indexes_docs_store(monkeypatch, tmp_path):
     src_dir = tmp_path / "dropbox"
     src_dir.mkdir()
-    (src_dir / "notes.txt").write_text("Operational runbook for the service.", encoding="utf-8")
+    (src_dir / "notes.md").write_text("# Ops Notes\n\nOperational runbook for the service.", encoding="utf-8")
 
     import context_cli.ingest as ingest_mod
-    monkeypatch.setattr(ingest_mod, "PROJECT_ROOT", tmp_path)
-    monkeypatch.setattr(ingest_mod, "STORE_DIR", tmp_path / ".king-context" / "docs")
-    monkeypatch.setattr(ingest_mod, "RESEARCH_STORE_DIR", tmp_path / ".king-context" / "research")
+    monkeypatch.setattr(ingest_mod, "_enrich_markdown_chunks", lambda chunks: asyncio.run(_fake_enrich(chunks, None)))
 
-    result = ingest_path(src_dir, name="ops-notes")
+    result = ingest_path(
+        src_dir,
+        name="ops-notes",
+        project_root=tmp_path,
+        store_dir=tmp_path / ".king-context" / "docs",
+        research_store_dir=tmp_path / ".king-context" / "research",
+    )
 
     assert result.doc_name == "ops-notes"
     assert result.indexed is True
@@ -90,28 +141,44 @@ def test_ingest_path_writes_json_and_indexes_docs_store(tmp_path, monkeypatch):
     payload = json.loads(result.json_path.read_text(encoding="utf-8"))
     assert payload["name"] == "ops-notes"
     section = payload["sections"][0]
-    assert section["source_collection"] == "ops-notes"
+    assert section["source_file"] == "notes.md"
     indexed_section = json.loads(
         (tmp_path / ".king-context" / "docs" / "ops-notes" / "sections" / section["path"]).with_suffix(".json").read_text(encoding="utf-8")
     )
-    assert indexed_section["source_file"] == "notes.txt"
-    assert indexed_section["source_format"] == "txt"
+    assert indexed_section["source_file"] == "notes.md"
+    assert indexed_section["source_type"] == "user-content"
+    assert "source_format" not in indexed_section
+    assert "source_collection" not in indexed_section
+    assert "source_kind" not in indexed_section
 
 
-def test_ingest_path_writes_research_json_when_requested(tmp_path, monkeypatch):
-    transcript = tmp_path / "youtube.vtt"
-    transcript.write_text("WEBVTT\n\n00:00.000 --> 00:01.000\nHello world", encoding="utf-8")
+def test_build_user_corpus_fails_when_enrichment_returns_partial_results(monkeypatch, tmp_path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "a.md").write_text("# A\n\nOne", encoding="utf-8")
+    (notes_dir / "b.md").write_text("# B\n\nTwo", encoding="utf-8")
 
     import context_cli.ingest as ingest_mod
-    monkeypatch.setattr(ingest_mod, "PROJECT_ROOT", tmp_path)
-    monkeypatch.setattr(ingest_mod, "STORE_DIR", tmp_path / ".king-context" / "docs")
-    monkeypatch.setattr(ingest_mod, "RESEARCH_STORE_DIR", tmp_path / ".king-context" / "research")
+    monkeypatch.setattr(ingest_mod, "_enrich_markdown_chunks", lambda chunks: asyncio.run(_fake_enrich(chunks[:1], None)))
 
-    result = ingest_path(transcript, source="research", auto_index=False)
+    try:
+        build_user_corpus(notes_dir)
+    except RuntimeError as exc:
+        assert "Failed to enrich one or more Markdown files" in str(exc)
+    else:
+        raise AssertionError("Expected partial enrichment mismatch error")
 
-    assert result.store_label == "research"
-    assert result.indexed is False
-    assert result.json_path.parent.name == "research"
-    payload = json.loads(result.json_path.read_text(encoding="utf-8"))
-    assert payload["sections"][0]["source_type"] == "research"
-    assert payload["sections"][0]["source_kind"] == "transcript"
+
+def test_ingest_path_requires_openrouter_key(monkeypatch, tmp_path):
+    note = tmp_path / "notes.md"
+    note.write_text("# Notes\n\nBody", encoding="utf-8")
+
+    import context_cli.ingest as ingest_mod
+    monkeypatch.setattr(ingest_mod, "load_config", lambda: SimpleNamespace(openrouter_api_key=""))
+
+    try:
+        ingest_mod._enrich_markdown_chunks([])
+    except RuntimeError as exc:
+        assert "OPENROUTER_API_KEY" in str(exc)
+    else:
+        raise AssertionError("Expected OPENROUTER_API_KEY error")

--- a/tests/test_context_cli/test_ingest.py
+++ b/tests/test_context_cli/test_ingest.py
@@ -17,13 +17,14 @@ def test_build_user_corpus_supports_markdown_directory(tmp_path):
         encoding="utf-8",
     )
 
-    data, file_count = build_user_corpus(
+    data, discovery = build_user_corpus(
         notes_dir,
         name="custom-bank",
         chunk_min_tokens=1,
     )
 
-    assert file_count == 2
+    assert discovery.discovered_count == 2
+    assert len(discovery.files) == 2
     assert data["name"] == "custom-bank"
     assert len(data["sections"]) >= 3
 
@@ -31,6 +32,11 @@ def test_build_user_corpus_supports_markdown_directory(tmp_path):
     assert "Authentication" in titles
     assert "OAuth" in titles
     assert any("Summary" in title for title in titles)
+    auth_section = next(section for section in data["sections"] if section["title"] == "Authentication")
+    assert auth_section["source_type"] == "user-content"
+    assert auth_section["source_format"] == "md"
+    assert auth_section["source_collection"] == "custom-bank"
+    assert auth_section["source_file"] == "guide.md"
 
 
 def test_build_user_corpus_marks_research_sections_when_requested(tmp_path):
@@ -41,6 +47,26 @@ def test_build_user_corpus_marks_research_sections_when_requested(tmp_path):
 
     assert data["sections"]
     assert all(section["source_type"] == "research" for section in data["sections"])
+    assert all(section["source_kind"] == "text" for section in data["sections"])
+
+
+def test_build_user_corpus_ignores_hidden_and_binary_files(tmp_path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "guide.md").write_text("## Intro\n\nVisible content.", encoding="utf-8")
+    (notes_dir / ".secret.txt").write_text("ignore me", encoding="utf-8")
+    (notes_dir / "diagram.png").write_bytes(b"png")
+    (notes_dir / "node_modules").mkdir()
+    (notes_dir / "node_modules" / "package.txt").write_text("ignored", encoding="utf-8")
+
+    data, discovery = build_user_corpus(notes_dir)
+
+    assert len(discovery.files) == 1
+    assert discovery.discovered_count == 3
+    assert discovery.ignored_count == 2
+    assert "<hidden>" in discovery.ignored_extensions
+    assert ".png" in discovery.ignored_extensions
+    assert len(data["sections"]) == 1
 
 
 def test_ingest_path_writes_json_and_indexes_docs_store(tmp_path, monkeypatch):
@@ -63,6 +89,13 @@ def test_ingest_path_writes_json_and_indexes_docs_store(tmp_path, monkeypatch):
 
     payload = json.loads(result.json_path.read_text(encoding="utf-8"))
     assert payload["name"] == "ops-notes"
+    section = payload["sections"][0]
+    assert section["source_collection"] == "ops-notes"
+    indexed_section = json.loads(
+        (tmp_path / ".king-context" / "docs" / "ops-notes" / "sections" / section["path"]).with_suffix(".json").read_text(encoding="utf-8")
+    )
+    assert indexed_section["source_file"] == "notes.txt"
+    assert indexed_section["source_format"] == "txt"
 
 
 def test_ingest_path_writes_research_json_when_requested(tmp_path, monkeypatch):
@@ -81,3 +114,4 @@ def test_ingest_path_writes_research_json_when_requested(tmp_path, monkeypatch):
     assert result.json_path.parent.name == "research"
     payload = json.loads(result.json_path.read_text(encoding="utf-8"))
     assert payload["sections"][0]["source_type"] == "research"
+    assert payload["sections"][0]["source_kind"] == "transcript"


### PR DESCRIPTION
## Summary

This PR reworks `kctx ingest` to align with the existing King Context retrieval architecture instead of maintaining a parallel ingestion/chunking path.

The feature is now intentionally narrower and more predictable:
- Markdown only
- one section per file
- metadata generated through the existing scraper enrichment flow

## What changed

- reduced ingestion scope to `.md` files only
- removed the custom Markdown chunking pipeline
- removed synthetic metadata generation
- reused the existing scraper enrichment pipeline for:
  - keywords
  - use cases
  - tags
  - priority
- kept only the source metadata that is currently useful:
  - `source_type`
  - `source_file`
- removed ingest chunk flags from the CLI
- removed module-level path rebinding from `_cmd_ingest`
- updated docs and tests to match the reduced contract

## Why this approach

The first version solved the feature in a parallel way, but it duplicated behavior that the project already has in the scraper pipeline.

This rework keeps the feature aligned with the project’s stronger invariant:
- retrieval quality should come from the same enrichment model already used elsewhere
- ingestion should stay small, predictable, and easy to maintain
- the CLI should not invent a second metadata/chunking strategy

## Behavior

`kctx ingest` now:

- accepts a Markdown file or directory
- ignores hidden files and common heavy directories
- creates one enriched section per Markdown file
- writes the resulting JSON into:
  - `.king-context/data/<name>.json`
  - or `.king-context/data/research/<name>.json`
- optionally indexes it immediately into the local store

## Testing

Validated with:

- `python -m py_compile src/context_cli/ingest.py src/context_cli/cli.py src/context_cli/indexer.py src/king_context/scraper/__init__.py tests/test_context_cli/test_ingest.py tests/test_context_cli/test_cli.py`
- `python -c "import context_cli.ingest; print('ingest-import-ok')"`
- `python -m context_cli.cli ingest --help`
- `pytest tests/test_context_cli/test_ingest.py tests/test_context_cli/test_cli.py -q`

Result:

- `31 passed`

## Scope

This PR is intentionally limited to Markdown ingestion.

Follow-up support for other formats such as `txt`, `pdf`, `srt`, or `vtt` should be added separately with their own parsing and failure-mode handling.
