### PR TITLE
Add CoC, PR/issue templates, CONTRIBUTING, docs wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a problem with King Context
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- Clear, concise description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you thought would happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages or stack traces. -->
+
+```
+<paste output here>
+```
+
+## Environment
+
+- King Context version (or commit SHA):
+- Install method: `npx @king-context/cli init` / `pip install -e .` / other
+- OS:
+- Python version:
+- Node version (if installer-related):
+- Claude Code / IDE / agent (if relevant):
+
+## Affected component
+
+- [ ] MCP server (`king-context`)
+- [ ] CLI (`kctx`)
+- [ ] Scraper (`king-scrape`)
+- [ ] Researcher (`king-research`)
+- [ ] Installer (`@king-context/cli`)
+- [ ] Skills (`.claude/skills/`)
+- [ ] Documentation
+- [ ] Other (please describe)
+
+## Additional context
+
+<!-- Logs, screenshots, related issues, or anything else useful. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/deandevz/king-context/discussions
+    about: Ask a question or start a discussion. Please use Discussions, not Issues, for open-ended questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[Feature] "
+labels: idea
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? Who is affected? -->
+
+## Proposed solution
+
+<!-- Describe what you would like to happen. -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about and why you didn't pick them. -->
+
+## Affected component
+
+- [ ] MCP server (`king-context`)
+- [ ] CLI (`kctx`)
+- [ ] Scraper (`king-scrape`)
+- [ ] Researcher (`king-research`)
+- [ ] Installer (`@king-context/cli`)
+- [ ] Skills (`.claude/skills/`)
+- [ ] Documentation
+- [ ] Other (please describe)
+
+## Additional context
+
+<!-- Mockups, links to related discussions, prior art, examples from other tools. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+Thanks for contributing to King Context!
+Please fill in the sections below. Delete any that do not apply.
+-->
+
+## Summary
+
+<!-- One or two sentences explaining what this PR does and why. -->
+
+## Related issue
+
+<!-- Link the issue this PR addresses. Use "Closes #123" to auto-close on merge. -->
+
+Closes #
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation update
+- [ ] Refactor / internal cleanup (no functional change)
+- [ ] Tooling / CI / build
+- [ ] New corpus package (scraped docs or research export)
+
+## How it was tested
+
+<!--
+Describe the tests you ran. Include commands and expected output.
+Example:
+  pytest tests/test_db.py -v
+  king-scrape https://example.com --stop-after fetch
+-->
+
+## Screenshots / output (optional)
+
+<!-- Paste CLI output, screenshots, or logs that help reviewers verify the change. -->
+
+## Checklist
+
+- [ ] My code follows the project style (English-only code, comments, and identifiers)
+- [ ] I ran the test suite locally and it passes (`pytest`)
+- [ ] I added or updated tests where it made sense
+- [ ] I updated the documentation in `docs/` and/or `README.md` if behavior changed
+- [ ] I read the [Contributing guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [ ] My commits follow the project commit message style
+- [ ] I confirmed there are no secrets or credentials in the diff
+
+## Additional notes
+
+<!-- Anything else reviewers should know: trade-offs, follow-ups, open questions. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <bruucetscontact@gmail.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+<https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+# Contributing to King Context
+
+Thanks for your interest in improving King Context. This document explains how to set up the project locally, the standards we follow, and the workflow for getting changes merged.
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+## Where to start
+
+The three areas where the project benefits the most from outside help:
+
+1. **Corpus packages** — scrape an API or research a topic and open a PR with the enriched JSON. A community library of pre-enriched corpora is the project's biggest lever.
+2. **Pipeline reliability** — edge cases in URL discovery, chunking, JavaScript-rendered pages, or source filtering in `king-research`.
+3. **Skill improvements** — sub-agent reliability, error handling, parallel enrichment in the Claude Code skills.
+
+If unsure where to start, browse [open issues](https://github.com/deandevz/king-context/issues) labeled `good first issue` or `help wanted`, or open a discussion describing what you want to work on.
+
+---
+
+## Project standards
+
+### Language
+
+- All code, comments, variable names, function names, and documentation must be in **English**.
+- Git commit messages and PR descriptions must be in **English**.
+- Architecture docs and design notes can be in Portuguese when scoped that way, but never mix languages inside the same file.
+
+### Code style
+
+- Python: follow the existing style in `src/` (PEP 8, type hints where helpful, no broad `except` clauses without a reason).
+- Shell scripts: POSIX-compatible when possible, `#!/usr/bin/env bash` otherwise.
+- Keep changes focused. A bug fix should not include unrelated refactors. A refactor should not change behavior.
+- Prefer editing existing files over creating new ones unless a new module is clearly needed.
+
+### Tests
+
+- Tests live in `tests/`. Use `pytest`.
+- Add or update tests when fixing a bug or adding a feature. Tests should fail before your fix and pass after.
+- See `tests/conftest.py` for shared fixtures and patterns.
+
+---
+
+## Local development setup
+
+### 1. Fork and clone
+
+```bash
+git clone git@github.com:<your-username>/king-context.git
+cd king-context
+git remote add upstream git@github.com:deandevz/king-context.git
+```
+
+### 2. Create a virtual environment and install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+### 3. Configure environment variables
+
+```bash
+cp .env.example .env
+# Fill in FIRECRAWL_API_KEY, EXA_API_KEY, OPENROUTER_API_KEY as needed
+```
+
+### 4. Seed the database (optional, for MCP work)
+
+```bash
+python -m king_context.seed_data
+```
+
+### 5. Run the test suite
+
+```bash
+pytest
+```
+
+For more detail on the codebase, see [`CLAUDE.md`](CLAUDE.md) and the [architecture overview](docs/architecture.md).
+
+---
+
+## Branching and commits
+
+### Branch names
+
+Use a short, descriptive prefix:
+
+- `feat/<short-name>` — new feature
+- `fix/<short-name>` — bug fix
+- `docs/<short-name>` — documentation only
+- `refactor/<short-name>` — internal cleanup, no behavior change
+- `chore/<short-name>` — tooling, dependencies, build
+
+Example: `feat/parallel-enrichment`, `fix/cache-collision`.
+
+### Commit messages
+
+The project follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+```txt
+<type>(<scope>): <short description>
+
+<optional longer body explaining the why>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`.
+Common scopes: `cli`, `mcp`, `scraper`, `research`, `installer`, `skill`, `db`, `docs`, `tests`.
+
+Examples:
+
+```txt
+feat(scraper): add JavaScript rendering fallback
+fix(db): handle empty FTS query without raising
+docs(readme): trim quick start, link to docs/architecture
+```
+
+Keep the subject under ~72 characters. Use the body to explain *why*, not *what* (the diff already shows what).
+
+---
+
+## Pull request workflow
+
+1. **Discuss first for large changes.** Open an issue or a discussion before starting on anything that takes more than a couple of hours. Saves rework.
+2. **Branch off `main`.** Keep your branch focused on one logical change.
+3. **Run tests locally.** `pytest` should pass before you push.
+4. **Open the PR against `main`.** Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — summary, related issue, type, how it was tested, checklist.
+5. **Be responsive to review.** Push follow-up commits on the same branch. Squash on merge is fine; we will handle that.
+6. **Sign-off is not required**, but `Co-Authored-By` trailers for pair work are welcome.
+
+### What makes a PR easy to merge
+
+- Small, focused diff.
+- Clear motivation in the description (link the issue, explain the why).
+- Tests that fail before and pass after, when applicable.
+- Documentation updated when behavior changes.
+- No unrelated formatting or refactor noise.
+
+---
+
+## Reporting bugs
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md). Include:
+
+- King Context version or commit SHA
+- Install method, OS, Python and Node versions
+- Exact steps to reproduce
+- Expected vs actual behavior
+- Logs, stack traces, or output
+
+---
+
+## Suggesting features
+
+Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md). Lead with the *problem*, then propose a solution. Alternatives considered help reviewers understand your reasoning.
+
+For broad direction questions ("should King Context do X?"), open a discussion instead of an issue.
+
+---
+
+## Security
+
+If you find a security issue, do **not** open a public issue. Email the maintainers at `bruucetscontact@gmail.com` with details. We will respond and coordinate disclosure.
+
+---
+
+## Questions
+
+- **Open-ended questions:** [GitHub Discussions](https://github.com/deandevz/king-context/discussions)
+- **Bugs:** [Issues](https://github.com/deandevz/king-context/issues)
+- **Conduct concerns:** `bruucetscontact@gmail.com`
+
+Thanks again for contributing.

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -16,15 +16,13 @@ Local first. Eficiente em tokens. Open source.
 
 ## Por que isso existe
 
-Agente escreve código melhor, análise melhor, qualquer coisa melhor quando tem o contexto certo. O problema é descobrir o que "certa" significa sem despejar a pia da cozinha inteira no contexto.
+Agente escreve código melhor, análise melhor, qualquer coisa melhor quando tem o contexto certo. O problema é descobrir o que "certo" significa sem despejar a pia da cozinha inteira no contexto.
 
 Uma única página de API custa 15 mil tokens de markdown cru, e a maior parte é ruído. Ferramentas de retrieval na nuvem tipo Context7 mandam chunks baseados em similaridade semântica — um servidor remoto decide o que seu agente vê, e o agente paga a conta dos tokens independente de ter precisado de tudo aquilo. Você não consegue ver o que tá indexado, não controla a atualização, e não funciona offline.
 
-Forçar um agente a ler dez arquivos `.md` de 400 linhas é o mesmo problema com outra roupagem: a maioria desses tokens nunca importou pro passo atual.
-
 King Context vai por outro caminho. Cada seção de cada página coletada ou fonte pesquisada recebe metadados estruturados (keywords, casos de uso, tags, prioridade). O agente busca nos metadados primeiro, faz preview antes de ler, e só puxa o conteúdo completo quando realmente precisa. O cache de queries aprende os caminhos mais comuns no seu corpus, então lookups repetidos caem pra menos de um milissegundo. Progressive disclosure, não dump.
 
-Na prática: um agente sem conhecimento prévio de uma API consegue ler os docs e produzir código funcional de primeira, geralmente com uns 2.800 tokens no total. Uma varredura `--high` de pesquisa sobre prompt engineering indexou 172 fontes, e o agente ainda conseguiu conversar longamente sobre design em cima desse corpus gastando uns ~4% da janela de contexto. Os mesmos workflows navegando webpages crus custam 15 mil+ tokens por página e ainda obrigam o agente a achar o que importa.
+Na prática: um agente sem conhecimento prévio de uma API consegue ler os docs e produzir código funcional de primeira, geralmente com uns 2.800 tokens no total. Uma varredura `--high` de pesquisa sobre prompt engineering indexou 172 fontes, e o agente ainda conseguiu conversar longamente sobre design em cima desse corpus gastando uns ~4% da janela de contexto.
 
 ---
 
@@ -54,237 +52,72 @@ Faz scraping de um site de docs:
 .king-context/bin/kctx index .king-context/data/stripe.json
 ```
 
-Ou pesquisa um tópico da web aberta — mesmo índice, sem precisar de URL inicial:
+Ou pesquisa um tópico na web aberta — mesmo índice, sem precisar de URL inicial:
 
 ```bash
 .king-context/bin/king-research "prompt engineering techniques" --high --yes
 .king-context/bin/king-research "retry backoff" --basic --yes
 ```
 
-O `king-research` descobre fontes pela web via Exa, faz chunking e enrichment do mesmo jeito que o scraper, e joga o resultado em `.king-context/research/<slug>/`. O tamanho do corpus escala com o esforço: `--basic` tipicamente cobre ~30 fontes em menos de um minuto, `--high` alcança bem mais de 150 em alguns minutos, `--extrahigh` é a varredura estado da arte.
+`king-research` descobre fontes pela web, faz chunk e enrichment do mesmo jeito que o `king-scrape`, e despeja o resultado em `.king-context/research/<slug>/`. Tamanho do corpus escala com o esforço: `--basic` geralmente indexa ~30 fontes em menos de um minuto, `--high` chega a mais de 150 em alguns minutos, `--extrahigh` é a varredura state-of-the-art.
 
-Ou simplesmente pede pro Claude Code em linguagem natural: *"faz scraping da documentação do Stripe"* ou *"pesquisa prompt engineering, detalhado"*. As skills instaladas roteiam pro pipeline certo.
+Ou simplesmente pede pro Claude Code em português: *"faz scraping dos docs do Stripe"* ou *"pesquisa prompt engineering, detalhado"*. As skills instaladas roteiam pra pipeline certa.
 
-Depois busca, faz preview e lê — mesmos comandos pra docs e pra pesquisa:
+Aí busca, faz preview e lê — mesmos comandos pra docs e research:
 
 ```bash
 kctx list                                           # docs
-kctx list research                                  # corpus de pesquisa
+kctx list research                                  # corpora de research
 kctx search "authentication" --doc stripe          # busca por metadados
-kctx read stripe authentication --preview          # uns 400 tokens
+kctx read stripe authentication --preview          # ~400 tokens
 kctx read stripe authentication                    # seção completa
-kctx topics prompt-engineering-techniques          # navega a árvore de um research
-kctx grep "Bearer" --doc stripe --context 3       # regex como fallback
+kctx topics prompt-engineering-techniques          # navega na árvore de research
+kctx grep "Bearer" --doc stripe --context 3       # fallback regex
 ```
 
-Todo comando aceita `--json` pra saída legível por máquina.
+Todo comando aceita `--json` pra output legível por máquina. Referência completa: [`docs/CLI_GUIDE.md`](docs/CLI_GUIDE.md).
 
 ---
 
-## Como funciona
+## Documentação
 
-Quatro peças.
+Wiki dentro do repo em [`docs/`](docs/index.md):
 
-**king-scrape** — aponta pra um site de docs. Ele descobre as páginas, baixa, faz chunking do conteúdo e enriquece cada chunk via LLM.
+- [Architecture](docs/architecture.md) — como o cascade search, o scraper e o researcher se conectam
+- [Vision](docs/vision.md) — pra onde o projeto tá indo, e as ideias de design por trás
+- [Benchmarks](docs/benchmarks.md) — números de performance contra Context7
+- [Case studies](docs/case-studies.md) — sessões reais de agente, com trace completo
+- [Roadmap](docs/roadmap.md) — planos de curto e longo prazo
+- [CLI guide](docs/CLI_GUIDE.md) — comandos e flags do `kctx`
 
-**king-research** — passa um tópico. Ele gera queries de busca, puxa fontes da web aberta via Exa, busca e faz chunking do conteúdo, e entrega os chunks pra mesma etapa de enrichment que o scraper usa. `--basic` até `--extrahigh` controla quantas queries e quantas iterações de aprofundamento rodam.
-
-Os dois produzem o mesmo formato de saída. Cada seção acaba anotada assim:
-
-```json
-{
-  "keywords": ["api-key", "bearer-token", "authentication"],
-  "use_cases": ["Configure API authentication", "Rotate API keys"],
-  "tags": ["security", "setup"],
-  "priority": 10
-}
-```
-
-**kctx index** transforma o JSON enriquecido numa estrutura de arquivos plana com índices reversos. Docs vão pra `.king-context/docs/`; pesquisas vão pra `.king-context/research/`. Stores separados, mesma superfície de retrieval.
-
-**kctx** é a interface de busca. Ela pontua as seções comparando os termos da query com os índices de keyword e use case. Sem full text scan, sem similaridade vetorial em uns 90% das lookups. Um cache local de queries colapsa lookups repetidos pra leituras em sub-milissegundo. Em cima disso, o próprio agente pode escrever shortcuts em `.king-context/_learned/<corpus>.md` conforme trabalha — mapeando perguntas comuns pros paths exatos das seções — e a próxima sessão pula a fase de busca inteira. A camada de retrieval fica mais rápida por corpus com o tempo, sem ninguém ter que configurar nada.
-
-A etapa de enrichment é o coração da ideia. Os agentes acham a seção certa via metadados estruturados, em vez de escanear conteúdo cru. É isso que faz o progressive disclosure funcionar sem perder recall — e é o que permite a mesma máquina servir tanto um site de doc de vendor quanto uma varredura de pesquisa cruzando a web.
+> Os documentos da wiki estão em inglês pra alinhar com as regras do projeto. Este README PT-BR é o ponto de entrada localizado.
 
 ---
 
-## Benchmarks
+## Em resumo
 
-Rodamos dois rounds contra o Context7, que é a ferramenta de documentação mais usada pra code agents hoje.
-
-### Round 1: MCP server vs MCP server
-
-Arquitetura original. As duas ferramentas expostas como MCP server, mesmo corpus, mesmo agente.
-
-| Métrica | King Context | Context7 | Melhoria |
-|---|---|---|---|
-| Tokens médios por query | 968 | 3.125 | 3,2x menos |
-| Latência (metadata hit) | 1,15ms | 200 a 500ms | 170x mais rápido |
-| Latência (full text search) | 97,83ms | 200 a 500ms | 2 a 5x mais rápido |
-| Resultados duplicados | 0 | 11 | zero desperdício |
-| Score de relevância | 3,2 / 5 | 2,8 / 5 | +14% |
-| Implementabilidade | 4,4 / 5 | 4,0 / 5 | +10% |
-
-Dados completos no [BENCHMARK.md](BENCHMARK.md).
-
-### Round 2: skill vs skill
-
-As duas ferramentas agora rodando como CLI + skill do Claude Code, com o mesmo agente dirigindo. A comparação foi feita sobre a doc da Google Gemini API usando Claude Opus 4.7.
-
-| Métrica | Context7 (skill) | King Context (skill) | Vencedor |
-|---|---|---|---|
-| Tokens médios por query | ~1.896 | ~1.064 | King Context |
-| Tokens medianos por query | 1.750 | 901 | King Context |
-| Fatos corretos | 32 / 38 (84%) | 38 / 38 (100%) | King Context |
-| Alucinações por query | 0,33 | 0,0 | King Context |
-| Qualidade composta (0 a 5) | 3,46 | 4,79 | King Context |
-| Código first-shot (Q4) | compila | compila | empate |
-
-### O que o round 2 realmente mostrou
-
-O gap de tokens diminuiu em relação ao round 1, mas a história mudou de quantidade pra qualidade. Com os dois lados agora dirigidos pelo agente, a diferença tá em como cada ferramenta estrutura aquilo que o agente pode pedir.
-
-Três coisas que o King Context fez e o Context7 não:
-
-**Se corrigir sozinho.** A busca inicial da Q1 não pegou a página de spec do modelo. O agente rodou `grep`, achou a linha, leu a seção em modo preview, e parou ali. Custo total ainda menor que a chamada única e inchada do Context7. Progressive disclosure (`search, grep, preview, read`) dá checkpoints pro agente voltar atrás e tentar outro ângulo sem gastar muito.
-
-**Se recusar a alucinar.** A Q5 perguntou sobre headers `Retry-After`. O King Context respondeu explicitamente "não presente nos docs indexados". O Context7 retornou uns 600 tokens de exemplos curl de upload sem relação nenhuma, só porque "rate limit" bateu por proximidade. Quando o retrieval devolve chunks grandes escolhidos por similaridade semântica, falso positivo entra no contexto silenciosamente. Quando o retrieval é em etapas e filtrado por metadados, o agente sabe reconhecer quando tá faltando alguma coisa.
-
-**Lidar com ambiguidade.** A Q3 tocou em `media_resolution`. A Gemini API tem duas gerações desse parâmetro. O King Context retornou as duas. O Context7 retornou só a versão legada, que tá defasada pro Gemini 3. Metadados estruturados (keywords + use cases + tags) pegam as duas gerações; similaridade semântica trava na que tem mais massa no corpus.
-
-A vitória do round 2 não é "o agente dirige o retrieval". Os dois lados dirigem o retrieval agora. A vitória é o formato daquilo que o agente pode alcançar: unidades pequenas, indexadas por metadados, previewáveis, versus chunks maiores rankeados por semântica.
-
-### Limitações que a gente assume
-
-* Só uma run por query no round 2, não duas. Variância desconhecida.
-* Contagem de tokens do Context7 é estimativa por caractere, não tiktoken. Margem de erro de uns 20%.
-
----
-
-## Case studies
-
-Sessões reais, não benchmarks sintéticos. Cada uma registra a sequência de comandos que o agente rodou, o corpus que ele consultou, e o artefato que ele produziu.
-
-- **[MiniMax TTS — first-shot code](validation/minimax-tts-first-shot/)** — Agente lê a API reference de um vendor via `kctx` e escreve código que funciona de primeira. 5 lookups, ~2.800 tokens de doc consumidos, zero ajustes.
-- **[Triage-1 — síntese a partir de pesquisa](validation/examples/prompt-engineering-triage1/)** — Agente consulta um corpus de 172 fontes do `king-research --high` sobre prompt engineering e compõe um prompt de suporte nível produção cruzando 5–6 seções indexadas. Conversa de design inteira cabe em ~4% da janela de contexto. Um arquivo `.king-context/_learned/` é escrito pelo próprio agente no meio da sessão — o cache de retrieval se aquecendo como efeito colateral do trabalho.
-
-Mais casos em [`validation/examples/`](validation/examples/). PRs bem-vindos.
-
----
-
-## Pra onde isso vai
-
-King Context começou como ferramenta de busca contra docs coletados. A direção daqui pra frente é maior: uma camada de retrieval que qualquer agente, em qualquer tópico, pode encostar sem queimar a janela de contexto.
-
-### O problema do `.md`, resolvido de lado
-
-O padrão dominante hoje pra dar conhecimento pra agente é uma pasta de arquivos markdown. Ele desmorona no momento em que a pasta fica séria. Dez docs de 400 linhas é um imposto de cinco dígitos de token em cada turno, e os agentes ainda perdem o parágrafo específico que importava.
-
-King Context substitui esse padrão. O corpus pode ser arbitrariamente grande porque o agente nunca carrega ele inteiro. A busca por metadados filtra pra seção certa, o preview devolve ~400 tokens, o read completo só devolve o resto se precisar. O cache de queries aprende seus caminhos mais comuns. Quanto maior o corpus, mais a disciplina de retrieval compensa.
-
-### Skills e agentes rodando em vários corpus
-
-Uma skill ou sub-agente não devia precisar carregar o material de referência dentro do contexto. Ele devia consultar o corpus do mesmo jeito que um dev faz grep num codebase — com precisão, progressivamente, só quando precisa.
-
-Com o King Context, um único agente pode ter na manga o índice da API do Stripe, a varredura de pesquisa em "webhook security", o runbook interno do time, e um corpus de pesquisa específico de domínio (culinária LATAM, estado da arte em prompt engineering), e alcançar qualquer um deles no meio de uma tarefa. O formato de retrieval é o mesmo em todos. Constrói uma vez, pluga várias bases de conhecimento.
-
-### Registry comunitário de conhecimento
-
-Qualquer pessoa que fizer scraping de uma lib ou pesquisar um tópico pode publicar o corpus enriquecido. Outras pessoas instalam com um comando:
-
-```bash
-kctx install stripe@v1
-kctx install prompt-engineering-2026
-```
-
-Mantido pela comunidade, versionado, sempre atualizado. Pré-enriquecido, então você pula a etapa de scraping ou de pesquisa. Docs de vendor são ponto de partida, não o teto — o registry pode guardar corpus de pesquisa, coleções internas curadas, e alternativas mantidas pela comunidade com exemplos melhores e ciclos de update mais rápidos.
-
-### Agentes que escrevem skills especializadas a partir de um corpus
-
-Um agente que lê seu corpus pode gerar uma skill do Claude Code que conhece as convenções da lib, as pegadinhas, e os padrões idiomáticos. Ou, a partir de um corpus de pesquisa, uma skill que codifica o consenso e as divergências entre 30+ fontes. Corpus entra, skill sai.
-
-É aqui que o King Context deixa de ser só uma ferramenta de retrieval e vira uma fábrica de skills.
-
-### Integração no workflow de dev
-
-Retrieval é a base. A camada seguinte é morar dentro do loop de desenvolvimento: pinar versões de doc pro projeto pra seu agente nunca dar drift, monitorar mudanças upstream nos docs que possam afetar código que você já escreveu, trazer à tona as seções relevantes quando o agente te vê trabalhando em algo.
-
-A ideia não é "agente pergunta, corpus responde". A ideia é que seu agente sempre tenha o contexto certo na mão, silenciosamente, sem você precisar pedir.
-
----
-
-## CLI e MCP
-
-King Context entrega duas interfaces. Elas servem ambientes diferentes.
-
-A **CLI e a skill do Claude Code** são o foco. É onde code agents trabalham melhor, e é de onde saem os números de qualidade do benchmark. Se você usa King Context dentro do Claude Code, Cursor, ou qualquer workflow de coding agentic, esse é o caminho.
-
-O **MCP server** continua com suporte. Algumas ferramentas e workflows precisam de MCP nativo: agentes não coders, integração com IDE, e qualquer coisa que espera um endpoint MCP. Roda em cima do mesmo corpus e continua recebendo melhorias, só que num ritmo menos agressivo que a CLI.
-
-Escolhe com base no seu ambiente. O corpus é o mesmo dos dois jeitos.
-
----
-
-## Estrutura do projeto
-
-```
-king-context/
-├── src/context_cli/        # pacote da CLI (kctx)
-│   ├── searcher.py         # busca por metadados
-│   ├── reader.py           # leitor de seção com preview
-│   ├── indexer.py          # indexador de JSON pra arquivo
-│   └── grep.py             # fallback de regex
-├── src/king_context/       # MCP server, scraper, researcher
-│   ├── server.py           # MCP server
-│   ├── db.py               # cascade search em SQLite
-│   ├── scraper/            # pipeline do king-scrape (URL → corpus)
-│   └── research/           # pipeline do king-research (tópico → corpus)
-├── .king-context/          # data store (gerado)
-│   ├── docs/               # documentação coletada
-│   ├── research/           # tópicos pesquisados
-│   └── _learned/           # cache de shortcuts escrito pelo agente (cresce com o uso)
-├── validation/
-│   ├── minimax-tts-first-shot/   # case doc-driven (código first-shot)
-│   └── examples/                 # cases de síntese / multi-fonte
-└── .claude/skills/         # skills do Claude Code (king-context, scraper-workflow, king-research)
-```
-
----
-
-## Roadmap
-
-Curto prazo:
-
-* Registry comunitário com pacotes de doc e pesquisa versionados
-* Distribuição via `pip install king-context`
-* Skills geradas por agente a partir dos docs coletados e dos corpus de pesquisa
-* Melhor confiabilidade dos sub-agentes durante o enrichment
-* Pipeline de pesquisa mais rico: filtros por domínio, deduplicação de fontes entre tópicos
-
-Mais pra frente:
-
-* Pin de versão por projeto, com notificação quando docs upstream mudam
-* Hooks de workflow que trazem seções relevantes durante coding ativo
-* Scraping mais esperto: descoberta de URL, limites de chunk, conteúdo renderizado por JavaScript
-* Busca cross-corpus (query em vários índices numa chamada só)
-* Mais casos de validação cobrindo estilos de API e tasks de agente variadas
+- **Eficiente em tokens.** ~1.000 tokens por query versus ~3.000 do Context7 no benchmark original, e 100% de precisão factual versus 84% no round skill-vs-skill. Números e metodologia em [Benchmarks](docs/benchmarks.md).
+- **Local first.** Seu corpus, sua máquina. Zero round-trip pra nuvem na hora de buscar. Funciona offline.
+- **Dois caminhos de entrada, uma superfície de retrieval.** `king-scrape` pra docs de vendor, `king-research` pra tópicos da web aberta. Mesmo JSON enriquecido, mesma interface `kctx`.
+- **Progressive disclosure.** Busca por metadados → preview → leitura completa. Agente só puxa o que precisa.
+- **Cache que se aquece sozinho.** Agentes escrevem shortcuts em `.king-context/_learned/<corpus>.md` enquanto trabalham. Retrieval fica mais rápido por corpus ao longo do tempo, sem ninguém configurar nada.
 
 ---
 
 ## Contribuindo
 
-Três áreas em que o projeto mais precisa de ajuda.
+O projeto é open source porque infraestrutura de retrieval pra LLMs deveria ser transparente, dirigida pela comunidade, e independente de qualquer provedor.
 
-**Pacotes de corpus.** Se tem alguma API, framework ou tópico que você usa bastante, faz scraping ou pesquisa e abre um PR. Uma biblioteca comunitária de bases de conhecimento pré-enriquecidas é a maior alavanca desse projeto.
+Três áreas onde o projeto mais precisa de ajuda externa:
 
-**Confiabilidade dos pipelines.** Casos extremos na descoberta de URL, estratégias de chunking pra formatos de doc incomuns, páginas renderizadas por JavaScript, filtragem melhor de fontes no `king-research`.
+- **Pacotes de corpus.** Faz scraping de uma API ou pesquisa um tópico que você usa muito, e abre um PR. Uma biblioteca comunitária de corpora pré-enriquecidos é a maior alavanca do projeto.
+- **Confiabilidade da pipeline.** Edge cases em URL discovery, chunking, páginas com JavaScript, filtragem de fontes.
+- **Melhorias de skill.** Confiabilidade de sub-agente, tratamento de erro, enrichment paralelo.
 
-**Melhorias nas skills.** Os workflows do Claude Code tão em beta. Deixar os sub-agentes mais confiáveis, lidar com erros direito, rodar as etapas de enrichment em paralelo.
-
-Esse projeto é open source porque infraestrutura de retrieval pra LLM tem que ser transparente, movida pela comunidade, e independente de qualquer provider único.
+Lê o [contributing guide](CONTRIBUTING.md) pra setup, branches, estilo de commit e workflow de PR. Participando, você concorda com o [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 
 ## Licença
 
-MIT. Usa, faz fork, melhora.
+MIT. Usa, dá fork, melhora.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # King Context
 
-Portuguese Version: [README-pt-br.md](README-pt-br.md).
+Portuguese version: [README-pt-br.md](README-pt-br.md).
 
 > *What started as an open-source alternative to Context7 just became the start of something much bigger than we imagined.*
 
@@ -20,11 +20,9 @@ Agents write better code, better analysis, better anything when they have the ri
 
 A single API page costs 15k tokens of raw markdown, and most of it is noise. Cloud retrieval tools like Context7 send chunks based on semantic similarity — a remote server decides what your agent sees, and the agent pays the token bill whether it needed all of that or not. You can't see what's indexed, you don't control updates, and it doesn't work offline.
 
-Forcing an agent to read ten 400-line `.md` files is the same problem dressed differently: most of those tokens never mattered for the current step.
-
 King Context takes a different route. Every section of every scraped page or researched source gets structured metadata (keywords, use cases, tags, priority). The agent searches metadata first, previews before reading, and only pulls full content when it actually needs to. The query cache learns the common paths into your corpus, so repeat lookups hit in under a millisecond. Progressive disclosure, not dump.
 
-In practice: an agent with no prior knowledge of an API can read the docs and produce working code on the first try, usually around 2,800 tokens total. A `--high` research sweep on prompt engineering indexed 172 sources and the agent could still hold a full design conversation on top of that corpus using ~4% of its context window. Same workflows browsing raw webpages run 15k+ tokens per page and still leave the agent to figure out what matters.
+In practice: an agent with no prior knowledge of an API can read the docs and produce working code on the first try, usually around 2,800 tokens total. A `--high` research sweep on prompt engineering indexed 172 sources and the agent could still hold a full design conversation on top of that corpus using ~4% of its context window.
 
 ---
 
@@ -77,211 +75,44 @@ kctx topics prompt-engineering-techniques          # browse a research tree
 kctx grep "Bearer" --doc stripe --context 3       # regex fallback
 ```
 
-Every command accepts `--json` for machine-readable output.
+Every command accepts `--json` for machine-readable output. Full reference: [`docs/CLI_GUIDE.md`](docs/CLI_GUIDE.md).
 
 ---
 
-## How it works
+## Documentation
 
-Four pieces.
+In repo wiki under [`docs/`](docs/index.md):
 
-**king-scrape** — point it at a docs site. It discovers pages, downloads them, chunks the content, and enriches each chunk through an LLM.
-
-**king-research** — give it a topic. It generates search queries, pulls sources from the open web via Exa, fetches and chunks their content, and hands the chunks to the same enrichment step as the scraper. `--basic` to `--extrahigh` controls how many queries and how many deepening iterations run.
-
-Both produce the same shape of output. Each section ends up annotated like this:
-
-```json
-{
-  "keywords": ["api-key", "bearer-token", "authentication"],
-  "use_cases": ["Configure API authentication", "Rotate API keys"],
-  "tags": ["security", "setup"],
-  "priority": 10
-}
-```
-
-**kctx index** turns the enriched JSON into a flat file structure with reverse indexes. Docs go to `.king-context/docs/`; research goes to `.king-context/research/`. Separate stores, same retrieval surface.
-
-**kctx** is the search interface. It scores sections by matching query terms against the keyword and use case indexes. No full-text scan, no vector similarity on roughly 90% of lookups. A local query cache collapses repeat lookups to sub-millisecond reads. On top of that, agents can write `.king-context/_learned/<corpus>.md` shortcuts as they work — mapping common questions to exact section paths — so the next session skips the search phase entirely. The retrieval layer gets faster per corpus over time, without anyone wiring it up.
-
-The enrichment step is the core of the idea. Agents find the right section through structured metadata instead of scanning raw content. That's what makes progressive disclosure work without losing recall — and it's what lets the same machinery serve both a vendor doc site and a cross-web research sweep.
+- [Architecture](docs/architecture.md) — how the cascade search, scraper, and researcher fit together
+- [Vision](docs/vision.md) — where the project is going, and the design ideas behind it
+- [Benchmarks](docs/benchmarks.md) — performance numbers vs Context7
+- [Case studies](docs/case-studies.md) — real agent sessions with full traces
+- [Roadmap](docs/roadmap.md) — short-term and long-term plans
+- [CLI guide](docs/CLI_GUIDE.md) — `kctx` commands and flags
 
 ---
 
-## Benchmarks
+## At a glance
 
-We ran two rounds against Context7, the most widely used documentation tool for code agents today.
-
-### Round 1: MCP server vs MCP server
-
-Original architecture. Both tools exposed as MCP servers, same corpus, same agent.
-
-| Metric | King Context | Context7 | Improvement |
-|---|---|---|---|
-| Average tokens per query | 968 | 3,125 | 3.2x less |
-| Latency (metadata hit) | 1.15ms | 200 to 500ms | 170x faster |
-| Latency (full text search) | 97.83ms | 200 to 500ms | 2 to 5x faster |
-| Duplicate results | 0 | 11 | zero waste |
-| Relevance score | 3.2 / 5 | 2.8 / 5 | +14% |
-| Implementability | 4.4 / 5 | 4.0 / 5 | +10% |
-
-Full data in [BENCHMARK.md](BENCHMARK.md).
-
-### Round 2: skill vs skill
-
-Both tools now running as CLI + Claude Code skill, driven by the same agent. The comparison ran on the Google Gemini API docs using Claude Opus 4.7.
-
-| Metric | Context7 (skill) | King Context (skill) | Winner |
-|---|---|---|---|
-| Average tokens per query | ~1,896 | ~1,064 | King Context |
-| Median tokens per query | 1,750 | 901 | King Context |
-| Correct facts | 32 / 38 (84%) | 38 / 38 (100%) | King Context |
-| Hallucinations per query | 0.33 | 0.0 | King Context |
-| Composite quality (0 to 5) | 3.46 | 4.79 | King Context |
-| First-shot code (Q4) | compiles | compiles | tie |
-
-### What round 2 actually showed
-
-The token gap shrank compared to round 1, but the story shifted from quantity to quality. With both sides now agent-driven, the difference is in how each tool shapes what the agent can ask for.
-
-Three things King Context did that Context7 didn't:
-
-**Self-correct.** The initial Q1 search missed the model spec page. The agent ran `grep`, found the line, read the section in preview mode, and stopped there. Total cost still lower than Context7's single bloated call. Progressive disclosure (`search, grep, preview, read`) gives the agent checkpoints to backtrack and try another angle without burning budget.
-
-**Refuse to hallucinate.** Q5 asked about `Retry-After` headers. King Context explicitly answered "not present in the indexed docs". Context7 returned about 600 tokens of unrelated curl upload examples, purely because "rate limit" matched by proximity. When retrieval hands back large chunks picked by semantic similarity, false positives slip into context quietly. When retrieval is staged and filtered by metadata, the agent can tell when something is missing.
-
-**Handle ambiguity.** Q3 touched `media_resolution`. The Gemini API has two generations of that parameter. King Context returned both. Context7 returned only the legacy version, which is outdated for Gemini 3. Structured metadata (keywords + use cases + tags) catches both generations; semantic similarity locks onto whichever has more mass in the corpus.
-
-The round 2 win isn't "the agent drives retrieval". Both sides drive retrieval now. The win is the shape of what the agent can reach: small units indexed by metadata, previewable, versus bigger chunks ranked by semantics.
-
-### Limitations we own
-
-* One run per query in round 2, not two. Variance unknown.
-* Context7 token counts are per-character estimates, not tiktoken. About 20% margin of error.
-
----
-
-## Case studies
-
-Real sessions, not synthetic benchmarks. Each one captures the command sequence the agent ran, the corpus it worked against, and the artifact it produced.
-
-- **[MiniMax TTS — first-shot code](validation/minimax-tts-first-shot/)** — Agent reads a vendor API reference through `kctx` and writes working code on the first run. 5 lookups, ~2,800 tokens of docs consumed, zero adjustments.
-- **[Triage-1 — research-driven synthesis](validation/examples/prompt-engineering-triage1/)** — Agent queries a 172-source `king-research --high` corpus on prompt engineering and composes a production-grade customer-support prompt, cross-referencing 5–6 indexed sources. Full design conversation fits in ~4% of the context window. A `.king-context/_learned/` shortcut file is written mid-session — the retrieval cache warming itself as a side effect of the work.
-
-More cases under [`validation/examples/`](validation/examples/). PRs welcome.
-
----
-
-## Where this is going
-
-King Context started as a search tool against scraped docs. The direction from here is bigger: a retrieval layer that any agent, on any topic, can lean on without burning its context window.
-
-### The `.md` problem, solved sideways
-
-The dominant pattern for giving agents knowledge today is a folder of markdown files. It falls over the moment the folder gets real. Ten 400-line docs is a five-digit token tax on every turn, and agents still miss the one paragraph that matters.
-
-King Context replaces that pattern. The corpus can be arbitrarily large because the agent never loads it whole. Metadata search filters to the right section, preview returns ~400 tokens, full read returns the rest only if needed. The query cache learns your common paths. The bigger the corpus, the more the retrieval discipline pays off.
-
-### Skills and agents that run on multiple corpora
-
-A skill or sub-agent shouldn't need to carry its reference material in-context. It should query the corpus the same way a developer greps a codebase — narrowly, progressively, only when needed.
-
-With King Context, a single agent can hold an index for Stripe's API, the research sweep on "webhook security", the team's internal runbook, and a domain-specific research corpus (e.g. LATAM cooking techniques, prompt engineering state of the art), and reach into any of them mid-task. The retrieval shape is the same across all of them. Build once, plug in many knowledge bases.
-
-### Community knowledge registry
-
-Anyone who scrapes a lib or researches a topic can publish the enriched corpus. Others install with a single command:
-
-```bash
-kctx install stripe@v1
-kctx install prompt-engineering-2026
-```
-
-Community maintained, versioned, always current. Pre-enriched, so you skip the scraping or research step. Vendor docs are a starting point, not a ceiling — the registry can hold research corpora, curated internal collections, and community-maintained alternates with better examples and faster update cycles.
-
-### Agents that write specialized skills from a corpus
-
-An agent reading your corpus can generate a Claude Code skill that knows the lib's conventions, its gotchas, and its idiomatic patterns. Or, from a research corpus, a skill that encodes the consensus and the disagreements across 30+ sources. Corpus in, skill out.
-
-This is where King Context stops being just a retrieval tool and becomes a skill factory.
-
-### Integration into the dev workflow
-
-Retrieval is the baseline. The next layer is living inside the development loop: pin doc versions to the project so your agent never drifts, monitor upstream doc changes that might affect code you already wrote, surface the relevant sections when the agent notices you working on something.
-
-The idea isn't "agent asks, corpus answers". The idea is that your agent always has the right context on hand, quietly, without you having to ask.
-
----
-
-## CLI and MCP
-
-King Context ships two interfaces. They serve different environments.
-
-The **CLI and the Claude Code skill** are the focus. That's where code agents work best, and that's where the quality numbers from the benchmark come from. If you use King Context inside Claude Code, Cursor, or any agentic coding workflow, that's the path.
-
-The **MCP server** is still supported. Some tools and workflows need native MCP: non-coding agents, IDE integrations, anything that expects an MCP endpoint. It runs on the same corpus and keeps getting improvements, just at a less aggressive pace than the CLI.
-
-Pick based on your environment. The corpus is the same either way.
-
----
-
-## Project layout
-
-```
-king-context/
-├── src/context_cli/        # CLI package (kctx)
-│   ├── searcher.py         # metadata search
-│   ├── reader.py           # section reader with preview
-│   ├── indexer.py          # JSON-to-file indexer
-│   └── grep.py             # regex fallback
-├── src/king_context/       # MCP server, scraper, researcher
-│   ├── server.py           # MCP server
-│   ├── db.py               # SQLite cascade search
-│   ├── scraper/            # king-scrape pipeline (URL → corpus)
-│   └── research/           # king-research pipeline (topic → corpus)
-├── .king-context/          # data store (generated)
-│   ├── docs/               # scraped documentation
-│   ├── research/           # researched topics
-│   └── _learned/           # agent-authored shortcut cache (grows with use)
-├── validation/
-│   ├── minimax-tts-first-shot/   # doc-driven first-shot code case
-│   └── examples/                 # synthesis / multi-source case studies
-└── .claude/skills/         # Claude Code skills (king-context, scraper-workflow, king-research)
-```
-
----
-
-## Roadmap
-
-Short term:
-
-* Community registry with versioned doc and research packages
-* Distribution via `pip install king-context`
-* Agent-generated skills built from scraped docs and research corpora
-* Better sub-agent reliability during enrichment
-* Richer research pipeline: domain filters, source deduplication across topics
-
-Further out:
-
-* Per-project version pinning, with notifications when upstream docs change
-* Workflow hooks that surface relevant sections during active coding
-* Smarter scraping: URL discovery, chunk limits, JavaScript-rendered content
-* Cross-corpus search (query multiple indices in one call)
-* More validation cases covering varied API styles and agent tasks
+- **Token efficient.** ~1,000 tokens per query vs ~3,000 for Context7 in the original benchmark, and 100% factual accuracy vs 84% in the skill-vs-skill round. Numbers and methodology in [Benchmarks](docs/benchmarks.md).
+- **Local first.** Your corpus, your machine. No cloud round-trips on retrieval. Works offline.
+- **Two intake paths, one retrieval surface.** `king-scrape` for vendor docs, `king-research` for open-web topics. Same enriched JSON, same `kctx` interface.
+- **Progressive disclosure.** Metadata search → preview → full read. Agents only pull what they need.
+- **Self-warming cache.** Agents write `.king-context/_learned/<corpus>.md` shortcuts as they work. Retrieval gets faster per corpus over time, with no manual wiring.
 
 ---
 
 ## Contributing
 
-Three areas where the project needs the most help.
+This project is open source because retrieval infrastructure for LLMs should be transparent, community-driven, and independent of any single provider.
 
-**Corpus packages.** If there's an API, framework, or topic you use a lot, scrape it or research it and open a PR. A community library of pre-enriched knowledge bases is this project's biggest lever.
+Three areas where the project benefits the most from outside help:
 
-**Pipeline reliability.** Edge cases in URL discovery, chunking strategies for unusual doc formats, JavaScript-rendered pages, better source filtering in `king-research`.
+- **Corpus packages.** Scrape an API or research a topic you use a lot, and open a PR. A community library of pre-enriched corpora is the biggest lever this project has.
+- **Pipeline reliability.** Edge cases in URL discovery, chunking, JavaScript-rendered pages, source filtering.
+- **Skill improvements.** Sub-agent reliability, error handling, parallel enrichment.
 
-**Skill improvements.** The Claude Code workflows are in beta. Making sub-agents more reliable, handling errors properly, running enrichment steps in parallel.
-
-This project is open source because retrieval infrastructure for LLMs should be transparent, community driven, and independent of any single provider.
+Read the [contributing guide](CONTRIBUTING.md) for setup, branching, commit style, and the PR workflow. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,85 @@
+# Architecture
+
+King Context is a local-first retrieval layer for LLM agents. It indexes scraped documentation and researched topics into a structured store that supports progressive disclosure: metadata first, preview on demand, full read only when the agent needs it.
+
+## The four pieces
+
+### `king-scrape` — URL → corpus
+
+Point it at a docs site. The pipeline runs:
+
+1. **Discover** — find pages from sitemaps, navigation, and link graph.
+2. **Filter** — drop irrelevant pages (heuristic + optional LLM filter).
+3. **Fetch** — download HTML/markdown via Firecrawl.
+4. **Chunk** — split content into sections that respect the source structure.
+5. **Enrich** — annotate each chunk with `keywords`, `use_cases`, `tags`, `priority` via an LLM.
+6. **Export** — write enriched JSON to `.king-context/data/<name>.json`.
+
+### `king-research` — topic → corpus
+
+Same enrichment shape, different intake. Give it a topic. It generates search queries, pulls sources from the open web via Exa, fetches and chunks them, and runs the same enrichment step. Effort flags (`--basic`, `--high`, `--extrahigh`) control how many queries and deepening iterations run.
+
+Output goes to `.king-context/research/<slug>/`. The retrieval surface is identical to scraped docs.
+
+### `kctx index` — JSON → flat store
+
+Turns the enriched JSON into a flat file structure with reverse indexes:
+
+- Docs go to `.king-context/docs/`
+- Research goes to `.king-context/research/`
+- Each section becomes a file plus entries in keyword and use-case indexes
+
+### `kctx` — search and read
+
+The retrieval interface. Scores sections by matching query terms against the keyword and use-case indexes. No full-text scan, no vector similarity on roughly 90% of lookups. A local query cache collapses repeat lookups to sub-millisecond reads.
+
+Agents can write `.king-context/_learned/<corpus>.md` shortcuts as they work — mapping common questions to exact section paths. The retrieval layer gets faster per corpus over time, with no manual wiring.
+
+## Cascade search (MCP server)
+
+The MCP server (`king-context`) uses a four-layer cascade in `db.py`. It stops at the first hit:
+
+1. **Cache** (`<1ms`) — exact query previously executed.
+2. **Metadata** (`<5ms`) — match on keywords, use_cases, tags.
+3. **FTS5** (`<10ms`) — full-text search via SQLite FTS5 with BM25 ranking.
+4. **Hybrid rerank** (`<15ms`) — cosine similarity over `all-MiniLM-L6-v2` embeddings, threshold `0.3`.
+
+Every search response includes a `transparency` object with `method`, `latency_ms`, `search_path`, and `from_cache` fields, so agents can see exactly which layer answered.
+
+## Section schema
+
+Every enriched section has the same shape, regardless of source:
+
+```json
+{
+  "title": "Section title",
+  "path": "section-path",
+  "url": "https://docs.example.com/section",
+  "keywords": ["keyword1", "keyword2"],
+  "use_cases": ["how to do X", "when to use Y"],
+  "tags": ["category1", "category2"],
+  "priority": 10,
+  "content": "Markdown content..."
+}
+```
+
+Metadata is what makes progressive disclosure work without losing recall. The agent finds the right section through structured fields instead of scanning raw content.
+
+## Storage layout
+
+```
+.king-context/
+├── docs/                # Scraped documentation (indexed)
+├── research/            # Researched topics (indexed)
+├── data/                # Raw enriched JSON exports
+├── _temp/               # Scraper work directories
+├── _learned/            # Agent-authored shortcut cache
+├── core/venv/           # Python virtual environment
+└── bin/                 # CLI wrappers (kctx, king-scrape, king-research)
+```
+
+The MCP server keeps a SQLite database (`docs.db`) at the project root with tables `documentations`, `sections`, `sections_fts`, `query_cache`. See [`CLAUDE.md`](../CLAUDE.md) for the schema and module map.
+
+## Why progressive disclosure
+
+A single API page costs 15k tokens of raw markdown, and most of it is noise. Forcing an agent to read ten 400-line `.md` files is the same problem dressed differently. King Context keeps the corpus arbitrarily large because the agent never loads it whole. Metadata search filters to the right section, preview returns ~400 tokens, full read returns the rest only if needed. The bigger the corpus, the more the retrieval discipline pays off.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,62 @@
+# Benchmarks
+
+We ran two rounds against Context7, the most widely used documentation tool for code agents today.
+
+For methodology, rubrics, and reproducibility instructions, see [`BENCHMARK.md`](../BENCHMARK.md).
+
+---
+
+## Round 1: MCP server vs MCP server
+
+Original architecture. Both tools exposed as MCP servers, same corpus, same agent.
+
+| Metric | King Context | Context7 | Improvement |
+|---|---|---|---|
+| Average tokens per query | 968 | 3,125 | 3.2x less |
+| Latency (metadata hit) | 1.15ms | 200 to 500ms | 170x faster |
+| Latency (full text search) | 97.83ms | 200 to 500ms | 2 to 5x faster |
+| Duplicate results | 0 | 11 | zero waste |
+| Relevance score | 3.2 / 5 | 2.8 / 5 | +14% |
+| Implementability | 4.4 / 5 | 4.0 / 5 | +10% |
+
+---
+
+## Round 2: skill vs skill
+
+Both tools running as CLI + Claude Code skill, driven by the same agent. Comparison ran on the Google Gemini API docs using Claude Opus 4.7.
+
+| Metric | Context7 (skill) | King Context (skill) | Winner |
+|---|---|---|---|
+| Average tokens per query | ~1,896 | ~1,064 | King Context |
+| Median tokens per query | 1,750 | 901 | King Context |
+| Correct facts | 32 / 38 (84%) | 38 / 38 (100%) | King Context |
+| Hallucinations per query | 0.33 | 0.0 | King Context |
+| Composite quality (0 to 5) | 3.46 | 4.79 | King Context |
+| First-shot code (Q4) | compiles | compiles | tie |
+
+### What round 2 actually showed
+
+The token gap shrank compared to round 1, but the story shifted from quantity to quality. With both sides now agent-driven, the difference is in how each tool shapes what the agent can ask for.
+
+Three things King Context did that Context7 didn't:
+
+**Self-correct.** The initial Q1 search missed the model spec page. The agent ran `grep`, found the line, read the section in preview mode, and stopped there. Total cost still lower than Context7's single bloated call. Progressive disclosure (`search, grep, preview, read`) gives the agent checkpoints to backtrack and try another angle without burning budget.
+
+**Refuse to hallucinate.** Q5 asked about `Retry-After` headers. King Context explicitly answered "not present in the indexed docs". Context7 returned about 600 tokens of unrelated curl upload examples, purely because "rate limit" matched by proximity. When retrieval hands back large chunks picked by semantic similarity, false positives slip into context quietly. When retrieval is staged and filtered by metadata, the agent can tell when something is missing.
+
+**Handle ambiguity.** Q3 touched `media_resolution`. The Gemini API has two generations of that parameter. King Context returned both. Context7 returned only the legacy version, which is outdated for Gemini 3. Structured metadata (keywords + use cases + tags) catches both generations; semantic similarity locks onto whichever has more mass in the corpus.
+
+The round 2 win isn't "the agent drives retrieval". Both sides drive retrieval now. The win is the shape of what the agent can reach: small units indexed by metadata, previewable, versus bigger chunks ranked by semantics.
+
+---
+
+## Limitations we own
+
+- One run per query in round 2, not two. Variance unknown.
+- Context7 token counts are per-character estimates, not tiktoken. About 20% margin of error.
+
+---
+
+## Reproducing the results
+
+See [`BENCHMARK.md`](../BENCHMARK.md) for the full methodology — developer profiles, question categories, evaluation rubrics, and the procedure to re-run the comparison on a different corpus.

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -1,0 +1,24 @@
+# Case studies
+
+Real agent sessions, not synthetic benchmarks. Each one captures the command sequence the agent ran, the corpus it worked against, and the artifact it produced.
+
+## Available cases
+
+- **[MiniMax TTS — first-shot code](../validation/minimax-tts-first-shot/)**
+  Agent reads a vendor API reference through `kctx` and writes working code on the first run. 5 lookups, ~2,800 tokens of docs consumed, zero adjustments.
+
+- **[Triage-1 — research-driven synthesis](../validation/examples/prompt-engineering-triage1/)**
+  Agent queries a 172-source `king-research --high` corpus on prompt engineering and composes a production-grade customer-support prompt, cross-referencing 5–6 indexed sources. Full design conversation fits in ~4% of the context window. A `.king-context/_learned/` shortcut file is written mid-session — the retrieval cache warming itself as a side effect of the work.
+
+More cases under [`validation/examples/`](../validation/examples/).
+
+## Contributing a case study
+
+Run a real session against your own corpus and document it. A useful case study includes:
+
+- The corpus the agent worked against (scrape command or research command).
+- The full sequence of `kctx` calls the agent made, with token counts.
+- The artifact produced (working code, design doc, analysis).
+- Any `.king-context/_learned/` shortcuts that emerged.
+
+Open a PR adding the session under `validation/examples/<slug>/`. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# King Context Documentation
+
+In-repo wiki for King Context. Pages live next to the code so they version with it.
+
+## Overview
+
+- [Architecture](architecture.md) — how the cascade search, scraper, and researcher fit together.
+- [Vision](vision.md) — what the project is, where it's going, and the design ideas behind it.
+- [Roadmap](roadmap.md) — short-term and long-term plans.
+
+## Using King Context
+
+- [CLI guide](CLI_GUIDE.md) — `kctx` commands and flags.
+- [Benchmarks](benchmarks.md) — performance numbers vs Context7.
+- [Case studies](case-studies.md) — real agent sessions, full traces.
+
+## Contributing
+
+- [Contributing guide](../CONTRIBUTING.md) — setup, branching, commit style, PR flow.
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Pull request template](../.github/PULL_REQUEST_TEMPLATE.md)
+- [Issue templates](../.github/ISSUE_TEMPLATE/)
+
+## Reference
+
+- [`CLAUDE.md`](../CLAUDE.md) — guidance for Claude Code working in this repo.
+- [`BENCHMARK.md`](../BENCHMARK.md) — benchmark methodology and rubrics.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,29 @@
+# Roadmap
+
+## Short term
+
+- Community registry with versioned doc and research packages
+- Distribution via `pip install king-context`
+- Agent-generated skills built from scraped docs and research corpora
+- Better sub-agent reliability during enrichment
+- Richer research pipeline: domain filters, source deduplication across topics
+- GitHub Actions CI for tests and lint
+
+## Further out
+
+- Per-project version pinning, with notifications when upstream docs change
+- Workflow hooks that surface relevant sections during active coding
+- Smarter scraping: URL discovery, chunk limits, JavaScript-rendered content
+- Cross-corpus search (query multiple indices in one call)
+- More validation cases covering varied API styles and agent tasks
+
+## How priorities are set
+
+Priorities follow contributor leverage:
+
+1. **Corpus packages.** A community library of pre-enriched corpora is the project's single biggest lever. Anything that lowers the cost of producing or sharing a corpus jumps the queue.
+2. **Pipeline reliability.** Edge cases in scraping and research that produce empty or low-quality corpora block everything else.
+3. **Agent ergonomics.** Skills, MCP, CLI ergonomics — the surface agents touch. Improvements here compound across every corpus.
+4. **Distribution.** Easy install and update paths grow the user base, which feeds back into corpus and reliability work.
+
+If you have an idea that fits the leverage model but isn't on this list, open an issue or a discussion. The roadmap is not a ceiling.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,50 @@
+# Vision
+
+King Context started as a search tool against scraped docs. The direction from here is bigger: a retrieval layer that any agent, on any topic, can lean on without burning its context window.
+
+## The `.md` problem, solved sideways
+
+The dominant pattern for giving agents knowledge today is a folder of markdown files. It falls over the moment the folder gets real. Ten 400-line docs is a five-digit token tax on every turn, and agents still miss the one paragraph that matters.
+
+King Context replaces that pattern. The corpus can be arbitrarily large because the agent never loads it whole. Metadata search filters to the right section, preview returns ~400 tokens, full read returns the rest only if needed. The query cache learns your common paths. The bigger the corpus, the more the retrieval discipline pays off.
+
+## Skills and agents that run on multiple corpora
+
+A skill or sub-agent shouldn't need to carry its reference material in-context. It should query the corpus the same way a developer greps a codebase — narrowly, progressively, only when needed.
+
+With King Context, a single agent can hold an index for Stripe's API, the research sweep on "webhook security", the team's internal runbook, and a domain-specific research corpus, and reach into any of them mid-task. The retrieval shape is the same across all of them. Build once, plug in many knowledge bases.
+
+## Community knowledge registry
+
+Anyone who scrapes a lib or researches a topic can publish the enriched corpus. Others install with a single command:
+
+```bash
+kctx install stripe@v1
+kctx install prompt-engineering-2026
+```
+
+Community maintained, versioned, always current. Pre-enriched, so you skip the scraping or research step. Vendor docs are a starting point, not a ceiling — the registry can hold research corpora, curated internal collections, and community-maintained alternates with better examples and faster update cycles.
+
+## Agents that write specialized skills from a corpus
+
+An agent reading your corpus can generate a Claude Code skill that knows the lib's conventions, its gotchas, and its idiomatic patterns. Or, from a research corpus, a skill that encodes the consensus and the disagreements across 30+ sources. Corpus in, skill out.
+
+This is where King Context stops being just a retrieval tool and becomes a skill factory.
+
+## Integration into the dev workflow
+
+Retrieval is the baseline. The next layer is living inside the development loop: pin doc versions to the project so your agent never drifts, monitor upstream doc changes that might affect code you already wrote, surface the relevant sections when the agent notices you working on something.
+
+The idea isn't "agent asks, corpus answers". The idea is that your agent always has the right context on hand, quietly, without you having to ask.
+
+---
+
+## CLI and MCP
+
+King Context ships two interfaces. They serve different environments.
+
+The **CLI and the Claude Code skill** are the focus. That's where code agents work best, and that's where the quality numbers from the [benchmarks](benchmarks.md) come from. If you use King Context inside Claude Code, Cursor, or any agentic coding workflow, that's the path.
+
+The **MCP server** is still supported. Some tools and workflows need native MCP: non-coding agents, IDE integrations, anything that expects an MCP endpoint. It runs on the same corpus and keeps getting improvements, just at a less aggressive pace than the CLI.
+
+Pick based on your environment. The corpus is the same either way.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,19 @@ name = "king-context"
 version = "0.1.0"
 description = "Local-first, token-efficient documentation server for LLM context injection"
 requires-python = ">=3.10"
+license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Documentation",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "fastmcp>=0.4.0",
     "sentence-transformers>=2.2.0",
@@ -27,7 +40,7 @@ king-research = "king_context.research.cli:main"
 kctx = "context_cli.cli:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

  Sets up community infrastructure for incoming contributors and reorganizes documentation into an in repo wiki under `docs/`. README is slimmed from 290 → 121 lines and points to the new pages. CI is intentionally skipped per the issue scope.

  ## Related issue

  Closes #15

  ## Type of change

  - [x] Documentation update
  - [x] Tooling / CI / build (PR + issue templates, pyproject metadata)

  ## What changed

  **Community infrastructure**
  
  - `CODE_OF_CONDUCT.md` — Contributor Covenant 1.4, contact `bruucetscontact@gmail.com`
  - `CONTRIBUTING.md` — setup, project standards, branching, Conventional Commits, PR workflow, security reporting
  - `.github/PULL_REQUEST_TEMPLATE.md` — summary, related issue, type, testing, checklist (modeled on Creative Commons + gitmore guidelines)
  - `.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, `config.yml` (Discussions link, blank issues disabled)

  **In-repo wiki under `docs/`**
  - `index.md` — entry point and link map
  - `architecture.md` — cascade search, scraper, researcher, storage layout
  - `benchmarks.md` — round 1 + round 2 numbers (linked to `BENCHMARK.md` for methodology)
  - `case-studies.md` — pulled from README, plus how to contribute a case
  - `vision.md` — where the project is going (formerly README "Where this is going")
  - `roadmap.md` — short-term, long-term, prioritization model

  **README cleanup**
  - `README.md` slimmed to intro, quick start, doc index, at-a-glance, contributing pointer, license
  - `README-pt-br.md` mirrors the new structure

  **Packaging metadata (small follow-on while editing)**
  - `pyproject.toml` — added trove classifiers (Python 3.10–3.13, Topic :: Documentation, Libraries :: Python Modules, Dev Status, Audience, OS), switched to PEP 639 SPDX `license = "MIT"`,
   pinned `hatchling>=1.27` (required for SPDX support)

  ## How it was tested

  - Verified all cross-links resolve (`README.md` → `docs/*`, `CONTRIBUTING.md` → `.github/*`, `docs/index.md` → root files).
  - Manually inspected each new file for formatting and rendered preview.
  - No code changed; existing test suite untouched.

  ## Out of scope

  - GitHub Actions CI
  - GitHub Wiki proper — chose in repo `docs/` so pages version with the code and work for fork reviewers.

  ## Checklist

  - [x] English only content
  - [x] Documentation updated (this PR is documentation)
  - [x] Read CONTRIBUTING and CoC (added in this PR)
  - [x] Conventional commit message
  - [x] No secrets in diff