### PR TITLE
feat(scraper): add documentation sync manifest and change detection

### DIFF
--- a/src/king_context/scraper/SCRAPER.md
+++ b/src/king_context/scraper/SCRAPER.md
@@ -1,10 +1,12 @@
 # King Context Scraper
 
-A 6-stage pipeline that turns any documentation website into a structured, searchable JSON ready for the King Context MCP server.
+A 6-stage pipeline that turns any documentation website into a structured,
+searchable JSON ready for King Context.
 
 ## Requirements
 
-Two API keys, set as environment variables or in a `.env` file at the project root:
+Two API keys, set as environment variables or in a `.env` file at the project
+root:
 
 | Variable | Service | Used for |
 |---|---|---|
@@ -23,54 +25,76 @@ pip install -e .
 king-scrape https://docs.stripe.com
 ```
 
-This runs the full pipeline: discovers all URLs on the site, filters for documentation pages, fetches them as Markdown, splits into chunks, enriches each chunk with metadata via LLM, and exports a JSON file to `.king-context/data/stripe.json`.
+This runs the full pipeline: discovers all URLs on the site, filters for
+documentation pages, fetches them as Markdown, splits them into chunks,
+enriches each chunk with metadata via LLM, and exports a JSON file to
+`.king-context/data/stripe.json`.
 
-The doc name is inferred from the URL (`docs.stripe.com` → `stripe`). Override it with `--name` and `--display-name`.
+The doc name is inferred from the URL (`docs.stripe.com` -> `stripe`).
+Override it with `--name` and `--display-name`.
+
+To check whether a previously scraped documentation set has changed without
+re-running fetch, chunking, or enrichment, use:
+
+```bash
+king-scrape https://docs.stripe.com --check-updates
+```
 
 ## How the Pipeline Works
 
-The scraper runs 6 sequential stages. Each stage saves its output to a working directory at `.king-context/_temp/{domain}/`, enabling resumption if anything fails.
+The scraper runs 6 sequential stages. Each stage saves its output to a working
+directory at `.king-context/_temp/{domain}/`, enabling resumption if anything
+fails.
 
 ### 1. Discover
 
-Uses Firecrawl's `map()` to crawl the site and collect all reachable URLs. Output: `discovered_urls.json`.
+Uses Firecrawl's `map()` to crawl the site and collect all reachable URLs.
+Output: `discovered_urls.json`.
 
 ### 2. Filter
 
-Classifies URLs into **accepted**, **rejected**, or **maybe** using regex heuristics:
+Classifies URLs into **accepted**, **rejected**, or **maybe** using regex
+heuristics:
 
 - Paths like `/docs/`, `/api/`, `/guides/`, `/reference/` are accepted
 - Paths like `/blog/`, `/pricing/`, `/careers/`, `/login/` are rejected
-- Everything else is marked "maybe"
+- Everything else is marked `maybe`
 
-If too few URLs pass (< 10 accepted or > 60% rejected), an LLM fallback reclassifies the uncertain ones. Disable with `--no-llm-filter`.
+If too few URLs pass (`< 10 accepted` or `> 60% rejected`), an LLM fallback
+reclassifies the uncertain ones. Disable with `--no-llm-filter`.
 
 ### 3. Fetch
 
-Downloads each accepted URL as Markdown using Firecrawl's `scrape()`. Runs concurrently (default: 5 parallel requests). Failed pages are logged but don't stop the pipeline.
+Downloads each accepted URL as Markdown using Firecrawl's `scrape()`. Runs
+concurrently (default: 5 parallel requests). Failed pages are logged but do
+not stop the pipeline.
 
 ### 4. Chunk
 
-Splits each Markdown page at `##` and `###` headers into token-bounded chunks. Oversized chunks are split further by paragraph. Tiny chunks are merged with their predecessor. Tables are never split mid-row.
+Splits each Markdown page at `##` and `###` headers into token-bounded chunks.
+Oversized chunks are split further by paragraph. Tiny chunks are merged with
+their predecessor. Tables are never split mid-row.
 
 ### 5. Enrich
 
 Sends each chunk to an LLM (via OpenRouter) to generate structured metadata:
 
-- **keywords** — specific technical terms (API names, config keys, methods)
-- **use_cases** — practical scenarios starting with action verbs
-- **tags** — broad category labels
-- **priority** — 1-10 importance score
+- **keywords**: specific technical terms (API names, config keys, methods)
+- **use_cases**: practical scenarios starting with action verbs
+- **tags**: broad category labels
+- **priority**: 1-10 importance score
 
-Processed in batches with checkpoints saved after each batch. Before starting, the CLI shows an estimated cost and asks for confirmation.
+Processed in batches with checkpoints saved after each batch. Before starting,
+the CLI shows an estimated cost and asks for confirmation.
 
 ### 6. Export
 
-Assembles all enriched chunks into a single JSON file matching King Context's documentation schema and saves it to `.king-context/data/{name}.json`.
+Assembles all enriched chunks into a single JSON file matching King Context's
+documentation schema and saves it to `.king-context/data/{name}.json`.
 
 ## CLI Reference
 
-```
+```text
 king-scrape <URL> [options]
 ```
 
@@ -79,41 +103,75 @@ king-scrape <URL> [options]
 | `--name` | inferred from URL | Unique doc identifier |
 | `--display-name` | titlecased name | Human-readable name |
 | `--step STAGE` | run all | Start from a specific stage (loads earlier data from checkpoints) |
+| `--check-updates` | off | Discover current URLs and compare them against the saved page manifest |
 | `--model` | `google/gemini-3-flash-preview` | OpenRouter model for enrichment |
 | `--chunk-max-tokens` | 800 | Max tokens per chunk |
 | `--chunk-min-tokens` | 50 | Min tokens before merging with previous chunk |
 | `--concurrency` | 5 | Parallel fetch requests |
 | `--no-llm-filter` | off | Disable LLM fallback in URL filtering |
 | `--no-auto-seed` | off | Skip database indexing after export |
-| `--include-maybe` | off | Also fetch URLs classified as "maybe" |
+| `--include-maybe` | off | Also fetch URLs classified as `maybe` |
+| `--stop-after STAGE` | none | Run up to and including one stage, then stop |
+| `--yes`, `-y` | off | Skip enrichment confirmation prompts |
 
 ## Resuming a Failed Run
 
-The pipeline tracks progress in a `manifest.json` file inside the working directory. If a run is interrupted:
+The pipeline tracks progress in a `manifest.json` file inside the working
+directory. If a run is interrupted:
 
-- **Re-run the same command** — completed stages are skipped automatically.
-- **Jump to a specific stage** — use `--step` to restart from that point. Earlier stages are loaded from their saved checkpoints.
+- Re-run the same command: completed stages are skipped automatically.
+- Jump to a specific stage: use `--step` to restart from that point. Earlier
+  stages are loaded from their saved checkpoints.
 
 ```bash
-# Re-run from enrichment (e.g., after tweaking the model)
+# Re-run from enrichment after tweaking the model
 king-scrape https://docs.stripe.com --step enrich --model openai/gpt-4o-mini
 ```
 
+## Detecting Changes Without Re-Scraping
+
+The scraper now stores a page-level sync baseline alongside the normal
+pipeline progress manifest.
+
+When a page is fetched, King Context records metadata such as:
+
+- URL
+- slug
+- fetch timestamp
+- markdown hash
+- `etag`
+- `last_modified`
+- fallback body hash when cache headers are not enough
+
+Later, `king-scrape --check-updates` can:
+
+- rediscover the current URL set
+- detect new pages
+- detect removed pages
+- detect changed pages with `etag`, `last_modified`, or fallback body hashes
+- write a `sync_report.json` summary without re-enriching content
+
+This is the phase-1 foundation for future incremental update flows.
+
 ## Working Directory
 
-Each scrape creates a working directory at `.king-context/_temp/{domain}/` containing:
+Each scrape creates a working directory at `.king-context/_temp/{domain}/`
+containing:
 
-```
+```text
 .king-context/_temp/docs-stripe-com/
-├── manifest.json           # Progress tracker
-├── discovered_urls.json    # All found URLs
-├── filtered_urls.json      # Classification results
-├── pages/                  # Fetched Markdown files
-├── chunks/                 # Per-page chunk JSONs
-└── enriched/               # Batch checkpoint files
+|-- manifest.json           # Pipeline progress tracker
+|-- page_manifest.json      # Per-page sync metadata baseline
+|-- sync_report.json        # Latest change-detection report
+|-- discovered_urls.json    # All found URLs
+|-- filtered_urls.json      # Classification results
+|-- pages/                  # Fetched Markdown files
+|-- chunks/                 # Per-page chunk JSONs
+`-- enriched/               # Batch checkpoint files
 ```
 
-This directory persists after the run completes, so you can inspect intermediate results or re-run later stages with different settings.
+This directory persists after the run completes, so you can inspect
+intermediate results or re-run later stages with different settings.
 
 ## Output Format
 
@@ -140,4 +198,5 @@ The final JSON file follows King Context's documentation schema:
 }
 ```
 
-This is the same format used by `.king-context/data/*.json` files. Once indexed, sections are searchable through `kctx` CLI commands.
+This is the same format used by `.king-context/data/*.json` files. Once
+indexed, sections are searchable through `kctx` CLI commands.

--- a/src/king_context/scraper/__init__.py
+++ b/src/king_context/scraper/__init__.py
@@ -1,17 +1,58 @@
-from king_context.scraper.config import ScraperConfig, load_config, ConfigError
-from king_context.scraper.discover import discover_urls, DiscoveryResult
-from king_context.scraper.filter import filter_urls, FilterResult
-from king_context.scraper.fetch import fetch_pages, FetchResult, PageResult
-from king_context.scraper.chunk import chunk_page, chunk_pages, Chunk
-from king_context.scraper.enrich import enrich_chunks, EnrichedChunk, validate_enrichment, estimate_cost
-from king_context.scraper.export import export_to_json, save_and_index
+"""Scraper package for King Context."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
 
 __all__ = [
-    "ScraperConfig", "load_config", "ConfigError",
-    "discover_urls", "DiscoveryResult",
-    "filter_urls", "FilterResult",
-    "fetch_pages", "FetchResult", "PageResult",
-    "chunk_page", "chunk_pages", "Chunk",
-    "enrich_chunks", "EnrichedChunk", "validate_enrichment", "estimate_cost",
-    "export_to_json", "save_and_index",
+    "ScraperConfig",
+    "load_config",
+    "ConfigError",
+    "discover_urls",
+    "DiscoveryResult",
+    "filter_urls",
+    "FilterResult",
+    "fetch_pages",
+    "FetchResult",
+    "PageResult",
+    "chunk_page",
+    "chunk_pages",
+    "Chunk",
+    "enrich_chunks",
+    "EnrichedChunk",
+    "validate_enrichment",
+    "estimate_cost",
+    "export_to_json",
+    "save_and_index",
 ]
+
+
+_ATTR_TO_MODULE = {
+    "ScraperConfig": "king_context.scraper.config",
+    "load_config": "king_context.scraper.config",
+    "ConfigError": "king_context.scraper.config",
+    "discover_urls": "king_context.scraper.discover",
+    "DiscoveryResult": "king_context.scraper.discover",
+    "filter_urls": "king_context.scraper.filter",
+    "FilterResult": "king_context.scraper.filter",
+    "fetch_pages": "king_context.scraper.fetch",
+    "FetchResult": "king_context.scraper.fetch",
+    "PageResult": "king_context.scraper.fetch",
+    "chunk_page": "king_context.scraper.chunk",
+    "chunk_pages": "king_context.scraper.chunk",
+    "Chunk": "king_context.scraper.chunk",
+    "enrich_chunks": "king_context.scraper.enrich",
+    "EnrichedChunk": "king_context.scraper.enrich",
+    "validate_enrichment": "king_context.scraper.enrich",
+    "estimate_cost": "king_context.scraper.enrich",
+    "export_to_json": "king_context.scraper.export",
+    "save_and_index": "king_context.scraper.export",
+}
+
+
+def __getattr__(name: str):
+    if name not in _ATTR_TO_MODULE:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(_ATTR_TO_MODULE[name])
+    return getattr(module, name)

--- a/src/king_context/scraper/cli.py
+++ b/src/king_context/scraper/cli.py
@@ -18,6 +18,7 @@ from king_context.scraper.enrich import EnrichedChunk, enrich_chunks, estimate_c
 from king_context.scraper.export import export_to_json, save_and_index
 from king_context.scraper.fetch import fetch_pages
 from king_context.scraper.filter import FilterResult, filter_urls
+from king_context.scraper.sync import check_for_updates
 
 PIPELINE_STEPS = ["discover", "filter", "fetch", "chunk", "enrich", "export"]
 
@@ -96,6 +97,37 @@ async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
 
     manifest = _load_manifest(work_dir)
 
+    if getattr(args, "check_updates", False):
+        print("[discover] running sync discovery...")
+        discovery_result = await discover_urls(args.url, config)
+        report = await check_for_updates(
+            base_url=args.url,
+            current_urls=discovery_result.urls,
+            work_dir=work_dir,
+            concurrency=config.concurrency,
+        )
+        _update_step(
+            work_dir,
+            "sync",
+            {
+                "status": "done",
+                "checked_at": report.checked_at,
+                "new": len(report.new_urls),
+                "removed": len(report.removed_urls),
+                "changed": len(report.changed),
+                "unchanged": len(report.unchanged_urls),
+                "unchecked": len(report.unchecked),
+            },
+        )
+        print("=== Sync Check Summary ===")
+        print(f"  New: {len(report.new_urls)}")
+        print(f"  Removed: {len(report.removed_urls)}")
+        print(f"  Changed: {len(report.changed)}")
+        print(f"  Unchanged: {len(report.unchanged_urls)}")
+        print(f"  Unchecked: {len(report.unchecked)}")
+        print(f"  Report: {work_dir / 'sync_report.json'}")
+        return
+
     target_step = getattr(args, "step", None)
     if target_step:
         start_idx = PIPELINE_STEPS.index(target_step)
@@ -169,7 +201,7 @@ async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
             urls_to_fetch = filter_result.accepted[:]
             if getattr(args, "include_maybe", False):
                 urls_to_fetch += filter_result.maybe
-            fetch_result = await fetch_pages(urls_to_fetch, work_dir, config)
+            fetch_result = await fetch_pages(urls_to_fetch, work_dir, config, base_url=args.url)
             print(f"  fetched {fetch_result.completed}/{fetch_result.total} pages")
 
         elif step == "chunk":
@@ -243,6 +275,12 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=PIPELINE_STEPS,
         default=None,
         help="Start the pipeline from this step (loads earlier stages from checkpoints)",
+    )
+    parser.add_argument(
+        "--check-updates",
+        dest="check_updates",
+        action="store_true",
+        help="Run discovery plus page-level change detection without re-fetching or re-enriching",
     )
     parser.add_argument(
         "--model",

--- a/src/king_context/scraper/discover.py
+++ b/src/king_context/scraper/discover.py
@@ -5,7 +5,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
-from firecrawl import FirecrawlApp
+try:
+    from firecrawl import FirecrawlApp
+except ImportError:  # pragma: no cover - exercised via patched tests/dev envs
+    class FirecrawlApp:  # type: ignore[override]
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("firecrawl is required for URL discovery")
 
 from king_context import PROJECT_ROOT
 from king_context.scraper.config import ScraperConfig

--- a/src/king_context/scraper/fetch.py
+++ b/src/king_context/scraper/fetch.py
@@ -3,10 +3,16 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from firecrawl import FirecrawlApp
+try:
+    from firecrawl import FirecrawlApp
+except ImportError:  # pragma: no cover - exercised via patched tests/dev envs
+    class FirecrawlApp:  # type: ignore[override]
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("firecrawl is required for page fetching")
 
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import _update_step
+from king_context.scraper.sync import probe_url_state, record_page_state
 
 
 @dataclass
@@ -37,6 +43,8 @@ async def _fetch_one(
     semaphore: asyncio.Semaphore,
     pages_dir: Path,
     app: FirecrawlApp,
+    output_dir: Path,
+    base_url: str,
 ) -> PageResult:
     async with semaphore:
         try:
@@ -45,6 +53,17 @@ async def _fetch_one(
             markdown = raw.markdown if hasattr(raw, "markdown") else (raw.get("markdown", "") if isinstance(raw, dict) else str(raw))
             slug = _url_to_slug(url)
             (pages_dir / f"{slug}.md").write_text(markdown)
+            state = await probe_url_state(url)
+            record_page_state(
+                output_dir,
+                base_url=base_url,
+                url=url,
+                markdown=markdown,
+                etag=state.get("etag"),
+                last_modified=state.get("last_modified"),
+                probe_hash=state.get("probe_hash"),
+                content_length=state.get("content_length"),
+            )
             return PageResult(url=url, markdown=markdown, success=True, error=None)
         except Exception as e:
             return PageResult(url=url, markdown="", success=False, error=str(e))
@@ -54,6 +73,8 @@ async def fetch_pages(
     urls: list[str],
     output_dir: Path,
     config: ScraperConfig,
+    *,
+    base_url: str = "",
 ) -> FetchResult:
     pages_dir = output_dir / "pages"
     pages_dir.mkdir(parents=True, exist_ok=True)
@@ -72,7 +93,7 @@ async def fetch_pages(
     progress = {"completed": skipped, "failed": 0}
 
     async def _fetch_and_track(url: str) -> PageResult:
-        result = await _fetch_one(url, semaphore, pages_dir, app)
+        result = await _fetch_one(url, semaphore, pages_dir, app, output_dir, base_url)
         if result.success:
             progress["completed"] += 1
         else:

--- a/src/king_context/scraper/sync.py
+++ b/src/king_context/scraper/sync.py
@@ -1,0 +1,292 @@
+"""Page-level sync metadata and change detection for scraped documentation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+
+PAGE_MANIFEST_FILE = "page_manifest.json"
+SYNC_REPORT_FILE = "sync_report.json"
+
+
+@dataclass
+class PageState:
+    url: str
+    slug: str
+    fetched_at: str
+    markdown_hash: str
+    etag: str | None
+    last_modified: str | None
+    probe_hash: str | None
+    content_length: int | None
+
+
+@dataclass
+class SyncFinding:
+    url: str
+    reason: str
+
+
+@dataclass
+class SyncReport:
+    base_url: str
+    checked_at: str
+    total_current_urls: int
+    total_known_urls: int
+    new_urls: list[str]
+    removed_urls: list[str]
+    changed: list[SyncFinding]
+    unchanged_urls: list[str]
+    unchecked: list[SyncFinding]
+
+    def to_dict(self) -> dict:
+        return {
+            "base_url": self.base_url,
+            "checked_at": self.checked_at,
+            "total_current_urls": self.total_current_urls,
+            "total_known_urls": self.total_known_urls,
+            "summary": {
+                "new": len(self.new_urls),
+                "removed": len(self.removed_urls),
+                "changed": len(self.changed),
+                "unchanged": len(self.unchanged_urls),
+                "unchecked": len(self.unchecked),
+            },
+            "new_urls": self.new_urls,
+            "removed_urls": self.removed_urls,
+            "changed": [asdict(item) for item in self.changed],
+            "unchanged_urls": self.unchanged_urls,
+            "unchecked": [asdict(item) for item in self.unchecked],
+        }
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _url_to_slug(url: str) -> str:
+    slug = re.sub(r"^https?://", "", url)
+    slug = re.sub(r"[^a-zA-Z0-9]", "-", slug)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug[:200]
+
+
+def _normalize_body(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _page_manifest_path(work_dir: Path) -> Path:
+    return work_dir / PAGE_MANIFEST_FILE
+
+
+def _sync_report_path(work_dir: Path) -> Path:
+    return work_dir / SYNC_REPORT_FILE
+
+
+def load_page_manifest(work_dir: Path) -> dict[str, dict]:
+    manifest_path = _page_manifest_path(work_dir)
+    if not manifest_path.exists():
+        return {}
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return data.get("pages", {})
+
+
+def save_page_manifest(work_dir: Path, pages: dict[str, dict], *, base_url: str | None = None) -> None:
+    payload = {
+        "base_url": base_url or "",
+        "updated_at": _utc_now(),
+        "page_count": len(pages),
+        "pages": pages,
+    }
+    _page_manifest_path(work_dir).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def record_page_state(
+    work_dir: Path,
+    *,
+    base_url: str,
+    url: str,
+    markdown: str,
+    etag: str | None = None,
+    last_modified: str | None = None,
+    probe_hash: str | None = None,
+    content_length: int | None = None,
+) -> None:
+    pages = load_page_manifest(work_dir)
+    page = PageState(
+        url=url,
+        slug=_url_to_slug(url),
+        fetched_at=_utc_now(),
+        markdown_hash=_hash_text(markdown),
+        etag=etag,
+        last_modified=last_modified,
+        probe_hash=probe_hash,
+        content_length=content_length,
+    )
+    pages[url] = asdict(page)
+    save_page_manifest(work_dir, pages, base_url=base_url)
+
+
+async def probe_url_state(url: str, client: httpx.AsyncClient | None = None) -> dict:
+    owns_client = client is None
+    http = client or httpx.AsyncClient(follow_redirects=True, timeout=10.0)
+
+    try:
+        head = await http.head(url)
+        if head.status_code >= 400:
+            get_resp = await http.get(url)
+            if get_resp.status_code >= 400:
+                return {
+                    "ok": False,
+                    "status_code": get_resp.status_code,
+                    "reason": f"http_{get_resp.status_code}",
+                }
+            return {
+                "ok": True,
+                "status_code": get_resp.status_code,
+                "etag": get_resp.headers.get("etag"),
+                "last_modified": get_resp.headers.get("last-modified"),
+                "probe_hash": _hash_text(_normalize_body(get_resp.text)),
+                "content_length": len(get_resp.text.encode("utf-8")),
+            }
+        etag = head.headers.get("etag")
+        last_modified = head.headers.get("last-modified")
+        content_length_raw = head.headers.get("content-length")
+        content_length = int(content_length_raw) if content_length_raw and content_length_raw.isdigit() else None
+
+        probe_hash = None
+        if not etag and not last_modified:
+            get_resp = await http.get(url)
+            if get_resp.status_code >= 400:
+                return {
+                    "ok": False,
+                    "status_code": get_resp.status_code,
+                    "reason": f"http_{get_resp.status_code}",
+                }
+            probe_hash = _hash_text(_normalize_body(get_resp.text))
+            content_length = content_length or len(get_resp.text.encode("utf-8"))
+
+        return {
+            "ok": head.status_code < 400,
+            "status_code": head.status_code,
+            "etag": etag,
+            "last_modified": last_modified,
+            "probe_hash": probe_hash,
+            "content_length": content_length,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "status_code": None,
+            "reason": str(exc),
+        }
+    finally:
+        if owns_client:
+            await http.aclose()
+
+
+def _compare_page_state(previous: dict, current: dict) -> tuple[str, str]:
+    prev_etag = previous.get("etag")
+    prev_last_modified = previous.get("last_modified")
+    prev_probe_hash = previous.get("probe_hash")
+
+    curr_etag = current.get("etag")
+    curr_last_modified = current.get("last_modified")
+    curr_probe_hash = current.get("probe_hash")
+
+    if prev_etag and curr_etag:
+        return ("changed", "etag_changed") if prev_etag != curr_etag else ("unchanged", "etag_same")
+    if prev_last_modified and curr_last_modified:
+        return (
+            ("changed", "last_modified_changed")
+            if prev_last_modified != curr_last_modified
+            else ("unchanged", "last_modified_same")
+        )
+    if prev_probe_hash and curr_probe_hash:
+        return (
+            ("changed", "body_hash_changed")
+            if prev_probe_hash != curr_probe_hash
+            else ("unchanged", "body_hash_same")
+        )
+    return "unchecked", "missing_comparable_state"
+
+
+async def check_for_updates(
+    *,
+    base_url: str,
+    current_urls: list[str],
+    work_dir: Path,
+    concurrency: int = 5,
+    probe_func=probe_url_state,
+) -> SyncReport:
+    known_pages = load_page_manifest(work_dir)
+    current_set = set(current_urls)
+    known_set = set(known_pages.keys())
+
+    new_urls = sorted(current_set - known_set)
+    removed_urls = sorted(known_set - current_set)
+
+    changed: list[SyncFinding] = []
+    unchanged_urls: list[str] = []
+    unchecked: list[SyncFinding] = []
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _probe(url: str) -> tuple[str, dict]:
+        async with semaphore:
+            return url, await probe_func(url)
+
+    existing_urls = sorted(current_set & known_set)
+    probe_results = await asyncio.gather(*[_probe(url) for url in existing_urls])
+
+    refreshed_pages = dict(known_pages)
+
+    for url, current_state in probe_results:
+        if not current_state.get("ok"):
+            unchecked.append(SyncFinding(url=url, reason=current_state.get("reason", "probe_failed")))
+            continue
+
+        previous = known_pages[url]
+        status, reason = _compare_page_state(previous, current_state)
+        if status == "changed":
+            changed.append(SyncFinding(url=url, reason=reason))
+        elif status == "unchanged":
+            unchanged_urls.append(url)
+        else:
+            unchecked.append(SyncFinding(url=url, reason=reason))
+
+        refreshed_pages[url] = {
+            **previous,
+            "etag": current_state.get("etag"),
+            "last_modified": current_state.get("last_modified"),
+            "probe_hash": current_state.get("probe_hash"),
+            "content_length": current_state.get("content_length"),
+        }
+
+    save_page_manifest(work_dir, refreshed_pages, base_url=base_url)
+
+    report = SyncReport(
+        base_url=base_url,
+        checked_at=_utc_now(),
+        total_current_urls=len(current_urls),
+        total_known_urls=len(known_pages),
+        new_urls=new_urls,
+        removed_urls=removed_urls,
+        changed=changed,
+        unchanged_urls=unchanged_urls,
+        unchecked=unchecked,
+    )
+    _sync_report_path(work_dir).write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    return report

--- a/tests/test_scraper/test_cli.py
+++ b/tests/test_scraper/test_cli.py
@@ -29,6 +29,7 @@ def make_args(**kwargs) -> argparse.Namespace:
         name="example",
         display_name="Example Docs",
         step=None,
+        check_updates=False,
         model="google/gemini-flash-2.0",
         chunk_max_tokens=800,
         chunk_min_tokens=50,
@@ -36,6 +37,8 @@ def make_args(**kwargs) -> argparse.Namespace:
         no_llm_filter=False,
         no_auto_seed=True,
         include_maybe=False,
+        stop_after=None,
+        yes=False,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -106,6 +109,7 @@ def test_cli_parse_args_basic():
     assert args.no_llm_filter is False
     assert args.no_auto_seed is False
     assert args.include_maybe is False
+    assert args.check_updates is False
 
 
 def test_cli_parse_args_with_flags():
@@ -122,6 +126,7 @@ def test_cli_parse_args_with_flags():
         "--no-llm-filter",
         "--no-auto-seed",
         "--include-maybe",
+        "--check-updates",
     ])
     assert args.name == "stripe"
     assert args.display_name == "Stripe Docs"
@@ -133,12 +138,53 @@ def test_cli_parse_args_with_flags():
     assert args.no_llm_filter is True
     assert args.no_auto_seed is True
     assert args.include_maybe is True
+    assert args.check_updates is True
 
 
 def test_cli_parse_args_invalid_step():
     parser = _build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["https://docs.example.com", "--step", "invalid"])
+
+
+@pytest.mark.asyncio
+async def test_cli_check_updates_runs_sync_only(tmp_path):
+    work_dir = tmp_path / "docs-example-com"
+    work_dir.mkdir()
+
+    discovery = DiscoveryResult(
+        base_url="https://docs.example.com",
+        discovered_at="2026-01-01T00:00:00+00:00",
+        total_urls=2,
+        urls=["https://docs.example.com/a", "https://docs.example.com/b"],
+    )
+
+    report = type(
+        "Report",
+        (),
+        {
+            "checked_at": "2026-01-01T00:00:00+00:00",
+            "new_urls": ["https://docs.example.com/b"],
+            "removed_urls": [],
+            "changed": [],
+            "unchanged_urls": ["https://docs.example.com/a"],
+            "unchecked": [],
+        },
+    )()
+
+    with (
+        patch("king_context.scraper.cli.get_work_dir", return_value=work_dir),
+        patch("king_context.scraper.cli.discover_urls", new_callable=AsyncMock, return_value=discovery) as mock_discover,
+        patch("king_context.scraper.cli.check_for_updates", new_callable=AsyncMock, return_value=report) as mock_check,
+        patch("king_context.scraper.cli.fetch_pages", new_callable=AsyncMock) as mock_fetch,
+        patch("king_context.scraper.cli._update_step") as mock_update,
+    ):
+        await run_pipeline(make_args(check_updates=True), ScraperConfig())
+
+    mock_discover.assert_awaited_once()
+    mock_check.assert_awaited_once()
+    mock_fetch.assert_not_called()
+    mock_update.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +221,7 @@ def test_cli_full_pipeline(tmp_path):
         call_order.append("discover")
         return discovery
 
-    async def mock_fetch(urls, out_dir, cfg):
+    async def mock_fetch(urls, out_dir, cfg, base_url=""):
         call_order.append("fetch")
         return fetch_res
 

--- a/tests/test_scraper/test_fetch.py
+++ b/tests/test_scraper/test_fetch.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import threading
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from king_context.scraper.fetch import fetch_pages, FetchResult
 from king_context.scraper.config import ScraperConfig
@@ -19,7 +19,12 @@ def test_fetch_pages_success(tmp_path):
     ]
 
     with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        result = asyncio.run(fetch_pages(urls, tmp_path, config))
+        with patch(
+            "king_context.scraper.fetch.probe_url_state",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "etag": '"abc"', "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT", "probe_hash": None, "content_length": 123},
+        ):
+            result = asyncio.run(fetch_pages(urls, tmp_path, config))
 
     assert isinstance(result, FetchResult)
     assert result.total == 2
@@ -49,7 +54,12 @@ def test_fetch_handles_failure(tmp_path):
     ]
 
     with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        result = asyncio.run(fetch_pages(urls, tmp_path, config))
+        with patch(
+            "king_context.scraper.fetch.probe_url_state",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "etag": None, "last_modified": None, "probe_hash": "bodyhash", "content_length": 12},
+        ):
+            result = asyncio.run(fetch_pages(urls, tmp_path, config))
 
     assert result.total == 2
     assert result.completed == 1
@@ -80,7 +90,12 @@ def test_fetch_respects_concurrency(tmp_path):
     urls = [f"https://docs.example.com/page-{i}" for i in range(6)]
 
     with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        asyncio.run(fetch_pages(urls, tmp_path, config))
+        with patch(
+            "king_context.scraper.fetch.probe_url_state",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "etag": '"etag"', "last_modified": None, "probe_hash": None, "content_length": 10},
+        ):
+            asyncio.run(fetch_pages(urls, tmp_path, config))
 
     assert active["max"] <= 2
 
@@ -94,7 +109,12 @@ def test_fetch_updates_manifest(tmp_path):
     urls = ["https://docs.example.com/api/intro"]
 
     with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        asyncio.run(fetch_pages(urls, tmp_path, config))
+        with patch(
+            "king_context.scraper.fetch.probe_url_state",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "etag": None, "last_modified": None, "probe_hash": "bodyhash", "content_length": 10},
+        ):
+            asyncio.run(fetch_pages(urls, tmp_path, config))
 
     manifest_path = tmp_path / "manifest.json"
     assert manifest_path.exists()
@@ -102,3 +122,5 @@ def test_fetch_updates_manifest(tmp_path):
     assert "fetch" in manifest
     assert manifest["fetch"]["completed"] == 1
     assert manifest["fetch"]["total"] == 1
+    page_manifest = json.loads((tmp_path / "page_manifest.json").read_text())
+    assert page_manifest["page_count"] == 1

--- a/tests/test_scraper_resume_integration.py
+++ b/tests/test_scraper_resume_integration.py
@@ -167,7 +167,7 @@ class TestFetchResumeIntegration:
 
         fetched_urls = []
 
-        async def mock_fetch_one(url, semaphore, pages_dir, app):
+        async def mock_fetch_one(url, semaphore, pages_dir, app, output_dir, base_url):
             fetched_urls.append(url)
             slug = _url_to_slug(url)
             (pages_dir / f"{slug}.md").write_text(f"# {url}")

--- a/tests/test_scraper_sync.py
+++ b/tests/test_scraper_sync.py
@@ -1,0 +1,159 @@
+"""Tests for page-level scraper sync manifests and change detection."""
+
+import json
+
+import pytest
+
+from king_context.scraper.sync import (
+    check_for_updates,
+    load_page_manifest,
+    probe_url_state,
+    record_page_state,
+)
+
+
+def test_record_page_state_writes_page_manifest(tmp_path):
+    record_page_state(
+        tmp_path,
+        base_url="https://docs.example.com",
+        url="https://docs.example.com/a",
+        markdown="# Intro\n\nHello",
+        etag='"etag-a"',
+        last_modified="Mon, 01 Jan 2026 00:00:00 GMT",
+        probe_hash=None,
+        content_length=42,
+    )
+
+    manifest = json.loads((tmp_path / "page_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["base_url"] == "https://docs.example.com"
+    assert manifest["page_count"] == 1
+    assert "https://docs.example.com/a" in manifest["pages"]
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_detects_new_removed_changed_and_unchanged(tmp_path):
+    record_page_state(
+        tmp_path,
+        base_url="https://docs.example.com",
+        url="https://docs.example.com/a",
+        markdown="# A",
+        etag='"a1"',
+    )
+    record_page_state(
+        tmp_path,
+        base_url="https://docs.example.com",
+        url="https://docs.example.com/b",
+        markdown="# B",
+        etag='"b1"',
+    )
+
+    current_urls = [
+        "https://docs.example.com/a",
+        "https://docs.example.com/c",
+    ]
+
+    async def fake_probe(url: str) -> dict:
+        if url.endswith("/a"):
+            return {"ok": True, "etag": '"a1"', "last_modified": None, "probe_hash": None, "content_length": 10}
+        return {"ok": True, "etag": '"c1"', "last_modified": None, "probe_hash": None, "content_length": 10}
+
+    report = await check_for_updates(
+        base_url="https://docs.example.com",
+        current_urls=current_urls,
+        work_dir=tmp_path,
+        concurrency=2,
+        probe_func=fake_probe,
+    )
+
+    assert report.new_urls == ["https://docs.example.com/c"]
+    assert report.removed_urls == ["https://docs.example.com/b"]
+    assert report.unchanged_urls == ["https://docs.example.com/a"]
+    assert report.changed == []
+    assert report.unchecked == []
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_marks_changed_by_body_hash(tmp_path):
+    record_page_state(
+        tmp_path,
+        base_url="https://docs.example.com",
+        url="https://docs.example.com/a",
+        markdown="# A",
+        probe_hash="oldhash",
+    )
+
+    async def fake_probe(url: str) -> dict:
+        return {"ok": True, "etag": None, "last_modified": None, "probe_hash": "newhash", "content_length": 20}
+
+    report = await check_for_updates(
+        base_url="https://docs.example.com",
+        current_urls=["https://docs.example.com/a"],
+        work_dir=tmp_path,
+        probe_func=fake_probe,
+    )
+
+    assert len(report.changed) == 1
+    assert report.changed[0].url == "https://docs.example.com/a"
+    assert report.changed[0].reason == "body_hash_changed"
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_marks_unchecked_when_probe_fails(tmp_path):
+    record_page_state(
+        tmp_path,
+        base_url="https://docs.example.com",
+        url="https://docs.example.com/a",
+        markdown="# A",
+        etag='"a1"',
+    )
+
+    async def fake_probe(url: str) -> dict:
+        return {"ok": False, "reason": "timeout"}
+
+    report = await check_for_updates(
+        base_url="https://docs.example.com",
+        current_urls=["https://docs.example.com/a"],
+        work_dir=tmp_path,
+        probe_func=fake_probe,
+    )
+
+    assert report.new_urls == []
+    assert report.removed_urls == []
+    assert report.changed == []
+    assert report.unchanged_urls == []
+    assert len(report.unchecked) == 1
+    assert report.unchecked[0].reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_probe_url_state_falls_back_to_get_when_head_has_no_useful_metadata():
+    class FakeResponse:
+        def __init__(self, status_code: int, headers: dict[str, str], text: str = ""):
+            self.status_code = status_code
+            self.headers = headers
+            self.text = text
+
+    class FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def head(self, url: str):
+            return FakeResponse(200, {})
+
+        async def get(self, url: str):
+            return FakeResponse(200, {}, "Hello world")
+
+        async def aclose(self):
+            self.closed = True
+
+    client = FakeClient()
+    state = await probe_url_state("https://docs.example.com/a", client=client)
+
+    assert state["ok"] is True
+    assert state["probe_hash"] is not None
+    assert state["content_length"] == len("Hello world".encode("utf-8"))
+    assert client.closed is False
+
+
+def test_load_page_manifest_returns_empty_when_missing(tmp_path):
+    assert load_page_manifest(tmp_path) == {}


### PR DESCRIPTION
## Summary

This PR adds the first phase of incremental documentation update support to the scraper.

Instead of treating every follow-up scrape like a full rebuild, King Context now stores page-level sync metadata and can detect documentation changes without re-running fetch, chunking, or enrichment.

This is intended as the foundation for future incremental update flows.

## What changed

- added a new page-level sync module for scraped documentation
- introduced page_manifest.json to store per-page sync metadata
- introduced sync_report.json to store change-detection results
- added king-scrape --check-updates
- record page metadata during fetch:
  - URL
  - slug
  - fetch timestamp
  - markdown hash
  - etag
  - last_modified
  - fallback body hash
  - content length
- compare current discovery results against the saved baseline and classify pages as:
  - new
  - removed
  - changed
  - unchanged
  - unchecked
- made scraper package imports lazier so scraper tests and local tooling do not require eager irecrawl imports during module collection

## Why this matters

This gives King Context a much cheaper way to observe documentation drift before doing expensive downstream work.

It does not implement selective re-enrichment yet, but it creates the manifest and comparison layer needed for that next step.

## Testing

Validated with:

pytest tests/test_scraper_sync.py tests/test_scraper/test_fetch.py tests/test_scraper/test_cli.py tests/test_scraper_manifest.py tests/test_scraper_resume_integration.py tests/test_scraper_cli_flags.py -q

Result:

- 40 passed in 1.17s

Also manually validated by creating a page manifest baseline and confirming that sync reports correctly classify:
- new pages
- changed pages
- unchanged pages

## Scope

This PR is intentionally phase 1 only.

It adds persistent sync metadata and change detection, but does not yet perform selective fetch/chunk/enrich/export for only changed pages.