### PR TITLE
feat(llm): add Ollama support via provider layer

### DIFF
--- a/.agents/skills/king-context/SKILL.md
+++ b/.agents/skills/king-context/SKILL.md
@@ -25,6 +25,8 @@ Every `kctx` command is source-aware:
 
 Every search/grep hit is prefixed `[docs]` or `[research]` so you can tell the source at a glance.
 
+Scraping/research LLM stages can use local Ollama by setting env vars such as `ENRICH_PROVIDER=ollama`, `ENRICH_MODEL=<model>`, `OLLAMA_API_MODE=openai`, and `OLLAMA_BASE_URL=http://localhost:11434/v1`. For Ollama Cloud/direct native API, use `OLLAMA_API_MODE=native`, `OLLAMA_BASE_URL=https://ollama.com`, and `OLLAMA_API_KEY`. OpenRouter fallback is opt-in with `ENABLE_FALLBACK=true` plus `OPENROUTER_API_KEY`.
+
 ---
 
 ## Search Strategy

--- a/.claude/skills/king-context/skill.md
+++ b/.claude/skills/king-context/skill.md
@@ -22,6 +22,8 @@ Every `kctx` command is source-aware:
 
 Every search/grep hit is prefixed `[docs]` or `[research]` so you can tell the source at a glance.
 
+Scraping/research LLM stages can use local Ollama by setting env vars such as `ENRICH_PROVIDER=ollama`, `ENRICH_MODEL=<model>`, `OLLAMA_API_MODE=openai`, and `OLLAMA_BASE_URL=http://localhost:11434/v1`. For Ollama Cloud/direct native API, use `OLLAMA_API_MODE=native`, `OLLAMA_BASE_URL=https://ollama.com`, and `OLLAMA_API_KEY`. OpenRouter fallback is opt-in with `ENABLE_FALLBACK=true` plus `OPENROUTER_API_KEY`.
+
 ---
 
 ## Search Strategy

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,68 @@
-# Firecrawl API key — get yours at https://firecrawl.dev
+# King Context — API Keys
+# Copy this file to .env at your project root
+
+# Required — Firecrawl API key for documentation scraping
+# Get yours at https://firecrawl.dev
 FIRECRAWL_API_KEY=
 
-# OpenRouter API key — get yours at https://openrouter.ai
+# Optional — OpenRouter API key for OpenRouter LLM stages or Ollama fallback
+# Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=
+
+# LLM provider selection per stage
+# Defaults preserve current behavior: OpenRouter + google/gemini-3-flash-preview
+# Allowed providers: openrouter, ollama
+ENRICH_PROVIDER=openrouter
+ENRICH_MODEL=google/gemini-3-flash-preview
+FILTER_PROVIDER=openrouter
+FILTER_MODEL=google/gemini-3-flash-preview
+RESEARCH_PROVIDER=openrouter
+RESEARCH_MODEL=google/gemini-3-flash-preview
+
+# Ollama local, OpenAI-compatible API
+OLLAMA_API_MODE=openai
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_API_KEY=
+
+# Ollama Cloud/direct native API example
+#OLLAMA_API_MODE=native
+#OLLAMA_BASE_URL=https://ollama.com
+#OLLAMA_API_KEY=
+
+# Provider LLM call concurrency (independent of fetch concurrency/checkpoint batch size)
+CONCURRENCY_OPENROUTER=5
+CONCURRENCY_OLLAMA=2
+
+# Optional one-way fallback: Ollama -> OpenRouter only
+# Requires OPENROUTER_API_KEY when an active Ollama stage can fall back
+ENABLE_FALLBACK=false
+FALLBACK_MODEL=google/gemini-3-flash-preview
+
+# Required — Exa API key for king-research topic-driven web search
+# Powers semantic search and content retrieval for the research pipeline
+# Get yours at https://dashboard.exa.ai/api-keys
+EXA_API_KEY=
+
+# Optional — Jina API key for reranking and embeddings in king-research
+# The anonymous tier works for light use; set a key to raise rate limits
+# Get yours at https://jina.ai/api
+JINA_API_KEY=
+
+# Legacy optional alias for research query generation.
+# Prefer RESEARCH_MODEL above for new configs.
+OPENROUTER_MODEL_RESEARCH=
+
+# Optional — Effort-ladder overrides for king-research
+# Uncomment any line to override the built-in defaults shown below
+#RESEARCH_BASIC_QUERIES=3
+#RESEARCH_MEDIUM_QUERIES=5
+#RESEARCH_MEDIUM_ITERATIONS=1
+#RESEARCH_MEDIUM_FOLLOWUPS=3
+#RESEARCH_HIGH_QUERIES=8
+#RESEARCH_HIGH_ITERATIONS=2
+#RESEARCH_HIGH_FOLLOWUPS=5
+#RESEARCH_EXTRAHIGH_QUERIES=12
+#RESEARCH_EXTRAHIGH_ITERATIONS=3
+#RESEARCH_EXTRAHIGH_FOLLOWUPS=8
+#EXA_RESULTS_PER_QUERY=10
+#EXA_MAX_CHARS=15000

--- a/.king-context/adr/0001-adopt-cli-first-architecture-for-agent-retrieval.md
+++ b/.king-context/adr/0001-adopt-cli-first-architecture-for-agent-retrieval.md
@@ -13,6 +13,7 @@ supersedes: []
 superseded_by: []
 related:
   - ADR-0002
+  - ADR-0003
 keywords:
   - cli-first
   - agent-retrieval

--- a/.king-context/adr/0003-pluggable-llm-provider-abstraction-for-cli-tools.md
+++ b/.king-context/adr/0003-pluggable-llm-provider-abstraction-for-cli-tools.md
@@ -1,0 +1,49 @@
+---
+id: ADR-0003
+title: Pluggable LLM provider abstraction for CLI tools
+status: accepted
+date: 2026-05-05
+areas:
+  - cli
+  - llm-providers
+  - scraper
+  - research
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0001
+keywords:
+  - llm-provider
+  - openrouter
+  - ollama
+  - cli-enrichment
+  - stage-aware-config
+  - fallback
+tags:
+  - architecture
+  - llm
+  - cli
+---
+
+
+# ADR-0003: Pluggable LLM provider abstraction for CLI tools
+
+## Context
+
+The scraper and research CLIs called OpenRouter directly from stage modules. That made local model use, Ollama deployments, provider-specific error handling, and future provider additions leak into scraper and research code.
+
+## Decision
+
+Introduce a top-level llm_providers package with a small LLMClient interface, stage-aware environment resolution, provider registry, OpenRouter and Ollama clients, robust JSON parsing, and one-way Ollama to OpenRouter fallback. Scraper and research stages remain responsible for prompts and schema validation while provider HTTP details live behind the abstraction.
+
+## Alternatives Considered
+
+Keep direct OpenRouter calls in each stage; add Ollama branches directly inside scraper and research modules; expose provider selection as per-command flags before proving the environment-driven MVP. These options either duplicate provider logic, weaken the CLI-first stage boundaries, or add command surface before the provider contract stabilizes.
+
+## Consequences
+
+Default OpenRouter behavior remains compatible, while configured CLI stages can use local or remote Ollama without MCP changes. Validation must stay stage-aware so partial pipelines do not require inactive credentials. Provider failures become explicit and testable, but the abstraction adds a new package and requires call-sites to depend on provider clients instead of raw HTTP.
+
+## Links
+
+.specs/features/local-models-enrichment/spec.md, .specs/features/local-models-enrichment/design.md

--- a/.specs/features/local-models-enrichment/human.md
+++ b/.specs/features/local-models-enrichment/human.md
@@ -35,12 +35,14 @@ https://docs.ollama.com/api/openai-compatibility, https://docs.ollama.com/api/ch
 - O fallback Ollama -> OpenRouter agora respeita concorrencia por provider. Quando `CONCURRENCY_OLLAMA` e maior que `CONCURRENCY_OPENROUTER`, chamadas de fallback para OpenRouter ficam protegidas pelo semaforo do OpenRouter, nao pelo limite do primary.
 - A factory de providers agora resolve `CONCURRENCY_OPENROUTER` tambem para o cliente OpenRouter usado como fallback, em vez de usar um valor fixo.
 - Erros combinados do `FallbackClient` agora usam a transiencia do erro do fallback. Se Ollama falha de forma transiente, mas OpenRouter falha com erro nao transiente, como `auth_error`, o caller falha imediatamente em vez de retentar uma configuracao invalida.
-- Testes de regressao cobrem isolamento do modelo de research, surfacing dos erros combinados de fallback, surfacing de falhas de config/provider no filtro LLM, retry de erros transientes no enrichment, erro apos 3 tentativas, fail-fast para fallback nao transiente e concorrencia do OpenRouter em fallback.
+- O schema fallback do enrichment tambem nao engole mais metadados invalidos. Se Ollama falha validacao 3 vezes e o fallback OpenRouter retorna JSON parseavel mas fora do schema, o enrichment levanta `ProviderError(reason="validation_failed_3x")` em vez de descartar o chunk silenciosamente.
+- Testes de regressao cobrem isolamento do modelo de research, surfacing dos erros combinados de fallback, surfacing de falhas de config/provider no filtro LLM, retry de erros transientes no enrichment, erro apos 3 tentativas, fail-fast para fallback nao transiente, concorrencia do OpenRouter em fallback e falha explicita quando o schema fallback tambem retorna metadados invalidos.
 
 ## Validacao
 
-- `pytest` -> `465 passed`
-- `pytest tests/test_llm_providers/test_fallback.py tests/test_scraper/test_enrich.py` -> `14 passed`
+- `pytest` -> `466 passed`
+- `pytest tests/test_scraper/test_enrich.py` -> `11 passed`
+- `pytest tests/test_llm_providers/test_fallback.py tests/test_scraper/test_enrich.py` -> `15 passed`
 - `pytest tests/test_llm_providers tests/test_scraper tests/test_scraper_manifest.py tests/test_scraper_enrich_resume.py tests/test_scraper_resume_integration.py` -> `96 passed`
 - `python -m context_cli.cli adr status` -> index up to date
 - `python -m context_cli.cli adr validate` -> passed

--- a/.specs/features/local-models-enrichment/human.md
+++ b/.specs/features/local-models-enrichment/human.md
@@ -34,13 +34,14 @@ https://docs.ollama.com/api/openai-compatibility, https://docs.ollama.com/api/ch
 - O enrichment agora retenta `ProviderError` transiente ate 3 tentativas no primary. Timeouts, rate limits e erros 5xx de OpenRouter ou Ollama nao abortam o batch na primeira falha; erros nao transientes continuam falhando imediatamente.
 - O fallback Ollama -> OpenRouter agora respeita concorrencia por provider. Quando `CONCURRENCY_OLLAMA` e maior que `CONCURRENCY_OPENROUTER`, chamadas de fallback para OpenRouter ficam protegidas pelo semaforo do OpenRouter, nao pelo limite do primary.
 - A factory de providers agora resolve `CONCURRENCY_OPENROUTER` tambem para o cliente OpenRouter usado como fallback, em vez de usar um valor fixo.
-- Testes de regressao cobrem isolamento do modelo de research, surfacing dos erros combinados de fallback, surfacing de falhas de config/provider no filtro LLM, retry de erros transientes no enrichment, erro apos 3 tentativas e concorrencia do OpenRouter em fallback.
+- Erros combinados do `FallbackClient` agora usam a transiencia do erro do fallback. Se Ollama falha de forma transiente, mas OpenRouter falha com erro nao transiente, como `auth_error`, o caller falha imediatamente em vez de retentar uma configuracao invalida.
+- Testes de regressao cobrem isolamento do modelo de research, surfacing dos erros combinados de fallback, surfacing de falhas de config/provider no filtro LLM, retry de erros transientes no enrichment, erro apos 3 tentativas, fail-fast para fallback nao transiente e concorrencia do OpenRouter em fallback.
 
 ## Validacao
 
-- `pytest` -> `463 passed`
-- `pytest tests/test_scraper/test_enrich.py tests/test_llm_providers/test_factory.py` -> `11 passed`
-- `pytest tests/test_llm_providers tests/test_scraper tests/test_scraper_manifest.py tests/test_scraper_enrich_resume.py tests/test_scraper_resume_integration.py` -> `94 passed`
+- `pytest` -> `465 passed`
+- `pytest tests/test_llm_providers/test_fallback.py tests/test_scraper/test_enrich.py` -> `14 passed`
+- `pytest tests/test_llm_providers tests/test_scraper tests/test_scraper_manifest.py tests/test_scraper_enrich_resume.py tests/test_scraper_resume_integration.py` -> `96 passed`
 - `python -m context_cli.cli adr status` -> index up to date
 - `python -m context_cli.cli adr validate` -> passed
 - `python -m context_cli.cli llm-doctor --json` -> `{"ollama": null}` quando nenhum stage usa Ollama

--- a/.specs/features/local-models-enrichment/human.md
+++ b/.specs/features/local-models-enrichment/human.md
@@ -31,12 +31,16 @@ https://docs.ollama.com/api/openai-compatibility, https://docs.ollama.com/api/ch
 - `king-research` nao herda mais `ENRICH_MODEL` para geracao de queries. Quando `RESEARCH_MODEL` nao esta definido, o stage `research` usa sua propria resolucao/default em `resolve("research")`.
 - O enrichment nao engole mais `ProviderError`. Se Ollama falha e o fallback OpenRouter tambem falha, o erro do `FallbackClient` sobe preservando `primary_error` e `fallback_error`, em vez de transformar o chunk em `None` silenciosamente.
 - O filtro LLM de URLs tambem nao engole mais falhas provider-aware. `ConfigError` e `ProviderError` vindos de `_call_llm` sobem para a CLI, entao configuracoes invalidas de `FILTER_PROVIDER` ou falhas de Ollama/OpenRouter ficam visiveis em vez de cair silenciosamente no resultado heuristico.
-- Testes de regressao cobrem os tres casos: isolamento do modelo de research, surfacing dos erros combinados de fallback e surfacing de falhas de config/provider no filtro LLM.
+- O enrichment agora retenta `ProviderError` transiente ate 3 tentativas no primary. Timeouts, rate limits e erros 5xx de OpenRouter ou Ollama nao abortam o batch na primeira falha; erros nao transientes continuam falhando imediatamente.
+- O fallback Ollama -> OpenRouter agora respeita concorrencia por provider. Quando `CONCURRENCY_OLLAMA` e maior que `CONCURRENCY_OPENROUTER`, chamadas de fallback para OpenRouter ficam protegidas pelo semaforo do OpenRouter, nao pelo limite do primary.
+- A factory de providers agora resolve `CONCURRENCY_OPENROUTER` tambem para o cliente OpenRouter usado como fallback, em vez de usar um valor fixo.
+- Testes de regressao cobrem isolamento do modelo de research, surfacing dos erros combinados de fallback, surfacing de falhas de config/provider no filtro LLM, retry de erros transientes no enrichment, erro apos 3 tentativas e concorrencia do OpenRouter em fallback.
 
 ## Validacao
 
-- `pytest` -> `457 passed`
-- `pytest tests/test_llm_providers tests/test_scraper/test_filter.py` -> `30 passed`
+- `pytest` -> `463 passed`
+- `pytest tests/test_scraper/test_enrich.py tests/test_llm_providers/test_factory.py` -> `11 passed`
+- `pytest tests/test_llm_providers tests/test_scraper tests/test_scraper_manifest.py tests/test_scraper_enrich_resume.py tests/test_scraper_resume_integration.py` -> `94 passed`
 - `python -m context_cli.cli adr status` -> index up to date
 - `python -m context_cli.cli adr validate` -> passed
 - `python -m context_cli.cli llm-doctor --json` -> `{"ollama": null}` quando nenhum stage usa Ollama

--- a/.specs/features/local-models-enrichment/human.md
+++ b/.specs/features/local-models-enrichment/human.md
@@ -1,0 +1,71 @@
+# Resumo da Implementacao
+
+Implementado o provider layer `src/llm_providers/` com `LLMClient`, parser JSON robusto, config por stage, registry, clientes OpenRouter/Ollama, fallback Ollama -> OpenRouter e testes. `king-scrape` e `king-research` agora usam providers em enrichment, filtro LLM e geracao de queries.
+
+Tambem foram adicionados `kctx llm-doctor`, hook no doctor Node, ADR-0003, env/docs/skills atualizados, `docs/ollama.md` com passo a passo de instalacao/configuracao, e custo de enrichment provider-aware: OpenRouter mostra estimativa em dolares; Ollama-only mostra custo local/runtime; Ollama com fallback avisa sobre possivel custo OpenRouter.
+
+Depois do smoke do installer, tambem foi centralizado o carregamento de env em `src/king_context/env.py`: `.king-context/.env` e `.env` agora sao lidos por `king-scrape`, `king-research`, providers LLM e `kctx llm-doctor`. Isso evita precisar exportar variaveis manualmente dentro da venv.
+
+## Ollama
+
+Pesquisa usada: docs oficiais do Ollama para OpenAI compatibility, native chat, tags e autenticacao:
+https://docs.ollama.com/api/openai-compatibility, https://docs.ollama.com/api/chat, https://docs.ollama.com/api/tags, https://docs.ollama.com/api/authentication.
+
+- Nesta maquina: Ollama `0.23.0` instalado via Homebrew, servico iniciado com `brew services start ollama`, modelo `qwen2.5:7b` baixado e listado localmente (`4.7 GB`).
+- Teste manual do usuario: `king-research` com Ollama local comecou a chunkear/enriquecer corretamente e gerou arquivo em `.king-context/_temp/research/.../enriched/batch_0001.json`.
+- Cobertura manual: foi testado somente Ollama local. Ollama Cloud/native ainda nao foi testado na pratica.
+- Status comunicado como beta em `kctx llm-doctor`, `docs/index.md`, `docs/CLI_GUIDE.md` e `docs/ollama.md`. Usuarios devem abrir issues com bugs ou validacoes de modelos locais que cheguem perto da qualidade do Gemini via OpenRouter.
+- OpenAI local: `OLLAMA_API_MODE=openai`, `OLLAMA_BASE_URL=http://localhost:11434/v1`, endpoint `POST /chat/completions`, doctor `GET /models`.
+- Native/cloud: `OLLAMA_API_MODE=native`, `OLLAMA_BASE_URL=https://ollama.com`, endpoint `POST /api/chat`, doctor `GET /api/tags`, `stream: false`, `format: "json"`.
+- `OLLAMA_API_KEY` e enviado como `Authorization: Bearer ...` quando definido.
+
+## Desvios/Notas
+
+- O binario `.king-context/bin/kctx` nao existe neste checkout local; usei `python -m context_cli.cli ...` para ADR/doctor durante a validacao.
+- O teste manual real de scrape com Ollama local nao foi executado para evitar consumir tempo de inferencia; o doctor real contra o servidor Ollama local passou. A cobertura automatizada mocka os endpoints e valida o formato das chamadas.
+- `--model` no parser agora fica `None` quando omitido, para permitir que `ENRICH_MODEL` do ambiente seja respeitado. Quando passado, continua sobrescrevendo o modelo de enrichment.
+- O `king-context init` do npm instala o pacote Python via `git+https://github.com/deandevz/king-context.git`. Para deploy, publique/merge as mudancas Python no GitHub antes ou junto do publish npm; se o GitHub remoto estiver antigo, o npm novo instala templates novos mas a venv fica sem `kctx llm-doctor`.
+
+## Correcoes Pos-Review
+
+- `king-research` nao herda mais `ENRICH_MODEL` para geracao de queries. Quando `RESEARCH_MODEL` nao esta definido, o stage `research` usa sua propria resolucao/default em `resolve("research")`.
+- O enrichment nao engole mais `ProviderError`. Se Ollama falha e o fallback OpenRouter tambem falha, o erro do `FallbackClient` sobe preservando `primary_error` e `fallback_error`, em vez de transformar o chunk em `None` silenciosamente.
+- O filtro LLM de URLs tambem nao engole mais falhas provider-aware. `ConfigError` e `ProviderError` vindos de `_call_llm` sobem para a CLI, entao configuracoes invalidas de `FILTER_PROVIDER` ou falhas de Ollama/OpenRouter ficam visiveis em vez de cair silenciosamente no resultado heuristico.
+- Testes de regressao cobrem os tres casos: isolamento do modelo de research, surfacing dos erros combinados de fallback e surfacing de falhas de config/provider no filtro LLM.
+
+## Validacao
+
+- `pytest` -> `457 passed`
+- `pytest tests/test_llm_providers tests/test_scraper/test_filter.py` -> `30 passed`
+- `python -m context_cli.cli adr status` -> index up to date
+- `python -m context_cli.cli adr validate` -> passed
+- `python -m context_cli.cli llm-doctor --json` -> `{"ollama": null}` quando nenhum stage usa Ollama
+- `ENRICH_PROVIDER=ollama ENRICH_MODEL=qwen2.5:7b OLLAMA_API_MODE=openai OLLAMA_BASE_URL=http://localhost:11434/v1 CONCURRENCY_OLLAMA=1 python -m context_cli.cli llm-doctor --json` -> reachable, model present
+- Smoke installer em `/private/tmp/kctx-installer-smoke...`: `npm pack --dry-run` OK; `king-context init` OK; venv com arvore local pos-merge; `.env` com Ollama local; `.king-context/bin/kctx llm-doctor --json` -> reachable/model present; `king-context doctor` -> `16 passed, 0 warnings, 0 failed`.
+
+## Teste Rapido na Pratica
+
+1. Local Ollama:
+
+```bash
+ollama pull qwen2.5:7b
+ENRICH_PROVIDER=ollama ENRICH_MODEL=qwen2.5:7b OLLAMA_API_MODE=openai OLLAMA_BASE_URL=http://localhost:11434/v1 python -m context_cli.cli llm-doctor --json
+```
+
+2. Scrape pequeno ate enrichment:
+
+```bash
+ENRICH_PROVIDER=ollama ENRICH_MODEL=qwen2.5:7b OLLAMA_API_MODE=openai OLLAMA_BASE_URL=http://localhost:11434/v1 king-scrape https://docs.example.com --name smoke --stop-after enrich --yes --no-llm-filter
+```
+
+3. Fallback:
+
+```bash
+ENRICH_PROVIDER=ollama ENRICH_MODEL=modelo-inexistente ENABLE_FALLBACK=true OPENROUTER_API_KEY=... king-scrape https://docs.example.com --name smoke-fallback --stop-after enrich --yes --no-llm-filter
+```
+
+Procure uma linha como:
+
+```text
+[fallback] enrich: ollama (...) -> openrouter (...) -- reason: model_not_found
+```

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -29,6 +29,8 @@ cp .king-context/.env.example .env
 # OPENROUTER_API_KEY=...    opcional, enriquecimento automatizado
 ```
 
+Quer rodar enrichment localmente? Ollama é suportado como **beta**. Veja [docs/ollama.md](docs/ollama.md) pra configurar.
+
 Monte um corpus a partir de um site de docs ou de um tópico:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ cp .king-context/.env.example .env
 # OPENROUTER_API_KEY=...    optional, automated enrichment
 ```
 
+Prefer running enrichment locally? Ollama is supported as **beta**. See [docs/ollama.md](docs/ollama.md) for setup.
+
 Build a corpus from a docs site or a topic:
 
 ```bash

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -365,6 +365,72 @@ Useful flags:
 `king-scrape` writes exported documentation JSON to `.king-context/data/`.
 Use `kctx index` to build or rebuild the file-based CLI store from that JSON.
 
+## LLM Provider Configuration
+
+`king-scrape` and `king-research` use OpenRouter by default:
+
+Ollama provider support is beta. If you find bugs, or if you validate local
+models that chunk and enrich content with quality close to Gemini through
+OpenRouter, open an issue with the model name, command, and a short quality
+note: [King Context issues](https://github.com/deandevz/king-context/issues).
+
+```dotenv
+OPENROUTER_API_KEY=...
+ENRICH_PROVIDER=openrouter
+FILTER_PROVIDER=openrouter
+RESEARCH_PROVIDER=openrouter
+```
+
+Each LLM stage can choose its own provider and model:
+
+```dotenv
+ENRICH_PROVIDER=ollama
+ENRICH_MODEL=qwen2.5:7b
+FILTER_PROVIDER=openrouter
+FILTER_MODEL=google/gemini-3-flash-preview
+RESEARCH_PROVIDER=ollama
+RESEARCH_MODEL=qwen2.5:7b
+```
+
+Local Ollama uses the OpenAI-compatible API:
+
+```dotenv
+OLLAMA_API_MODE=openai
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_API_KEY=
+```
+
+Ollama Cloud or another native Ollama host uses the native API:
+
+```dotenv
+OLLAMA_API_MODE=native
+OLLAMA_BASE_URL=https://ollama.com
+OLLAMA_API_KEY=...
+```
+
+Fallback is one-way from Ollama to OpenRouter:
+
+```dotenv
+ENABLE_FALLBACK=true
+FALLBACK_MODEL=google/gemini-3-flash-preview
+OPENROUTER_API_KEY=...
+```
+
+Provider validation is stage-aware. For example, `king-scrape --stop-after chunk`
+does not require LLM credentials, and URL filtering validates the filter provider
+only if the LLM fallback path actually runs. Ollama-only enrichment reports local
+runtime wording instead of a paid cost estimate; if fallback is enabled, the CLI
+warns that OpenRouter fallback may incur cost.
+
+Check configured Ollama stages with:
+
+```bash
+kctx llm-doctor --json
+```
+
+For installation, model download, and smoke test steps, see the
+[Ollama guide](ollama.md).
+
 ## Build research corpora
 
 Use `king-research` to research a topic from the open web and index the result

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ In-repo wiki for King Context. Pages live next to the code so they version with 
 ## Using King Context
 
 - [CLI guide](CLI_GUIDE.md) — `kctx` commands and flags.
+- [Ollama guide](ollama.md) — install Ollama and configure beta local model support.
 - [Benchmarks](benchmarks.md) — performance numbers vs Context7.
 
 ## Contributing

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -1,0 +1,163 @@
+# Use Ollama with King Context
+
+King Context can use Ollama for LLM-backed stages in `king-scrape` and
+`king-research`. Use this guide when you want local model execution or a direct
+Ollama Cloud/native host instead of OpenRouter.
+
+Ollama provider support is beta. If you find bugs, or if you validate models
+that chunk and enrich content with quality close to Gemini through OpenRouter,
+open an issue with the model name, command, topic or URL, and a short quality
+note: [King Context issues](https://github.com/deandevz/king-context/issues).
+
+## Install Ollama
+
+On macOS, install Ollama with one of these options:
+
+```bash
+brew install ollama
+```
+
+Or download the macOS app from the
+[Ollama download page](https://ollama.com/download).
+
+After installation, confirm that the CLI is available:
+
+```bash
+ollama --version
+```
+
+## Start Ollama
+
+If you installed the macOS app, open Ollama once so the local server starts.
+If you installed the CLI only, start the server in a terminal:
+
+```bash
+ollama serve
+```
+
+The local API runs at `http://localhost:11434`.
+
+## Download a model
+
+Download the model before running a King Context enrichment job:
+
+```bash
+ollama pull qwen2.5:7b
+```
+
+The first download can take several minutes, depending on the model size and
+your network. After the model is downloaded, later runs load it from your local
+Ollama model store.
+
+For a faster smoke test, use a smaller model:
+
+```bash
+ollama pull qwen2.5:1.5b
+```
+
+List local models with:
+
+```bash
+ollama list
+```
+
+## Configure King Context for local Ollama
+
+Set these variables in your project `.env` or `.king-context/.env`:
+
+```dotenv
+ENRICH_PROVIDER=ollama
+ENRICH_MODEL=qwen2.5:7b
+OLLAMA_API_MODE=openai
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_API_KEY=
+CONCURRENCY_OLLAMA=1
+```
+
+`OLLAMA_API_MODE=openai` uses Ollama's OpenAI-compatible API at
+`/v1/chat/completions`. Start with `CONCURRENCY_OLLAMA=1` for local runs. Raise
+it to `2` only after you confirm that your machine handles the workload well.
+
+Optional: configure other LLM-backed stages too:
+
+```dotenv
+FILTER_PROVIDER=ollama
+FILTER_MODEL=qwen2.5:7b
+RESEARCH_PROVIDER=ollama
+RESEARCH_MODEL=qwen2.5:7b
+```
+
+## Check the configuration
+
+Run the LLM doctor:
+
+```bash
+kctx llm-doctor --json
+```
+
+If you are working from the repository without installed wrapper scripts, use:
+
+```bash
+python -m context_cli.cli llm-doctor --json
+```
+
+When an Ollama stage is configured, the output includes the API mode, base URL,
+reachability, and whether the configured models are present.
+
+## Run a small scrape
+
+Use `--no-llm-filter` for the first test so only the enrichment stage exercises
+Ollama:
+
+```bash
+king-scrape https://docs.example.com \
+  --name ollama-smoke \
+  --stop-after enrich \
+  --yes \
+  --no-llm-filter
+```
+
+The enrichment cost prompt should use local runtime wording instead of an
+OpenRouter dollar estimate.
+
+## Configure fallback to OpenRouter
+
+Fallback is optional and one-way: Ollama to OpenRouter.
+
+```dotenv
+ENABLE_FALLBACK=true
+FALLBACK_MODEL=google/gemini-3-flash-preview
+OPENROUTER_API_KEY=...
+```
+
+Use fallback when you want the pipeline to continue if the local Ollama model is
+unavailable, returns invalid JSON, or fails enrichment validation after retries.
+Fallback may incur OpenRouter cost.
+
+## Use Ollama Cloud or a native Ollama host
+
+For direct Ollama Cloud/native API access, use native mode:
+
+```dotenv
+ENRICH_PROVIDER=ollama
+ENRICH_MODEL=gpt-oss:120b
+OLLAMA_API_MODE=native
+OLLAMA_BASE_URL=https://ollama.com
+OLLAMA_API_KEY=...
+CONCURRENCY_OLLAMA=1
+```
+
+Native mode calls `/api/chat` with `stream: false` and JSON mode enabled.
+
+## Help validate models
+
+Different local models can vary in JSON reliability, chunk quality, and
+enrichment quality. Contributions are useful when they include:
+
+- The model name and tag, such as `qwen2.5:7b`.
+- The King Context command and relevant provider environment variables.
+- Whether the run completed chunking, enrichment, and indexing.
+- A brief comparison against Gemini through OpenRouter when available.
+
+Open model validation results or bugs in
+[King Context issues](https://github.com/deandevz/king-context/issues).

--- a/installer/lib/doctor.js
+++ b/installer/lib/doctor.js
@@ -124,10 +124,51 @@ function checkApiKeys(projectDir) {
   if (envContent.match(/^OPENROUTER_API_KEY=.+/m)) {
     results.push({ status: 'ok', label: 'API Keys: OPENROUTER_API_KEY is set' });
   } else {
-    results.push({ status: 'warn', label: 'API Keys: OPENROUTER_API_KEY is missing (optional, needed for LLM enrichment)' });
+    results.push({ status: 'warn', label: 'API Keys: OPENROUTER_API_KEY is missing (optional, needed for OpenRouter LLM stages or fallback)' });
   }
 
   return results;
+}
+
+function checkLlmProviders(projectDir) {
+  const kctxPath = path.join(projectDir, '.king-context', 'bin', 'kctx');
+  if (!fs.existsSync(kctxPath)) {
+    return [];
+  }
+
+  try {
+    const raw = execSync(`"${kctxPath}" llm-doctor --json`, {
+      stdio: 'pipe',
+      timeout: 10000,
+      cwd: projectDir,
+    }).toString();
+    const payload = JSON.parse(raw);
+    if (!payload.ollama) {
+      return [];
+    }
+
+    const result = payload.ollama;
+    const results = [];
+    const mode = result.mode || 'unknown';
+    const baseUrl = result.base_url || 'unknown';
+    if (result.reachable) {
+      results.push({ status: 'ok', label: `Ollama: reachable (${mode}, ${baseUrl})` });
+    } else {
+      results.push({ status: 'warn', label: `Ollama: not reachable (${mode}, ${baseUrl})` });
+    }
+    if (Array.isArray(result.models_present) && result.models_present.length > 0) {
+      results.push({ status: 'ok', label: `Ollama models: present ${result.models_present.join(', ')}` });
+    }
+    if (Array.isArray(result.models_missing) && result.models_missing.length > 0) {
+      results.push({ status: 'warn', label: `Ollama models: missing ${result.models_missing.join(', ')}` });
+    }
+    if (result.version) {
+      results.push({ status: 'ok', label: `Ollama version: ${result.version}` });
+    }
+    return results;
+  } catch {
+    return [{ status: 'warn', label: 'Ollama: provider check unavailable' }];
+  }
 }
 
 function checkDirStructure(projectDir) {
@@ -187,7 +228,10 @@ async function run() {
   // 6. Dir structure
   results.push(checkDirStructure(projectDir));
 
-  // 7. Version
+  // 7. LLM providers
+  results.push(...checkLlmProviders(projectDir));
+
+  // 8. Version
   results.push(checkVersion());
 
   // Print results

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@king-context/cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Installer for King Context — local-first documentation search for AI agents",
   "bin": {
     "king-context": "./bin/king-context.js"

--- a/installer/templates/claude-md-snippet.md
+++ b/installer/templates/claude-md-snippet.md
@@ -29,7 +29,8 @@ Documentation search and scraping tools are available in this project.
 
 - API keys: copy `.king-context/.env.example` to `.env` and fill in your keys
 - `FIRECRAWL_API_KEY` (required for scraping)
-- `OPENROUTER_API_KEY` (optional, for automated enrichment)
+- `OPENROUTER_API_KEY` (optional, for OpenRouter LLM stages or fallback)
+- LLM stages can use OpenRouter or Ollama via provider env vars in `.king-context/.env.example`
 
 ### Directory Structure
 

--- a/installer/templates/env.example
+++ b/installer/templates/env.example
@@ -5,11 +5,38 @@
 # Get yours at https://firecrawl.dev
 FIRECRAWL_API_KEY=
 
-# Optional — OpenRouter API key for automated enrichment (Workflow A)
-# Only needed if using fully automated scraping pipeline
-# Not needed if using Claude Code sub-agents (Workflow B)
+# Optional — OpenRouter API key for OpenRouter LLM stages or Ollama fallback
 # Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=
+
+# LLM provider selection per stage
+# Defaults preserve current behavior: OpenRouter + google/gemini-3-flash-preview
+# Allowed providers: openrouter, ollama
+ENRICH_PROVIDER=openrouter
+ENRICH_MODEL=google/gemini-3-flash-preview
+FILTER_PROVIDER=openrouter
+FILTER_MODEL=google/gemini-3-flash-preview
+RESEARCH_PROVIDER=openrouter
+RESEARCH_MODEL=google/gemini-3-flash-preview
+
+# Ollama local, OpenAI-compatible API
+OLLAMA_API_MODE=openai
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_API_KEY=
+
+# Ollama Cloud/direct native API example
+#OLLAMA_API_MODE=native
+#OLLAMA_BASE_URL=https://ollama.com
+#OLLAMA_API_KEY=
+
+# Provider LLM call concurrency (independent of fetch concurrency/checkpoint batch size)
+CONCURRENCY_OPENROUTER=5
+CONCURRENCY_OLLAMA=2
+
+# Optional one-way fallback: Ollama -> OpenRouter only
+# Requires OPENROUTER_API_KEY when an active Ollama stage can fall back
+ENABLE_FALLBACK=false
+FALLBACK_MODEL=google/gemini-3-flash-preview
 
 # Required — Exa API key for king-research topic-driven web search
 # Powers semantic search and content retrieval for the research pipeline
@@ -21,8 +48,8 @@ EXA_API_KEY=
 # Get yours at https://jina.ai/api
 JINA_API_KEY=
 
-# Optional — OpenRouter model used by king-research for query generation and deepening follow-ups
-# When empty, falls back to OPENROUTER_MODEL_ENRICH (or the enrichment model default)
+# Legacy optional alias for research query generation.
+# Prefer RESEARCH_MODEL above for new configs.
 OPENROUTER_MODEL_RESEARCH=
 
 # Optional — Effort-ladder overrides for king-research

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/king_context", "src/context_cli"]
+packages = ["src/king_context", "src/context_cli", "src/llm_providers"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/context_cli/cli.py
+++ b/src/context_cli/cli.py
@@ -17,6 +17,7 @@ from context_cli.formatter import (
 )
 from context_cli.grep import grep_docs
 from context_cli.indexer import index_doc
+from context_cli.llm_doctor import print_probe
 from context_cli.reader import read_section
 from context_cli.searcher import search
 from context_cli.store import list_docs
@@ -251,6 +252,10 @@ def _cmd_index(args: argparse.Namespace) -> None:
         print(f"Indexed {result.doc_name} ({label}): {result.section_count} sections")
 
 
+def _cmd_llm_doctor(args: argparse.Namespace) -> None:
+    print_probe(as_json=args.json)
+
+
 def _add_source_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--source",
@@ -329,6 +334,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Force routing to a specific store (default: auto-detect from source_type)",
     )
     p_index.set_defaults(func=_cmd_index)
+
+    # llm-doctor
+    p_llm_doctor = subparsers.add_parser(
+        "llm-doctor",
+        help="Check configured LLM providers",
+        description=(
+            "Check configured LLM providers. Ollama provider support is beta; "
+            "report bugs and model-quality validation results in GitHub issues."
+        ),
+        epilog="Issues: https://github.com/deandevz/king-context/issues",
+    )
+    p_llm_doctor.add_argument("--json", action="store_true", help="JSON output")
+    p_llm_doctor.set_defaults(func=_cmd_llm_doctor)
 
     adr.add_subparser(subparsers)
 

--- a/src/context_cli/llm_doctor.py
+++ b/src/context_cli/llm_doctor.py
@@ -1,0 +1,114 @@
+"""LLM provider diagnostics for kctx and installer doctor."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from llm_providers.config import ResolvedConfig, resolve
+
+
+def _url(config: ResolvedConfig) -> str:
+    if config.ollama_api_mode == "openai":
+        return f"{config.ollama_base_url.rstrip('/')}/models"
+    return f"{config.ollama_base_url.rstrip('/')}/api/tags"
+
+
+def _headers(config: ResolvedConfig) -> dict[str, str]:
+    if config.ollama_api_key:
+        return {"Authorization": f"Bearer {config.ollama_api_key}"}
+    return {}
+
+
+def _model_names(data: dict[str, Any], mode: str) -> list[str]:
+    if mode == "openai":
+        items = data.get("data", [])
+        return sorted(
+            str(item["id"])
+            for item in items
+            if isinstance(item, dict) and item.get("id")
+        )
+
+    items = data.get("models", [])
+    names: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("model")
+        if name:
+            names.add(str(name))
+    return sorted(names)
+
+
+def probe_ollama() -> dict[str, Any]:
+    configs = [resolve(stage, validate=False) for stage in ("enrich", "filter", "research")]
+    ollama_configs = [config for config in configs if config.provider == "ollama"]
+    if not ollama_configs:
+        return {"ollama": None}
+
+    config = ollama_configs[0]
+    configured_models = sorted({item.model for item in ollama_configs})
+    base_payload: dict[str, Any] = {
+        "mode": config.ollama_api_mode,
+        "base_url": config.ollama_base_url,
+        "reachable": False,
+        "models_present": [],
+        "models_missing": configured_models,
+        "version": None,
+    }
+
+    try:
+        response = httpx.get(
+            _url(config),
+            headers=_headers(config),
+            timeout=5.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except Exception as exc:
+        base_payload["warning"] = str(exc)
+        return {"ollama": base_payload}
+
+    available = _model_names(data, config.ollama_api_mode)
+    present = [model for model in configured_models if model in available]
+    missing = [model for model in configured_models if model not in available]
+    version = response.headers.get("ollama-version") or response.headers.get("x-ollama-version")
+
+    base_payload.update(
+        {
+            "reachable": True,
+            "models_present": present,
+            "models_missing": missing,
+            "version": version,
+        }
+    )
+    return {"ollama": base_payload}
+
+
+def print_probe(*, as_json: bool) -> None:
+    payload = probe_ollama()
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    ollama = payload["ollama"]
+    if ollama is None:
+        print("Ollama: not configured")
+        return
+
+    status = "reachable" if ollama["reachable"] else "unreachable"
+    print(f"Ollama: {status} ({ollama['mode']}, {ollama['base_url']})")
+    print(
+        "Ollama provider support is beta. Report bugs and model-quality "
+        "validation results in GitHub issues: "
+        "https://github.com/deandevz/king-context/issues"
+    )
+    if ollama.get("version"):
+        print(f"Version: {ollama['version']}")
+    if ollama["models_present"]:
+        print("Models present: " + ", ".join(ollama["models_present"]))
+    if ollama["models_missing"]:
+        print("Models missing: " + ", ".join(ollama["models_missing"]))
+    if ollama.get("warning"):
+        print("Warning: " + ollama["warning"])

--- a/src/king_context/env.py
+++ b/src/king_context/env.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+
+def _apply_env_file(path: Path, *, override: bool, protected: set[str]) -> None:
+    for key, value in dotenv_values(path).items():
+        if value is None:
+            continue
+        if key in protected:
+            continue
+        if override or key not in os.environ:
+            os.environ[key] = value
+
+
+def load_project_env(project_root: Path | None = None) -> None:
+    """Load installer and project env files for CLI entry points."""
+    if os.environ.get("KING_CONTEXT_DISABLE_DOTENV", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return
+
+    root = project_root if project_root is not None else Path.cwd()
+    protected = set(os.environ)
+
+    installer_env = root / ".king-context" / ".env"
+    if installer_env.exists():
+        _apply_env_file(installer_env, override=False, protected=protected)
+
+    developer_env = root / ".env"
+    if developer_env.exists():
+        _apply_env_file(developer_env, override=True, protected=protected)

--- a/src/king_context/errors.py
+++ b/src/king_context/errors.py
@@ -1,0 +1,5 @@
+"""Shared project exceptions."""
+
+
+class ConfigError(Exception):
+    """Configuration is missing or invalid."""

--- a/src/king_context/research/config.py
+++ b/src/king_context/research/config.py
@@ -2,6 +2,7 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 
+from king_context.env import load_project_env
 from king_context.scraper.config import ConfigError, ScraperConfig, load_config
 
 
@@ -77,6 +78,7 @@ def _env_int(name: str, default: int) -> int:
 
 
 def load_research_config(**overrides) -> ResearchConfig:
+    load_project_env()
     scraper_cfg = load_config()
 
     exa_api_key = os.environ.get("EXA_API_KEY", "").strip()
@@ -84,7 +86,10 @@ def load_research_config(**overrides) -> ResearchConfig:
         raise ConfigError("EXA_API_KEY is not set")
 
     jina_api_key = os.environ.get("JINA_API_KEY", "").strip()
-    research_model = os.environ.get("OPENROUTER_MODEL_RESEARCH", "").strip()
+    research_model = (
+        os.environ.get("RESEARCH_MODEL", "").strip()
+        or os.environ.get("OPENROUTER_MODEL_RESEARCH", "").strip()
+    )
 
     config = ResearchConfig(
         scraper=scraper_cfg,

--- a/src/king_context/research/pipeline.py
+++ b/src/king_context/research/pipeline.py
@@ -44,10 +44,23 @@ def _validate_config(config: ResearchConfig) -> None:
         raise ConfigError(
             "EXA_API_KEY not set — add it to .env or .king-context/.env"
         )
-    if not config.scraper.openrouter_api_key:
-        raise ConfigError(
-            "OPENROUTER_API_KEY not set — add it to .env or .king-context/.env"
+
+
+def _print_enrichment_cost(cost: dict) -> None:
+    provider = cost.get("provider", "openrouter")
+    if provider == "openrouter":
+        print(
+            f"Enrichment cost estimate: ${cost['estimated_cost']:.4f} "
+            f"({cost['total_chunks']} chunks, model: {cost['model']})"
         )
+        return
+
+    print(
+        f"Enrichment local model estimate: {cost['total_chunks']} chunks, "
+        f"model: {cost['model']} (no estimated OpenRouter cost)"
+    )
+    if cost.get("fallback_warning"):
+        print("Warning: OpenRouter fallback is enabled and may incur cost")
 
 
 def _write_page_artifacts(source: SourceDoc, pages_dir: Path) -> None:
@@ -190,10 +203,7 @@ async def run_pipeline(args: argparse.Namespace, config: ResearchConfig) -> Path
                     "chunking produced no sections or resume state is missing."
                 )
             cost = estimate_cost(chunks, config.scraper)
-            print(
-                f"Enrichment cost estimate: ${cost['estimated_cost']:.4f} "
-                f"({cost['total_chunks']} chunks, model: {cost['model']})"
-            )
+            _print_enrichment_cost(cost)
             if not getattr(args, "yes", False):
                 confirm = input("Proceed? [y/N] ").strip().lower()
                 if confirm != "y":

--- a/src/king_context/research/queries.py
+++ b/src/king_context/research/queries.py
@@ -8,15 +8,13 @@ import re
 import string
 from dataclasses import dataclass
 
-import httpx
-
 from king_context.research.config import ResearchConfig
+from llm_providers import get_client
+from llm_providers.base import ProviderError
 
 
 log = logging.getLogger(__name__)
 
-_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
-_REQUEST_TIMEOUT = 30.0
 _MAX_ATTEMPTS = 3
 _RETRY_DELAYS: list[float] = [1.0, 2.0]
 _HIGHLIGHT_MAX_CHARS = 240
@@ -89,15 +87,18 @@ def _strip_code_fence(content: str) -> str:
     return stripped
 
 
-def _extract_queries(raw_content: str) -> list[str]:
-    """Parse the model's content string into a list of query strings."""
-    content = _strip_code_fence(raw_content)
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError as exc:
-        raise QueryGenerationError(
-            f"LLM response was not valid JSON: {exc}"
-        ) from exc
+def _extract_queries(raw_content: str | dict | list) -> list[str]:
+    """Parse the model's content or parsed payload into query strings."""
+    if isinstance(raw_content, str):
+        content = _strip_code_fence(raw_content)
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise QueryGenerationError(
+                f"LLM response was not valid JSON: {exc}"
+            ) from exc
+    else:
+        parsed = raw_content
 
     if isinstance(parsed, list):
         candidates = parsed
@@ -113,90 +114,6 @@ def _extract_queries(raw_content: str) -> list[str]:
         if isinstance(item, str) and item.strip():
             queries.append(item.strip())
     return queries
-
-
-def _should_retry(status_code: int) -> bool:
-    return status_code == 429 or status_code >= 500
-
-
-def _is_fatal_client_error(status_code: int) -> bool:
-    return status_code in (400, 401)
-
-
-async def _post_once(
-    client: httpx.AsyncClient,
-    payload: dict,
-    api_key: str,
-) -> httpx.Response:
-    return await client.post(
-        _OPENROUTER_URL,
-        headers={"Authorization": f"Bearer {api_key}"},
-        json=payload,
-    )
-
-
-async def _call_openrouter(
-    system_prompt: str,
-    user_prompt: str,
-    model: str,
-    api_key: str,
-) -> str:
-    """POST to OpenRouter with retries. Returns the raw ``content`` string."""
-    payload = {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
-        "response_format": {"type": "json_object"},
-    }
-
-    last_error: Exception | None = None
-    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
-        for attempt in range(_MAX_ATTEMPTS):
-            try:
-                response = await _post_once(client, payload, api_key)
-            except (httpx.TimeoutException, httpx.ConnectError) as exc:
-                last_error = exc
-                log.warning(
-                    "OpenRouter transient error on attempt %d: %s", attempt + 1, exc
-                )
-            else:
-                status = response.status_code
-                if status < 400:
-                    data = response.json()
-                    try:
-                        return data["choices"][0]["message"]["content"]
-                    except (KeyError, IndexError, TypeError) as exc:
-                        raise QueryGenerationError(
-                            f"Unexpected OpenRouter response shape: {exc}"
-                        ) from exc
-
-                if _is_fatal_client_error(status):
-                    raise QueryGenerationError(
-                        f"OpenRouter rejected request (status {status}): "
-                        f"{response.text[:200]}"
-                    )
-
-                if not _should_retry(status):
-                    raise QueryGenerationError(
-                        f"OpenRouter returned status {status}: "
-                        f"{response.text[:200]}"
-                    )
-
-                last_error = httpx.HTTPStatusError(
-                    f"status {status}", request=response.request, response=response
-                )
-                log.warning(
-                    "OpenRouter retryable status %d on attempt %d", status, attempt + 1
-                )
-
-            if attempt < len(_RETRY_DELAYS):
-                await asyncio.sleep(_RETRY_DELAYS[attempt])
-
-    raise QueryGenerationError(
-        f"OpenRouter call failed after {_MAX_ATTEMPTS} attempts: {last_error}"
-    )
 
 
 def _dedup(
@@ -242,19 +159,39 @@ async def generate_queries(
     if count <= 0:
         return []
 
-    model = config.research_model or config.scraper.enrichment_model
-    if not model:
-        raise QueryGenerationError("No model configured for query generation")
-    if not config.scraper.openrouter_api_key:
-        raise QueryGenerationError("OPENROUTER_API_KEY is not configured")
-
     user_prompt = _build_user_prompt(topic, count, previous_results, previous_queries)
-    raw_content = await _call_openrouter(
-        _SYSTEM_PROMPT,
-        user_prompt,
-        model,
-        config.scraper.openrouter_api_key,
+    model = config.research_model or config.scraper.enrichment_model or None
+    client = get_client(
+        "research",
+        model_override=model,
+        openrouter_api_key_override=config.scraper.openrouter_api_key,
     )
 
-    candidates = _extract_queries(raw_content)
-    return _dedup(candidates, previous_queries, count)
+    last_error: Exception | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        try:
+            payload = await client.complete(user_prompt, system=_SYSTEM_PROMPT)
+            candidates = _extract_queries(payload)
+            return _dedup(candidates, previous_queries, count)
+        except ProviderError as exc:
+            last_error = exc
+            if not exc.transient:
+                raise QueryGenerationError(
+                    f"{client.name} query generation failed: {exc.message}"
+                ) from exc
+            log.warning(
+                "%s transient error on attempt %d: %s",
+                client.name,
+                attempt + 1,
+                exc.message,
+            )
+        except QueryGenerationError:
+            raise
+
+        if attempt < len(_RETRY_DELAYS):
+            await asyncio.sleep(_RETRY_DELAYS[attempt])
+
+    raise QueryGenerationError(
+        f"{client.name} query generation failed after {_MAX_ATTEMPTS} attempts: "
+        f"{last_error}"
+    )

--- a/src/king_context/research/queries.py
+++ b/src/king_context/research/queries.py
@@ -160,7 +160,7 @@ async def generate_queries(
         return []
 
     user_prompt = _build_user_prompt(topic, count, previous_results, previous_queries)
-    model = config.research_model or config.scraper.enrichment_model or None
+    model = config.research_model or None
     client = get_client(
         "research",
         model_override=model,

--- a/src/king_context/scraper/cli.py
+++ b/src/king_context/scraper/cli.py
@@ -81,6 +81,23 @@ def _load_enriched_from_checkpoints(work_dir: Path) -> list[EnrichedChunk]:
     return [EnrichedChunk(**c) for c in data]
 
 
+def _print_enrichment_cost(cost: dict, *, prefix: str = "  ") -> None:
+    provider = cost.get("provider", "openrouter")
+    if provider == "openrouter":
+        print(
+            f"{prefix}cost estimate: ${cost['estimated_cost']:.4f} "
+            f"({cost['total_chunks']} chunks, model: {cost['model']})"
+        )
+        return
+
+    print(
+        f"{prefix}local model estimate: {cost['total_chunks']} chunks, "
+        f"model: {cost['model']} (no estimated OpenRouter cost)"
+    )
+    if cost.get("fallback_warning"):
+        print(f"{prefix}warning: OpenRouter fallback is enabled and may incur cost")
+
+
 async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
     """Orchestrate the full scraping pipeline with checkpoint resume support.
 
@@ -182,10 +199,7 @@ async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
             if not chunks:
                 chunks = _load_chunks_from_checkpoints(work_dir)
             cost = estimate_cost(chunks, config)
-            print(
-                f"  cost estimate: ${cost['estimated_cost']:.4f} "
-                f"({cost['total_chunks']} chunks, model: {cost['model']})"
-            )
+            _print_enrichment_cost(cost)
             if not getattr(args, "yes", False):
                 confirm = input("  Proceed with enrichment? [y/N] ").strip().lower()
                 if confirm != "y":
@@ -246,8 +260,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--model",
-        default="google/gemini-3-flash-preview", # Cheap and Fast Model for enrichment.
-        help="LLM model to use for enrichment (default: google/gemini-3-flash-preview)", ##  default name in cli.
+        default=None,
+        help="LLM model to use for enrichment (default: ENRICH_MODEL or project default)",
     )
     parser.add_argument(
         "--chunk-max-tokens",

--- a/src/king_context/scraper/config.py
+++ b/src/king_context/scraper/config.py
@@ -1,33 +1,17 @@
 import os
 from dataclasses import dataclass
-from pathlib import Path
-from dotenv import load_dotenv
 
-from king_context import PROJECT_ROOT
+from king_context.env import load_project_env
+from king_context.errors import ConfigError
 
-
-def _load_env_files(project_root: Path | None = None) -> None:
-    root = project_root if project_root is not None else PROJECT_ROOT
-    installer_env = root / ".king-context" / ".env"
-    if installer_env.exists():
-        load_dotenv(installer_env)
-    developer_env = root / ".env"
-    if developer_env.exists():
-        load_dotenv(developer_env, override=True)
-
-
-_load_env_files()
-
-
-class ConfigError(Exception):
-    pass
+DEFAULT_ENRICHMENT_MODEL = "google/gemini-3-flash-preview"
 
 
 @dataclass
 class ScraperConfig:
     firecrawl_api_key: str = ""
     openrouter_api_key: str = ""
-    enrichment_model: str = "google/gemini-3-flash-preview" ## Cheap and Fast Model for enrichment.
+    enrichment_model: str = DEFAULT_ENRICHMENT_MODEL
     enrichment_batch_size: int = 10
     chunk_max_tokens: int = 1000
     chunk_min_tokens: int = 100
@@ -36,6 +20,7 @@ class ScraperConfig:
 
 
 def get_firecrawl_key() -> str:
+    load_project_env()
     key = os.environ.get("FIRECRAWL_API_KEY", "")
     if not key:
         raise ConfigError("FIRECRAWL_API_KEY is not set")
@@ -43,6 +28,7 @@ def get_firecrawl_key() -> str:
 
 
 def get_openrouter_key() -> str:
+    load_project_env()
     key = os.environ.get("OPENROUTER_API_KEY", "")
     if not key:
         raise ConfigError("OPENROUTER_API_KEY is not set")
@@ -50,15 +36,19 @@ def get_openrouter_key() -> str:
 
 
 def load_config(**overrides) -> ScraperConfig:
+    load_project_env()
     firecrawl_api_key = os.environ.get("FIRECRAWL_API_KEY", "")
     openrouter_api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    enrichment_model = os.environ.get("ENRICH_MODEL", "").strip() or DEFAULT_ENRICHMENT_MODEL
 
     config = ScraperConfig(
         firecrawl_api_key=firecrawl_api_key,
         openrouter_api_key=openrouter_api_key,
+        enrichment_model=enrichment_model,
     )
 
     for key, value in overrides.items():
-        setattr(config, key, value)
+        if value is not None:
+            setattr(config, key, value)
 
     return config

--- a/src/king_context/scraper/enrich.py
+++ b/src/king_context/scraper/enrich.py
@@ -3,11 +3,13 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-import httpx
-
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import _update_step
+from llm_providers import LLMClient, get_stage_clients
+from llm_providers.config import ResolvedConfig, resolve
+from llm_providers.logging import log_fallback
+from llm_providers.openrouter import OpenRouterClient
 
 
 ENRICHMENT_PROMPT = """\
@@ -72,7 +74,7 @@ def validate_enrichment(enrichment: dict) -> list[str]:
 
 
 def estimate_cost(chunks: list[Chunk], config: ScraperConfig) -> dict:
-    """Estimate enrichment cost based on chunk token counts."""
+    """Estimate enrichment cost based on chunk token counts and provider."""
     total_chunks = len(chunks)
     total_batches = (
         (total_chunks + config.enrichment_batch_size - 1) // config.enrichment_batch_size
@@ -83,61 +85,105 @@ def estimate_cost(chunks: list[Chunk], config: ScraperConfig) -> dict:
     estimated_input_tokens = sum(c.token_count for c in chunks) + prompt_overhead * total_chunks
     estimated_output_tokens = total_chunks * 150
 
-    # Approximate pricing for gpt-4o-mini: $0.15/1M input, $0.60/1M output
-    input_cost_per_token = 0.15 / 1_000_000
-    output_cost_per_token = 0.60 / 1_000_000
-    estimated_cost = (
-        estimated_input_tokens * input_cost_per_token
-        + estimated_output_tokens * output_cost_per_token
+    provider_cfg = resolve(
+        "enrich",
+        validate=False,
+        model_override=config.enrichment_model,
+        openrouter_api_key_override=config.openrouter_api_key,
     )
+
+    estimated_cost = 0.0
+    cost_note = "local_runtime_only"
+    if provider_cfg.provider == "openrouter":
+        # Approximate pricing for gpt-4o-mini: $0.15/1M input, $0.60/1M output
+        input_cost_per_token = 0.15 / 1_000_000
+        output_cost_per_token = 0.60 / 1_000_000
+        estimated_cost = (
+            estimated_input_tokens * input_cost_per_token
+            + estimated_output_tokens * output_cost_per_token
+        )
+        cost_note = "estimated_openrouter_cost"
 
     return {
         "total_chunks": total_chunks,
         "total_batches": total_batches,
         "estimated_input_tokens": estimated_input_tokens,
         "estimated_output_tokens": estimated_output_tokens,
-        "model": config.enrichment_model,
+        "provider": provider_cfg.provider,
+        "model": provider_cfg.model,
         "estimated_cost": round(estimated_cost, 6),
+        "cost_note": cost_note,
+        "fallback_enabled": provider_cfg.fallback_enabled,
+        "fallback_warning": (
+            provider_cfg.provider == "ollama" and provider_cfg.fallback_enabled
+        ),
     }
 
 
 async def call_openrouter(prompt: str, config: ScraperConfig) -> dict:
-    """POST to OpenRouter and return parsed JSON from the model response."""
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(
-            "https://openrouter.ai/api/v1/chat/completions",
-            headers={"Authorization": f"Bearer {config.openrouter_api_key}"},
-            json={
-                "model": config.enrichment_model,
-                "messages": [{"role": "user", "content": prompt}],
-                "response_format": {"type": "json_object"},
-            },
-        )
-        response.raise_for_status()
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        return json.loads(content)
+    """Deprecated compatibility wrapper for direct OpenRouter enrichment."""
+    provider_cfg = resolve(
+        "enrich",
+        validate=False,
+        model_override=config.enrichment_model,
+        openrouter_api_key_override=config.openrouter_api_key,
+    )
+    openrouter_cfg = ResolvedConfig(
+        stage="enrich",
+        provider="openrouter",
+        model=config.enrichment_model,
+        concurrency=provider_cfg.concurrency,
+        openrouter_api_key=config.openrouter_api_key or provider_cfg.openrouter_api_key,
+        ollama_api_mode=provider_cfg.ollama_api_mode,
+        ollama_base_url=provider_cfg.ollama_base_url,
+        ollama_api_key=provider_cfg.ollama_api_key,
+        fallback_enabled=False,
+        fallback_model=provider_cfg.fallback_model,
+    )
+    return await OpenRouterClient(openrouter_cfg).complete(prompt)
 
 
-async def _enrich_one(chunk: Chunk, config: ScraperConfig) -> EnrichedChunk | None:
+def _to_enriched_chunk(chunk: Chunk, enrichment: dict) -> EnrichedChunk:
+    return EnrichedChunk(
+        title=chunk.title,
+        path=chunk.path,
+        url=chunk.source_url,
+        content=chunk.content,
+        keywords=enrichment["keywords"],
+        use_cases=enrichment["use_cases"],
+        tags=enrichment["tags"],
+        priority=enrichment["priority"],
+    )
+
+
+async def _enrich_one(
+    chunk: Chunk,
+    primary_client: LLMClient,
+    schema_fallback: LLMClient | None = None,
+) -> EnrichedChunk | None:
     """Enrich a single chunk with up to 2 retries on validation failure."""
     prompt = ENRICHMENT_PROMPT.format(title=chunk.title, content=chunk.content)
 
     for _ in range(3):  # 1 initial attempt + 2 retries
         try:
-            enrichment = await call_openrouter(prompt, config)
+            enrichment = await primary_client.complete(prompt)
             errors = validate_enrichment(enrichment)
             if not errors:
-                return EnrichedChunk(
-                    title=chunk.title,
-                    path=chunk.path,
-                    url=chunk.source_url,
-                    content=chunk.content,
-                    keywords=enrichment["keywords"],
-                    use_cases=enrichment["use_cases"],
-                    tags=enrichment["tags"],
-                    priority=enrichment["priority"],
-                )
+                return _to_enriched_chunk(chunk, enrichment)
+        except Exception:
+            pass
+
+    if schema_fallback is not None:
+        log_fallback(
+            stage="enrich",
+            primary=primary_client,
+            fallback=schema_fallback,
+            reason="validation_failed_3x",
+        )
+        try:
+            enrichment = await schema_fallback.complete(prompt)
+            if not validate_enrichment(enrichment):
+                return _to_enriched_chunk(chunk, enrichment)
         except Exception:
             pass
 
@@ -199,13 +245,27 @@ async def enrich_chunks(
             # Next batch number continues from existing count
             batch_offset = len(existing_batches)
 
+    clients = get_stage_clients(
+        "enrich",
+        model_override=config.enrichment_model,
+        openrouter_api_key_override=config.openrouter_api_key,
+    )
+    semaphore = asyncio.Semaphore(clients.primary.concurrency)
     batch_size = config.enrichment_batch_size
     total_chunks = len(chunks) + len(enriched)  # original total
+
+    async def guarded(chunk: Chunk) -> EnrichedChunk | None:
+        async with semaphore:
+            return await _enrich_one(
+                chunk,
+                clients.primary,
+                clients.schema_fallback,
+            )
 
     for batch_idx, start in enumerate(range(0, len(chunks), batch_size)):
         batch_num = batch_offset + batch_idx
         batch = chunks[start:start + batch_size]
-        results = await asyncio.gather(*[_enrich_one(c, config) for c in batch])
+        results = await asyncio.gather(*[guarded(c) for c in batch])
 
         for result in results:
             if result is not None:

--- a/src/king_context/scraper/enrich.py
+++ b/src/king_context/scraper/enrich.py
@@ -239,8 +239,18 @@ async def _enrich_one(
         )
         try:
             enrichment = await schema_fallback.complete(prompt)
-            if not validate_enrichment(enrichment):
+            fallback_errors = validate_enrichment(enrichment)
+            if not fallback_errors:
                 return _to_enriched_chunk(chunk, enrichment)
+            raise ProviderError(
+                "validation_failed_3x",
+                transient=False,
+                provider=schema_fallback.name,
+                message=(
+                    "Enrichment schema fallback returned invalid metadata: "
+                    + "; ".join(fallback_errors)
+                ),
+            )
         except ProviderError:
             raise
         except Exception:

--- a/src/king_context/scraper/enrich.py
+++ b/src/king_context/scraper/enrich.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import _update_step
-from llm_providers import LLMClient, get_stage_clients
+from llm_providers import LLMClient, ProviderError, get_stage_clients
 from llm_providers.config import ResolvedConfig, resolve
 from llm_providers.logging import log_fallback
 from llm_providers.openrouter import OpenRouterClient
@@ -170,6 +170,8 @@ async def _enrich_one(
             errors = validate_enrichment(enrichment)
             if not errors:
                 return _to_enriched_chunk(chunk, enrichment)
+        except ProviderError:
+            raise
         except Exception:
             pass
 
@@ -184,6 +186,8 @@ async def _enrich_one(
             enrichment = await schema_fallback.complete(prompt)
             if not validate_enrichment(enrichment):
                 return _to_enriched_chunk(chunk, enrichment)
+        except ProviderError:
+            raise
         except Exception:
             pass
 

--- a/src/king_context/scraper/enrich.py
+++ b/src/king_context/scraper/enrich.py
@@ -2,12 +2,14 @@ import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import _update_step
 from llm_providers import LLMClient, ProviderError, get_stage_clients
 from llm_providers.config import ResolvedConfig, resolve
+from llm_providers.fallback import FallbackClient
 from llm_providers.logging import log_fallback
 from llm_providers.openrouter import OpenRouterClient
 
@@ -156,6 +158,57 @@ def _to_enriched_chunk(chunk: Chunk, enrichment: dict) -> EnrichedChunk:
     )
 
 
+class _SemaphoredClient(LLMClient):
+    def __init__(self, client: LLMClient, semaphore: asyncio.Semaphore) -> None:
+        self._client = client
+        self._semaphore = semaphore
+        self.name = client.name
+        self.model = client.model
+        self.concurrency = client.concurrency
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        json_mode: bool = True,
+    ) -> dict[str, Any]:
+        async with self._semaphore:
+            return await self._client.complete(
+                prompt,
+                system=system,
+                json_mode=json_mode,
+            )
+
+
+def _collect_provider_semaphores(
+    client: LLMClient | None,
+    semaphores: dict[str, asyncio.Semaphore],
+) -> None:
+    if client is None:
+        return
+    if isinstance(client, FallbackClient):
+        _collect_provider_semaphores(client.primary, semaphores)
+        _collect_provider_semaphores(client.fallback, semaphores)
+        return
+    semaphores.setdefault(client.name, asyncio.Semaphore(client.concurrency))
+
+
+def _with_provider_semaphores(
+    client: LLMClient | None,
+    semaphores: dict[str, asyncio.Semaphore],
+) -> LLMClient | None:
+    if client is None:
+        return None
+    if isinstance(client, FallbackClient):
+        primary = _with_provider_semaphores(client.primary, semaphores)
+        fallback = _with_provider_semaphores(client.fallback, semaphores)
+        assert primary is not None
+        assert fallback is not None
+        return FallbackClient(primary=primary, fallback=fallback, stage=client.stage)
+    return _SemaphoredClient(client, semaphores[client.name])
+
+
 async def _enrich_one(
     chunk: Chunk,
     primary_client: LLMClient,
@@ -164,14 +217,16 @@ async def _enrich_one(
     """Enrich a single chunk with up to 2 retries on validation failure."""
     prompt = ENRICHMENT_PROMPT.format(title=chunk.title, content=chunk.content)
 
-    for _ in range(3):  # 1 initial attempt + 2 retries
+    for attempt in range(3):  # 1 initial attempt + 2 retries
         try:
             enrichment = await primary_client.complete(prompt)
             errors = validate_enrichment(enrichment)
             if not errors:
                 return _to_enriched_chunk(chunk, enrichment)
-        except ProviderError:
-            raise
+        except ProviderError as exc:
+            if not exc.transient or attempt == 2:
+                raise
+            continue
         except Exception:
             pass
 
@@ -254,17 +309,21 @@ async def enrich_chunks(
         model_override=config.enrichment_model,
         openrouter_api_key_override=config.openrouter_api_key,
     )
-    semaphore = asyncio.Semaphore(clients.primary.concurrency)
+    semaphores: dict[str, asyncio.Semaphore] = {}
+    _collect_provider_semaphores(clients.primary, semaphores)
+    _collect_provider_semaphores(clients.schema_fallback, semaphores)
+    primary_client = _with_provider_semaphores(clients.primary, semaphores)
+    schema_fallback = _with_provider_semaphores(clients.schema_fallback, semaphores)
+    assert primary_client is not None
     batch_size = config.enrichment_batch_size
     total_chunks = len(chunks) + len(enriched)  # original total
 
     async def guarded(chunk: Chunk) -> EnrichedChunk | None:
-        async with semaphore:
-            return await _enrich_one(
-                chunk,
-                clients.primary,
-                clients.schema_fallback,
-            )
+        return await _enrich_one(
+            chunk,
+            primary_client,
+            schema_fallback,
+        )
 
     for batch_idx, start in enumerate(range(0, len(chunks), batch_size)):
         batch_num = batch_offset + batch_idx

--- a/src/king_context/scraper/filter.py
+++ b/src/king_context/scraper/filter.py
@@ -1,12 +1,13 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import json
 import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
-import httpx
-
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import get_work_dir, _update_step
+from llm_providers import get_client
 
 
 INCLUDE_PATTERNS = [
@@ -86,22 +87,23 @@ def _matches_patterns(path: str, patterns: list[str]) -> bool:
 
 def _call_llm(urls: list[str], config: ScraperConfig) -> dict[str, str]:
     prompt = FILTER_PROMPT.format(urls="\n".join(urls))
-    response = httpx.post(
-        "https://openrouter.ai/api/v1/chat/completions",
-        headers={
-            "Authorization": f"Bearer {config.openrouter_api_key}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "model": config.enrichment_model,
-            "messages": [{"role": "user", "content": prompt}],
-            "response_format": {"type": "json_object"},
-        },
-        timeout=60.0,
+    client = get_client(
+        "filter",
+        openrouter_api_key_override=config.openrouter_api_key,
     )
-    response.raise_for_status()
-    content = response.json()["choices"][0]["message"]["content"]
-    return json.loads(content)
+
+    async def complete() -> dict:
+        return await client.complete(prompt)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        result = asyncio.run(complete())
+    else:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(lambda: asyncio.run(complete())).result()
+
+    return {str(key): str(value) for key, value in result.items()}
 
 
 def filter_urls(urls: list[str], base_url: str, config: ScraperConfig) -> FilterResult:

--- a/src/king_context/scraper/filter.py
+++ b/src/king_context/scraper/filter.py
@@ -5,9 +5,10 @@ import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+from king_context.errors import ConfigError
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import get_work_dir, _update_step
-from llm_providers import get_client
+from llm_providers import ProviderError, get_client
 
 
 INCLUDE_PATTERNS = [
@@ -157,6 +158,8 @@ def filter_urls(urls: list[str], base_url: str, config: ScraperConfig) -> Filter
                 accepted, rejected, maybe = new_accepted, new_rejected, new_maybe
                 llm_fallback_used = True
                 filter_method = "heuristic+llm"
+            except (ConfigError, ProviderError):
+                raise
             except Exception:
                 pass
 

--- a/src/llm_providers/__init__.py
+++ b/src/llm_providers/__init__.py
@@ -1,0 +1,84 @@
+"""LLM provider factory exports."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from llm_providers.base import LLMClient, ProviderError
+from llm_providers.config import ResolvedConfig, resolve
+from llm_providers.fallback import FallbackClient
+from llm_providers.ollama import OllamaClient
+from llm_providers.openrouter import OpenRouterClient
+from llm_providers.registry import create_client, register_provider
+
+
+register_provider("openrouter", OpenRouterClient)
+register_provider("ollama", OllamaClient)
+
+
+@dataclass(frozen=True)
+class StageClients:
+    primary: LLMClient
+    schema_fallback: LLMClient | None = None
+
+
+def _openrouter_fallback_config(config: ResolvedConfig) -> ResolvedConfig:
+    return ResolvedConfig(
+        stage=config.stage,
+        provider="openrouter",
+        model=config.fallback_model,
+        concurrency=5,
+        openrouter_api_key=config.openrouter_api_key,
+        ollama_api_mode=config.ollama_api_mode,
+        ollama_base_url=config.ollama_base_url,
+        ollama_api_key=config.ollama_api_key,
+        fallback_enabled=False,
+        fallback_model=config.fallback_model,
+    )
+
+
+def get_stage_clients(
+    stage: str,
+    *,
+    model_override: str | None = None,
+    openrouter_api_key_override: str | None = None,
+) -> StageClients:
+    config = resolve(
+        stage,
+        model_override=model_override,
+        openrouter_api_key_override=openrouter_api_key_override,
+    )
+    primary = create_client(config)
+    schema_fallback = None
+
+    if config.provider == "ollama" and config.fallback_enabled:
+        fallback_config = _openrouter_fallback_config(config)
+        fallback = OpenRouterClient(fallback_config)
+        primary = FallbackClient(primary=primary, fallback=fallback, stage=stage)
+        schema_fallback = fallback
+
+    return StageClients(primary=primary, schema_fallback=schema_fallback)
+
+
+def get_client(
+    stage: str,
+    *,
+    model_override: str | None = None,
+    openrouter_api_key_override: str | None = None,
+) -> LLMClient:
+    return get_stage_clients(
+        stage,
+        model_override=model_override,
+        openrouter_api_key_override=openrouter_api_key_override,
+    ).primary
+
+
+__all__ = [
+    "LLMClient",
+    "ProviderError",
+    "ResolvedConfig",
+    "StageClients",
+    "get_client",
+    "get_stage_clients",
+    "register_provider",
+    "resolve",
+]

--- a/src/llm_providers/__init__.py
+++ b/src/llm_providers/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from llm_providers.base import LLMClient, ProviderError
-from llm_providers.config import ResolvedConfig, resolve
+from llm_providers.config import ResolvedConfig, provider_concurrency, resolve
 from llm_providers.fallback import FallbackClient
 from llm_providers.ollama import OllamaClient
 from llm_providers.openrouter import OpenRouterClient
@@ -26,7 +26,7 @@ def _openrouter_fallback_config(config: ResolvedConfig) -> ResolvedConfig:
         stage=config.stage,
         provider="openrouter",
         model=config.fallback_model,
-        concurrency=5,
+        concurrency=provider_concurrency("openrouter"),
         openrouter_api_key=config.openrouter_api_key,
         ollama_api_mode=config.ollama_api_mode,
         ollama_base_url=config.ollama_base_url,

--- a/src/llm_providers/base.py
+++ b/src/llm_providers/base.py
@@ -1,0 +1,45 @@
+"""Common LLM provider interfaces."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ProviderError(Exception):
+    """Provider failure with a stable machine-readable reason."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        transient: bool,
+        message: str,
+        provider: str | None = None,
+        primary_error: "ProviderError | None" = None,
+        fallback_error: "ProviderError | None" = None,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.transient = transient
+        self.message = message
+        self.provider = provider
+        self.primary_error = primary_error
+        self.fallback_error = fallback_error
+
+
+class LLMClient(ABC):
+    """Single-call JSON completion client."""
+
+    name: str
+    model: str
+    concurrency: int
+
+    @abstractmethod
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        json_mode: bool = True,
+    ) -> dict[str, Any]:
+        """Call the configured model and return a parsed JSON object."""

--- a/src/llm_providers/config.py
+++ b/src/llm_providers/config.py
@@ -1,0 +1,137 @@
+"""Environment configuration for LLM providers."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from king_context.env import load_project_env
+from king_context.errors import ConfigError
+
+
+DEFAULT_MODEL = "google/gemini-3-flash-preview"
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1"
+VALID_STAGES = {"enrich", "filter", "research"}
+VALID_OLLAMA_MODES = {"openai", "native"}
+VALID_PROVIDERS = {"openrouter", "ollama"}
+
+
+@dataclass(frozen=True)
+class ResolvedConfig:
+    stage: str
+    provider: str
+    model: str
+    concurrency: int
+    openrouter_api_key: str | None
+    ollama_api_mode: str
+    ollama_base_url: str
+    ollama_api_key: str | None
+    fallback_enabled: bool
+    fallback_model: str
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = _env(name)
+    if not raw:
+        return default
+    return raw.lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = _env(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _stage_prefix(stage: str) -> str:
+    if stage not in VALID_STAGES:
+        raise ConfigError(f"Unknown LLM stage: {stage}")
+    return stage.upper()
+
+
+def _stage_model(stage: str, model_override: str | None) -> str:
+    if model_override:
+        return model_override
+    prefix = _stage_prefix(stage)
+    model = _env(f"{prefix}_MODEL")
+    if model:
+        return model
+    if stage == "research":
+        legacy = _env("OPENROUTER_MODEL_RESEARCH")
+        if legacy:
+            return legacy
+    return DEFAULT_MODEL
+
+
+def _provider_for(stage: str) -> str:
+    prefix = _stage_prefix(stage)
+    return _env(f"{prefix}_PROVIDER", "openrouter").lower()
+
+
+def register_provider_name(name: str) -> None:
+    key = name.strip().lower()
+    if key:
+        VALID_PROVIDERS.add(key)
+
+
+def resolve(
+    stage: str,
+    *,
+    validate: bool = True,
+    model_override: str | None = None,
+    openrouter_api_key_override: str | None = None,
+) -> ResolvedConfig:
+    """Resolve provider configuration for one active stage."""
+    load_project_env()
+    provider = _provider_for(stage)
+    if provider not in VALID_PROVIDERS:
+        raise ConfigError(
+            f"{_stage_prefix(stage)}_PROVIDER must be one of: "
+            f"{', '.join(sorted(VALID_PROVIDERS))}"
+        )
+    ollama_mode = _env("OLLAMA_API_MODE", "openai").lower()
+    openrouter_key = openrouter_api_key_override or _env("OPENROUTER_API_KEY") or None
+    config = ResolvedConfig(
+        stage=stage,
+        provider=provider,
+        model=_stage_model(stage, model_override),
+        concurrency=_env_int(
+            f"CONCURRENCY_{provider.upper()}",
+            5 if provider == "openrouter" else 2,
+        ),
+        openrouter_api_key=openrouter_key,
+        ollama_api_mode=ollama_mode,
+        ollama_base_url=_env("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL).rstrip("/"),
+        ollama_api_key=_env("OLLAMA_API_KEY") or None,
+        fallback_enabled=_env_bool("ENABLE_FALLBACK", False),
+        fallback_model=_env("FALLBACK_MODEL", DEFAULT_MODEL),
+    )
+
+    if validate:
+        validate_config(config)
+    return config
+
+
+def validate_config(config: ResolvedConfig) -> None:
+    if config.provider == "openrouter" and not config.openrouter_api_key:
+        raise ConfigError("OPENROUTER_API_KEY is required for OpenRouter provider")
+
+    if config.provider == "ollama" and config.ollama_api_mode not in VALID_OLLAMA_MODES:
+        raise ConfigError("OLLAMA_API_MODE must be one of: openai, native")
+
+    if (
+        config.provider == "ollama"
+        and config.fallback_enabled
+        and not config.openrouter_api_key
+    ):
+        raise ConfigError(
+            "OPENROUTER_API_KEY is required when ENABLE_FALLBACK=true for an Ollama stage"
+        )

--- a/src/llm_providers/config.py
+++ b/src/llm_providers/config.py
@@ -51,6 +51,15 @@ def _env_int(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def provider_concurrency(provider: str) -> int:
+    """Resolve concurrency for a provider name."""
+    provider_key = provider.upper()
+    return _env_int(
+        f"CONCURRENCY_{provider_key}",
+        5 if provider.lower() == "openrouter" else 2,
+    )
+
+
 def _stage_prefix(stage: str) -> str:
     if stage not in VALID_STAGES:
         raise ConfigError(f"Unknown LLM stage: {stage}")
@@ -103,10 +112,7 @@ def resolve(
         stage=stage,
         provider=provider,
         model=_stage_model(stage, model_override),
-        concurrency=_env_int(
-            f"CONCURRENCY_{provider.upper()}",
-            5 if provider == "openrouter" else 2,
-        ),
+        concurrency=provider_concurrency(provider),
         openrouter_api_key=openrouter_key,
         ollama_api_mode=ollama_mode,
         ollama_base_url=_env("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL).rstrip("/"),

--- a/src/llm_providers/fallback.py
+++ b/src/llm_providers/fallback.py
@@ -1,0 +1,81 @@
+"""One-way Ollama to OpenRouter fallback wrapper."""
+from __future__ import annotations
+
+from typing import Any
+
+from king_context.errors import ConfigError
+
+from llm_providers.base import LLMClient, ProviderError
+from llm_providers.logging import log_fallback
+
+
+FALLBACK_REASONS = {
+    "connection_refused",
+    "model_not_found",
+    "invalid_response",
+    "rate_limit",
+    "server_error",
+    "timeout",
+}
+
+
+class FallbackClient(LLMClient):
+    """Wrap an Ollama primary with a single OpenRouter fallback call."""
+
+    def __init__(
+        self,
+        *,
+        primary: LLMClient,
+        fallback: LLMClient,
+        stage: str,
+    ) -> None:
+        if primary.name != "ollama" or fallback.name != "openrouter":
+            raise ConfigError("FallbackClient only supports ollama -> openrouter")
+        self.primary = primary
+        self.fallback = fallback
+        self.stage = stage
+        self.name = primary.name
+        self.model = primary.model
+        self.concurrency = primary.concurrency
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        json_mode: bool = True,
+    ) -> dict[str, Any]:
+        try:
+            return await self.primary.complete(
+                prompt,
+                system=system,
+                json_mode=json_mode,
+            )
+        except ProviderError as primary_error:
+            reason = primary_error.reason
+            if reason not in FALLBACK_REASONS:
+                raise
+            log_fallback(
+                stage=self.stage,
+                primary=self.primary,
+                fallback=self.fallback,
+                reason=reason,
+            )
+            try:
+                return await self.fallback.complete(
+                    prompt,
+                    system=system,
+                    json_mode=json_mode,
+                )
+            except ProviderError as fallback_error:
+                raise ProviderError(
+                    reason,
+                    transient=primary_error.transient or fallback_error.transient,
+                    provider=self.name,
+                    message=(
+                        f"Primary {self.primary.name} failed with {primary_error.reason}; "
+                        f"fallback {self.fallback.name} failed with {fallback_error.reason}"
+                    ),
+                    primary_error=primary_error,
+                    fallback_error=fallback_error,
+                ) from fallback_error

--- a/src/llm_providers/fallback.py
+++ b/src/llm_providers/fallback.py
@@ -70,7 +70,7 @@ class FallbackClient(LLMClient):
             except ProviderError as fallback_error:
                 raise ProviderError(
                     reason,
-                    transient=primary_error.transient or fallback_error.transient,
+                    transient=fallback_error.transient,
                     provider=self.name,
                     message=(
                         f"Primary {self.primary.name} failed with {primary_error.reason}; "

--- a/src/llm_providers/logging.py
+++ b/src/llm_providers/logging.py
@@ -1,0 +1,17 @@
+"""Small provider logging helpers."""
+from __future__ import annotations
+
+from llm_providers.base import LLMClient
+
+
+def log_fallback(
+    *,
+    stage: str,
+    primary: LLMClient,
+    fallback: LLMClient,
+    reason: str,
+) -> None:
+    print(
+        f"[fallback] {stage}: {primary.name} ({primary.model}) -> "
+        f"{fallback.name} ({fallback.model}) -- reason: {reason}"
+    )

--- a/src/llm_providers/ollama.py
+++ b/src/llm_providers/ollama.py
@@ -1,0 +1,136 @@
+"""Ollama provider supporting OpenAI-compatible and native APIs."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from llm_providers.base import LLMClient, ProviderError
+from llm_providers.config import ResolvedConfig
+from llm_providers.openrouter import _content_from_openai_shape, _http_error
+from llm_providers.parser import parse_json_object
+
+
+REQUEST_TIMEOUT = 60.0
+
+
+def _join(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+class OllamaClient(LLMClient):
+    name = "ollama"
+
+    def __init__(self, config: ResolvedConfig) -> None:
+        self.model = config.model
+        self.concurrency = config.concurrency
+        self.mode = config.ollama_api_mode
+        self.base_url = config.ollama_base_url
+        self.api_key = config.ollama_api_key
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _payload(
+        self,
+        prompt: str,
+        *,
+        system: str | None,
+        json_mode: bool,
+    ) -> tuple[str, dict[str, Any]]:
+        messages: list[dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        if self.mode == "openai":
+            payload: dict[str, Any] = {
+                "model": self.model,
+                "messages": messages,
+            }
+            if json_mode:
+                payload["response_format"] = {"type": "json_object"}
+            return _join(self.base_url, "chat/completions"), payload
+
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+        }
+        if json_mode:
+            payload["format"] = "json"
+        return _join(self.base_url, "api/chat"), payload
+
+    def _content(self, data: dict[str, Any]) -> str | dict[str, Any]:
+        if self.mode == "openai":
+            return _content_from_openai_shape(data, self.name)
+        try:
+            return data["message"]["content"]
+        except (KeyError, TypeError) as exc:
+            raise ProviderError(
+                "invalid_response",
+                transient=False,
+                provider=self.name,
+                message=f"Unexpected {self.name} native response shape: {exc}",
+            ) from exc
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        json_mode: bool = True,
+    ) -> dict[str, Any]:
+        url, payload = self._payload(prompt, system=system, json_mode=json_mode)
+
+        try:
+            async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+                response = await client.post(
+                    url,
+                    headers=self._headers(),
+                    json=payload,
+                )
+        except httpx.TimeoutException as exc:
+            raise ProviderError(
+                "timeout",
+                transient=True,
+                provider=self.name,
+                message=f"{self.name} request timed out",
+            ) from exc
+        except httpx.ConnectError as exc:
+            raise ProviderError(
+                "connection_refused",
+                transient=True,
+                provider=self.name,
+                message=f"{self.name} connection failed: {exc}",
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ProviderError(
+                "server_error",
+                transient=True,
+                provider=self.name,
+                message=f"{self.name} request failed: {exc}",
+            ) from exc
+
+        if response.status_code >= 400:
+            raise _http_error(self.name, response.status_code, response.text)
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ProviderError(
+                "invalid_response",
+                transient=False,
+                provider=self.name,
+                message=f"{self.name} returned non-JSON response",
+            ) from exc
+
+        content = self._content(data)
+        try:
+            return parse_json_object(content)
+        except ProviderError as exc:
+            exc.provider = self.name
+            raise

--- a/src/llm_providers/openrouter.py
+++ b/src/llm_providers/openrouter.py
@@ -1,0 +1,147 @@
+"""OpenRouter chat completion provider."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from llm_providers.base import LLMClient, ProviderError
+from llm_providers.config import ResolvedConfig
+from llm_providers.parser import parse_json_object
+
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+REQUEST_TIMEOUT = 30.0
+
+
+def _http_error(provider: str, status_code: int, text: str) -> ProviderError:
+    if status_code in (401, 403):
+        return ProviderError(
+            "auth_error",
+            transient=False,
+            provider=provider,
+            message=f"{provider} authentication failed (status {status_code})",
+        )
+    if status_code == 400:
+        return ProviderError(
+            "bad_request",
+            transient=False,
+            provider=provider,
+            message=f"{provider} rejected request (status 400): {text[:200]}",
+        )
+    if status_code == 404:
+        return ProviderError(
+            "model_not_found",
+            transient=False,
+            provider=provider,
+            message=f"{provider} model or endpoint was not found (status 404)",
+        )
+    if status_code == 429:
+        return ProviderError(
+            "rate_limit",
+            transient=True,
+            provider=provider,
+            message=f"{provider} rate limited the request",
+        )
+    if status_code >= 500:
+        return ProviderError(
+            "server_error",
+            transient=True,
+            provider=provider,
+            message=f"{provider} server error (status {status_code})",
+        )
+    return ProviderError(
+        "bad_request",
+        transient=False,
+        provider=provider,
+        message=f"{provider} returned status {status_code}: {text[:200]}",
+    )
+
+
+def _content_from_openai_shape(data: dict[str, Any], provider: str) -> str | dict[str, Any]:
+    try:
+        return data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ProviderError(
+            "invalid_response",
+            transient=False,
+            provider=provider,
+            message=f"Unexpected {provider} response shape: {exc}",
+        ) from exc
+
+
+class OpenRouterClient(LLMClient):
+    name = "openrouter"
+
+    def __init__(self, config: ResolvedConfig) -> None:
+        self.model = config.model
+        self.concurrency = config.concurrency
+        self.api_key = config.openrouter_api_key or ""
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        json_mode: bool = True,
+    ) -> dict[str, Any]:
+        messages: list[dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+        }
+        if json_mode:
+            payload["response_format"] = {"type": "json_object"}
+
+        try:
+            async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+                response = await client.post(
+                    OPENROUTER_URL,
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                    json=payload,
+                )
+        except httpx.TimeoutException as exc:
+            raise ProviderError(
+                "timeout",
+                transient=True,
+                provider=self.name,
+                message=f"{self.name} request timed out",
+            ) from exc
+        except httpx.ConnectError as exc:
+            raise ProviderError(
+                "connection_refused",
+                transient=True,
+                provider=self.name,
+                message=f"{self.name} connection failed: {exc}",
+            ) from exc
+        except httpx.RequestError as exc:
+            raise ProviderError(
+                "server_error",
+                transient=True,
+                provider=self.name,
+                message=f"{self.name} request failed: {exc}",
+            ) from exc
+
+        if response.status_code >= 400:
+            raise _http_error(self.name, response.status_code, response.text)
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ProviderError(
+                "invalid_response",
+                transient=False,
+                provider=self.name,
+                message=f"{self.name} returned non-JSON response",
+            ) from exc
+
+        content = _content_from_openai_shape(data, self.name)
+        try:
+            return parse_json_object(content)
+        except ProviderError as exc:
+            exc.provider = self.name
+            raise

--- a/src/llm_providers/parser.py
+++ b/src/llm_providers/parser.py
@@ -1,0 +1,111 @@
+"""Robust JSON object parsing for model responses."""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from llm_providers.base import ProviderError
+
+
+_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?```$", re.IGNORECASE | re.DOTALL)
+_TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
+
+
+def _invalid(message: str) -> ProviderError:
+    return ProviderError(
+        "invalid_response",
+        transient=False,
+        message=message,
+    )
+
+
+def _ensure_object(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _invalid("LLM response JSON was not an object")
+    return value
+
+
+def _strip_fence(content: str) -> str:
+    stripped = content.strip()
+    match = _FENCE_RE.match(stripped)
+    if match:
+        return match.group(1).strip()
+    return stripped
+
+
+def _extract_first_object(content: str) -> str | None:
+    start = content.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+
+    for index in range(start, len(content)):
+        char = content[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return content[start : index + 1]
+
+    return None
+
+
+def _loads_object(content: str) -> dict[str, Any]:
+    parsed = json.loads(content)
+    return _ensure_object(parsed)
+
+
+def _repair_trailing_commas(content: str) -> str:
+    previous = None
+    repaired = content
+    while previous != repaired:
+        previous = repaired
+        repaired = _TRAILING_COMMA_RE.sub(r"\1", repaired)
+    return repaired
+
+
+def parse_json_object(content: str | dict[str, Any]) -> dict[str, Any]:
+    """Parse a JSON object from model content.
+
+    Accepts clean objects, fenced objects, prose-wrapped objects, and otherwise
+    valid JSON with trailing commas. Malformed content fails explicitly.
+    """
+    if isinstance(content, dict):
+        return content
+    if not isinstance(content, str):
+        raise _invalid("LLM response content was not a string or object")
+
+    stripped = _strip_fence(content)
+    candidates = [stripped]
+    extracted = _extract_first_object(stripped)
+    if extracted is not None and extracted != stripped:
+        candidates.append(extracted)
+
+    for candidate in candidates:
+        try:
+            return _loads_object(candidate)
+        except (json.JSONDecodeError, ProviderError):
+            repaired = _repair_trailing_commas(candidate)
+            if repaired != candidate:
+                try:
+                    return _loads_object(repaired)
+                except (json.JSONDecodeError, ProviderError):
+                    pass
+
+    raise _invalid("LLM response was not parseable JSON")

--- a/src/llm_providers/registry.py
+++ b/src/llm_providers/registry.py
@@ -1,0 +1,32 @@
+"""Provider registry."""
+from __future__ import annotations
+
+from king_context.errors import ConfigError
+
+from llm_providers.base import LLMClient
+from llm_providers.config import ResolvedConfig, register_provider_name
+
+
+ProviderClass = type[LLMClient]
+_PROVIDERS: dict[str, ProviderClass] = {}
+
+
+def register_provider(name: str, provider_cls: ProviderClass) -> None:
+    key = name.strip().lower()
+    if not key:
+        raise ConfigError("Provider name cannot be empty")
+    _PROVIDERS[key] = provider_cls
+    register_provider_name(key)
+
+
+def get_provider_class(name: str) -> ProviderClass:
+    key = name.strip().lower()
+    try:
+        return _PROVIDERS[key]
+    except KeyError as exc:
+        raise ConfigError(f"Unknown LLM provider: {name}") from exc
+
+
+def create_client(config: ResolvedConfig) -> LLMClient:
+    provider_cls = get_provider_class(config.provider)
+    return provider_cls(config)  # type: ignore[call-arg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,49 @@
 
 import pytest
 import king_context.db as db
+from types import SimpleNamespace
+
+
+class FakeLLMClient:
+    name = "openrouter"
+    model = "test-model"
+    concurrency = 100
+
+    def __init__(
+        self,
+        responses=None,
+        *,
+        name: str = "openrouter",
+        model: str = "test-model",
+        concurrency: int = 100,
+        side_effect=None,
+    ):
+        self.name = name
+        self.model = model
+        self.concurrency = concurrency
+        self.responses = list(responses or [])
+        self.side_effect = side_effect
+        self.calls = []
+
+    async def complete(self, prompt, *, system=None, json_mode=True):
+        self.calls.append(
+            {"prompt": prompt, "system": system, "json_mode": json_mode}
+        )
+        if self.side_effect is not None:
+            result = self.side_effect(prompt, system=system, json_mode=json_mode)
+            if hasattr(result, "__await__"):
+                return await result
+            return result
+        if not self.responses:
+            raise AssertionError("FakeLLMClient has no response left")
+        result = self.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def fake_stage_clients(primary, schema_fallback=None):
+    return SimpleNamespace(primary=primary, schema_fallback=schema_fallback)
 
 
 @pytest.fixture
@@ -12,3 +55,9 @@ def temp_db(tmp_path, monkeypatch):
     yield temp_db_path
     if temp_db_path.exists():
         temp_db_path.unlink()
+
+
+@pytest.fixture(autouse=True)
+def disable_project_dotenv(monkeypatch):
+    """Keep developer .env files from influencing tests by default."""
+    monkeypatch.setenv("KING_CONTEXT_DISABLE_DOTENV", "1")

--- a/tests/test_doctor_llm.py
+++ b/tests/test_doctor_llm.py
@@ -1,0 +1,111 @@
+import httpx
+
+from context_cli.llm_doctor import probe_ollama
+
+
+def _clear(monkeypatch):
+    for name in [
+        "ENRICH_PROVIDER",
+        "ENRICH_MODEL",
+        "FILTER_PROVIDER",
+        "FILTER_MODEL",
+        "RESEARCH_PROVIDER",
+        "RESEARCH_MODEL",
+        "OPENROUTER_MODEL_RESEARCH",
+        "OPENROUTER_API_KEY",
+        "OLLAMA_API_MODE",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_API_KEY",
+        "ENABLE_FALLBACK",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _patch_get(monkeypatch, handler):
+    monkeypatch.setattr(httpx, "get", handler)
+
+
+def test_llm_doctor_returns_null_when_no_ollama(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    assert probe_ollama() == {"ollama": None}
+
+
+def test_llm_doctor_openai_probe(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("ENRICH_PROVIDER", "ollama")
+    monkeypatch.setenv("ENRICH_MODEL", "embeddinggemma")
+    monkeypatch.setenv("OLLAMA_API_MODE", "openai")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+    captured = {}
+
+    def handler(url, **kwargs):
+        captured["url"] = url
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "embeddinggemma"}]},
+            request=httpx.Request("GET", url),
+        )
+
+    _patch_get(monkeypatch, handler)
+
+    result = probe_ollama()["ollama"]
+
+    assert captured["url"] == "http://localhost:11434/v1/models"
+    assert result["reachable"] is True
+    assert result["models_present"] == ["embeddinggemma"]
+    assert result["models_missing"] == []
+
+
+def test_llm_doctor_loads_project_env(monkeypatch, tmp_path):
+    _clear(monkeypatch)
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "ENRICH_PROVIDER=ollama",
+                "ENRICH_MODEL=qwen2.5:7b",
+                "OLLAMA_API_MODE=openai",
+                "OLLAMA_BASE_URL=http://localhost:11434/v1",
+            ]
+        )
+    )
+
+    def handler(url, **kwargs):
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "qwen2.5:7b"}]},
+            request=httpx.Request("GET", url),
+        )
+
+    _patch_get(monkeypatch, handler)
+
+    result = probe_ollama()["ollama"]
+
+    assert result["reachable"] is True
+    assert result["models_present"] == ["qwen2.5:7b"]
+
+
+def test_llm_doctor_native_probe_missing_model(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("RESEARCH_PROVIDER", "ollama")
+    monkeypatch.setenv("RESEARCH_MODEL", "qwen2.5:7b")
+    monkeypatch.setenv("OLLAMA_API_MODE", "native")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "https://ollama.com")
+
+    def handler(url, **kwargs):
+        return httpx.Response(
+            200,
+            json={"models": [{"name": "other"}]},
+            request=httpx.Request("GET", url),
+        )
+
+    _patch_get(monkeypatch, handler)
+
+    result = probe_ollama()["ollama"]
+
+    assert result["mode"] == "native"
+    assert result["models_missing"] == ["qwen2.5:7b"]

--- a/tests/test_llm_providers/test_clients.py
+++ b/tests/test_llm_providers/test_clients.py
@@ -1,0 +1,120 @@
+import json
+
+import httpx
+import pytest
+
+from llm_providers.config import ResolvedConfig
+from llm_providers.ollama import OllamaClient
+from llm_providers.openrouter import OpenRouterClient
+
+
+def _config(
+    *,
+    provider: str,
+    model: str = "test-model",
+    mode: str = "openai",
+    base_url: str = "http://localhost:11434/v1",
+    openrouter_key: str | None = "or-key",
+    ollama_key: str | None = None,
+) -> ResolvedConfig:
+    return ResolvedConfig(
+        stage="enrich",
+        provider=provider,
+        model=model,
+        concurrency=2,
+        openrouter_api_key=openrouter_key,
+        ollama_api_mode=mode,
+        ollama_base_url=base_url,
+        ollama_api_key=ollama_key,
+        fallback_enabled=False,
+        fallback_model="fallback-model",
+    )
+
+
+def _patch_async_client(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+    original_async_client = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        return original_async_client(
+            transport=transport,
+            timeout=kwargs.get("timeout"),
+        )
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_request_shape(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["headers"] = request.headers
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": '{"ok": true}'}}]},
+        )
+
+    _patch_async_client(monkeypatch, handler)
+    client = OpenRouterClient(_config(provider="openrouter"))
+
+    result = await client.complete("hello", system="sys")
+
+    assert result == {"ok": True}
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["headers"]["authorization"] == "Bearer or-key"
+    assert captured["body"]["response_format"] == {"type": "json_object"}
+    assert captured["body"]["messages"][0] == {"role": "system", "content": "sys"}
+
+
+@pytest.mark.asyncio
+async def test_ollama_openai_request_shape(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["headers"] = request.headers
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": '{"ok": true}'}}]},
+        )
+
+    _patch_async_client(monkeypatch, handler)
+    client = OllamaClient(
+        _config(provider="ollama", mode="openai", ollama_key="ollama-key")
+    )
+
+    result = await client.complete("hello")
+
+    assert result == {"ok": True}
+    assert captured["url"] == "http://localhost:11434/v1/chat/completions"
+    assert captured["headers"]["authorization"] == "Bearer ollama-key"
+    assert captured["body"]["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.asyncio
+async def test_ollama_native_request_shape(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"message": {"content": '{"ok": true}'}},
+        )
+
+    _patch_async_client(monkeypatch, handler)
+    client = OllamaClient(
+        _config(provider="ollama", mode="native", base_url="https://ollama.com")
+    )
+
+    result = await client.complete("hello")
+
+    assert result == {"ok": True}
+    assert captured["url"] == "https://ollama.com/api/chat"
+    assert captured["body"]["stream"] is False
+    assert captured["body"]["format"] == "json"

--- a/tests/test_llm_providers/test_config.py
+++ b/tests/test_llm_providers/test_config.py
@@ -1,0 +1,106 @@
+import pytest
+
+from king_context.scraper.config import ConfigError
+from llm_providers.config import DEFAULT_MODEL, resolve
+
+
+def _clear(monkeypatch):
+    for name in [
+        "ENRICH_PROVIDER",
+        "ENRICH_MODEL",
+        "FILTER_PROVIDER",
+        "FILTER_MODEL",
+        "RESEARCH_PROVIDER",
+        "RESEARCH_MODEL",
+        "OPENROUTER_MODEL_RESEARCH",
+        "OPENROUTER_API_KEY",
+        "OLLAMA_API_MODE",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_API_KEY",
+        "ENABLE_FALLBACK",
+        "FALLBACK_MODEL",
+        "CONCURRENCY_OPENROUTER",
+        "CONCURRENCY_OLLAMA",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_default_openrouter_requires_key_when_validating(monkeypatch):
+    _clear(monkeypatch)
+
+    with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
+        resolve("enrich")
+
+
+def test_default_openrouter_without_validation(monkeypatch):
+    _clear(monkeypatch)
+
+    config = resolve("enrich", validate=False)
+
+    assert config.provider == "openrouter"
+    assert config.model == DEFAULT_MODEL
+
+
+def test_resolve_loads_project_env_file(monkeypatch, tmp_path):
+    _clear(monkeypatch)
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "ENRICH_PROVIDER=ollama",
+                "ENRICH_MODEL=qwen2.5:7b",
+                "CONCURRENCY_OLLAMA=1",
+            ]
+        )
+    )
+
+    config = resolve("enrich")
+
+    assert config.provider == "ollama"
+    assert config.model == "qwen2.5:7b"
+    assert config.concurrency == 1
+
+
+def test_stage_model_and_concurrency(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("ENRICH_PROVIDER", "ollama")
+    monkeypatch.setenv("ENRICH_MODEL", "qwen2.5:7b")
+    monkeypatch.setenv("CONCURRENCY_OLLAMA", "3")
+
+    config = resolve("enrich")
+
+    assert config.provider == "ollama"
+    assert config.model == "qwen2.5:7b"
+    assert config.concurrency == 3
+
+
+def test_research_legacy_model_alias(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("RESEARCH_PROVIDER", "ollama")
+    monkeypatch.setenv("OPENROUTER_MODEL_RESEARCH", "legacy-model")
+
+    config = resolve("research")
+
+    assert config.model == "legacy-model"
+
+
+def test_invalid_ollama_mode_only_fails_for_ollama(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "key")
+    monkeypatch.setenv("OLLAMA_API_MODE", "bad")
+
+    assert resolve("enrich").provider == "openrouter"
+
+    monkeypatch.setenv("ENRICH_PROVIDER", "ollama")
+    with pytest.raises(ConfigError, match="OLLAMA_API_MODE"):
+        resolve("enrich")
+
+
+def test_fallback_requires_openrouter_key_for_ollama(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("ENRICH_PROVIDER", "ollama")
+    monkeypatch.setenv("ENABLE_FALLBACK", "true")
+
+    with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
+        resolve("enrich")

--- a/tests/test_llm_providers/test_factory.py
+++ b/tests/test_llm_providers/test_factory.py
@@ -1,0 +1,18 @@
+from llm_providers import get_stage_clients
+from llm_providers.fallback import FallbackClient
+
+
+def test_factory_returns_ollama_with_schema_fallback(monkeypatch):
+    monkeypatch.delenv("OLLAMA_API_MODE", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.setenv("ENRICH_PROVIDER", "ollama")
+    monkeypatch.setenv("ENRICH_MODEL", "qwen2.5:7b")
+    monkeypatch.setenv("ENABLE_FALLBACK", "true")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+    clients = get_stage_clients("enrich")
+
+    assert isinstance(clients.primary, FallbackClient)
+    assert clients.primary.name == "ollama"
+    assert clients.schema_fallback is not None
+    assert clients.schema_fallback.name == "openrouter"

--- a/tests/test_llm_providers/test_factory.py
+++ b/tests/test_llm_providers/test_factory.py
@@ -16,3 +16,22 @@ def test_factory_returns_ollama_with_schema_fallback(monkeypatch):
     assert clients.primary.name == "ollama"
     assert clients.schema_fallback is not None
     assert clients.schema_fallback.name == "openrouter"
+
+
+def test_factory_uses_openrouter_concurrency_for_fallback(monkeypatch):
+    monkeypatch.delenv("OLLAMA_API_MODE", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.setenv("ENRICH_PROVIDER", "ollama")
+    monkeypatch.setenv("ENRICH_MODEL", "qwen2.5:7b")
+    monkeypatch.setenv("ENABLE_FALLBACK", "true")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.setenv("CONCURRENCY_OLLAMA", "4")
+    monkeypatch.setenv("CONCURRENCY_OPENROUTER", "1")
+
+    clients = get_stage_clients("enrich")
+
+    assert isinstance(clients.primary, FallbackClient)
+    assert clients.primary.concurrency == 4
+    assert clients.primary.fallback.concurrency == 1
+    assert clients.schema_fallback is not None
+    assert clients.schema_fallback.concurrency == 1

--- a/tests/test_llm_providers/test_fallback.py
+++ b/tests/test_llm_providers/test_fallback.py
@@ -1,0 +1,71 @@
+import pytest
+
+from conftest import FakeLLMClient
+from king_context.scraper.config import ConfigError
+from llm_providers.base import ProviderError
+from llm_providers.fallback import FallbackClient
+
+
+@pytest.mark.asyncio
+async def test_fallback_calls_openrouter_once(capsys):
+    primary = FakeLLMClient(
+        responses=[
+            ProviderError(
+                "connection_refused",
+                transient=True,
+                message="down",
+                provider="ollama",
+            )
+        ],
+        name="ollama",
+        model="qwen2.5:7b",
+    )
+    fallback = FakeLLMClient(
+        responses=[{"ok": True}],
+        name="openrouter",
+        model="google/gemini-3-flash-preview",
+    )
+    client = FallbackClient(primary=primary, fallback=fallback, stage="enrich")
+
+    result = await client.complete("hello")
+
+    assert result == {"ok": True}
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+    assert "reason: connection_refused" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_fallback_surfaces_both_errors():
+    primary_error = ProviderError(
+        "timeout",
+        transient=True,
+        message="timeout",
+        provider="ollama",
+    )
+    fallback_error = ProviderError(
+        "rate_limit",
+        transient=True,
+        message="limited",
+        provider="openrouter",
+    )
+    client = FallbackClient(
+        primary=FakeLLMClient(responses=[primary_error], name="ollama"),
+        fallback=FakeLLMClient(responses=[fallback_error], name="openrouter"),
+        stage="enrich",
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        await client.complete("hello")
+
+    assert exc.value.primary_error is primary_error
+    assert exc.value.fallback_error is fallback_error
+
+
+def test_rejects_reverse_fallback():
+    with pytest.raises(ConfigError):
+        FallbackClient(
+            primary=FakeLLMClient(name="openrouter"),
+            fallback=FakeLLMClient(name="ollama"),
+            stage="enrich",
+        )

--- a/tests/test_llm_providers/test_fallback.py
+++ b/tests/test_llm_providers/test_fallback.py
@@ -62,6 +62,34 @@ async def test_fallback_surfaces_both_errors():
     assert exc.value.fallback_error is fallback_error
 
 
+@pytest.mark.asyncio
+async def test_fallback_combined_error_uses_fallback_transience():
+    primary_error = ProviderError(
+        "timeout",
+        transient=True,
+        message="timeout",
+        provider="ollama",
+    )
+    fallback_error = ProviderError(
+        "auth_error",
+        transient=False,
+        message="unauthorized",
+        provider="openrouter",
+    )
+    client = FallbackClient(
+        primary=FakeLLMClient(responses=[primary_error], name="ollama"),
+        fallback=FakeLLMClient(responses=[fallback_error], name="openrouter"),
+        stage="enrich",
+    )
+
+    with pytest.raises(ProviderError) as exc:
+        await client.complete("hello")
+
+    assert exc.value.transient is False
+    assert exc.value.primary_error is primary_error
+    assert exc.value.fallback_error is fallback_error
+
+
 def test_rejects_reverse_fallback():
     with pytest.raises(ConfigError):
         FallbackClient(

--- a/tests/test_llm_providers/test_parser.py
+++ b/tests/test_llm_providers/test_parser.py
@@ -1,0 +1,34 @@
+import pytest
+
+from llm_providers.base import ProviderError
+from llm_providers.parser import parse_json_object
+
+
+def test_parse_clean_object():
+    assert parse_json_object('{"ok": true}') == {"ok": True}
+
+
+def test_parse_existing_dict():
+    assert parse_json_object({"ok": True}) == {"ok": True}
+
+
+def test_parse_fenced_object():
+    assert parse_json_object('```json\n{"ok": true}\n```') == {"ok": True}
+
+
+def test_parse_prose_wrapped_object():
+    assert parse_json_object('Here is it:\n{"ok": true}\nthanks') == {"ok": True}
+
+
+def test_parse_repairs_trailing_commas():
+    assert parse_json_object('{"items": [1, 2,], "ok": true,}') == {
+        "items": [1, 2],
+        "ok": True,
+    }
+
+
+def test_parse_malformed_raises_provider_error():
+    with pytest.raises(ProviderError) as exc:
+        parse_json_object("not json {")
+
+    assert exc.value.reason == "invalid_response"

--- a/tests/test_llm_providers/test_registry.py
+++ b/tests/test_llm_providers/test_registry.py
@@ -1,0 +1,33 @@
+import pytest
+
+from king_context.scraper.config import ConfigError
+from llm_providers.base import LLMClient
+from llm_providers.config import resolve
+from llm_providers.registry import create_client, get_provider_class, register_provider
+
+
+class StubClient(LLMClient):
+    name = "stub"
+    model = "stub-model"
+    concurrency = 1
+
+    def __init__(self, config):
+        self.config = config
+
+    async def complete(self, prompt, *, system=None, json_mode=True):
+        return {"ok": True}
+
+
+def test_register_and_create_stub_provider(monkeypatch):
+    register_provider("stub", StubClient)
+    monkeypatch.setenv("ENRICH_PROVIDER", "stub")
+
+    config = resolve("enrich", validate=False)
+    client = create_client(config)
+
+    assert isinstance(client, StubClient)
+
+
+def test_unknown_provider_class_raises():
+    with pytest.raises(ConfigError):
+        get_provider_class("missing")

--- a/tests/test_research/test_config.py
+++ b/tests/test_research/test_config.py
@@ -18,7 +18,11 @@ def _set_base_env(monkeypatch):
 
 def _clear_research_env(monkeypatch):
     for name in [
+        "FIRECRAWL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "EXA_API_KEY",
         "JINA_API_KEY",
+        "RESEARCH_MODEL",
         "OPENROUTER_MODEL_RESEARCH",
         "RESEARCH_BASIC_QUERIES",
         "RESEARCH_MEDIUM_QUERIES",
@@ -71,6 +75,29 @@ def test_env_override_applies(monkeypatch):
     config = load_research_config()
 
     assert config.high_queries == 20
+
+
+def test_load_research_config_loads_project_env(monkeypatch, tmp_path):
+    _clear_research_env(monkeypatch)
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "FIRECRAWL_API_KEY=fc-file",
+                "OPENROUTER_API_KEY=or-file",
+                "EXA_API_KEY=exa-file",
+                "RESEARCH_MODEL=qwen2.5:7b",
+            ]
+        )
+    )
+
+    config = load_research_config()
+
+    assert config.scraper.firecrawl_api_key == "fc-file"
+    assert config.scraper.openrouter_api_key == "or-file"
+    assert config.exa_api_key == "exa-file"
+    assert config.research_model == "qwen2.5:7b"
 
 
 def test_missing_exa_key_raises(monkeypatch):

--- a/tests/test_research/test_integration.py
+++ b/tests/test_research/test_integration.py
@@ -1,6 +1,6 @@
 """End-to-end integration test for the research pipeline.
 
-All externals (Exa SDK, Jina httpx, OpenRouter httpx) are mocked. The pipeline,
+All externals (Exa SDK, query LLM, enrichment LLM) are mocked. The pipeline,
 chunk, enrich, export, and indexing code paths run for real so we exercise the
 wiring between components.
 """
@@ -10,18 +10,13 @@ import json
 from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
-import respx
-
+from conftest import FakeLLMClient, fake_stage_clients
 from king_context.research.config import EffortLevel, ResearchConfig
 from king_context.research.pipeline import run_pipeline
 from king_context.scraper.config import ScraperConfig
 from context_cli.indexer import index_doc
-
-
-skip_no_respx = pytest.mark.skipif(False, reason="")
 
 
 # ---------------------------------------------------------------------------
@@ -75,46 +70,13 @@ def _make_exa_response(query: str, num_results: int) -> MagicMock:
     return resp
 
 
-def _make_enrichment_response() -> httpx.Response:
-    payload = {
+def _make_enrichment_payload() -> dict:
+    return {
         "keywords": ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"],
         "use_cases": ["Use when testing", "Implement when integrating"],
         "tags": ["research"],
         "priority": 7,
     }
-    return httpx.Response(
-        200,
-        json={
-            "choices": [{"message": {"content": json.dumps(payload)}}]
-        },
-    )
-
-
-def _make_queries_response(queries: list[str]) -> httpx.Response:
-    return httpx.Response(
-        200,
-        json={
-            "choices": [
-                {"message": {"content": json.dumps({"queries": queries})}}
-            ]
-        },
-    )
-
-
-def _is_enrichment_request(body: dict) -> bool:
-    """Enrichment uses a single user message; queries uses system+user.
-    Detect by looking for the enrichment prompt's distinctive preamble.
-    """
-    messages = body.get("messages", [])
-    # Enrichment payload is one user message with the ENRICHMENT_PROMPT text.
-    for msg in messages:
-        content = msg.get("content", "")
-        if isinstance(content, str) and (
-            "documentation metadata specialist" in content
-            or "Documentation section:" in content
-        ):
-            return True
-    return False
 
 
 def _make_config(**overrides) -> ResearchConfig:
@@ -161,8 +123,6 @@ def _make_args(
 # ---------------------------------------------------------------------------
 
 
-@skip_no_respx
-@respx.mock
 async def test_basic_effort_end_to_end(tmp_path, monkeypatch):
     """Happy path: BASIC effort with all externals mocked.
 
@@ -177,22 +137,20 @@ async def test_basic_effort_end_to_end(tmp_path, monkeypatch):
         tmp_path / "data" / "research",
     )
 
-    # ---- Mock OpenRouter ----
-    def openrouter_handler(request):
-        body = json.loads(request.content)
-        if _is_enrichment_request(body):
-            return _make_enrichment_response()
-        return _make_queries_response(["query a", "query b", "query c"])
-
-    respx.post("https://openrouter.ai/api/v1/chat/completions").mock(
-        side_effect=openrouter_handler
+    query_client = FakeLLMClient(responses=[{"queries": ["query a", "query b", "query c"]}])
+    enrich_client = FakeLLMClient(
+        responses=[_make_enrichment_payload() for _ in range(100)]
     )
-
-    # ---- Mock Exa ----
     def fake_search_and_contents(**kwargs):
         return _make_exa_response(kwargs["query"], num_results=3)
 
-    with patch("king_context.research.exa.Exa") as mock_exa_cls:
+    with patch(
+        "king_context.research.queries.get_client",
+        return_value=query_client,
+    ), patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(enrich_client),
+    ), patch("king_context.research.exa.Exa") as mock_exa_cls:
         mock_exa_cls.return_value.search_and_contents.side_effect = (
             fake_search_and_contents
         )
@@ -244,8 +202,6 @@ async def test_basic_effort_end_to_end(tmp_path, monkeypatch):
     assert any(h.doc_name == "prompt-engineering" for h in hits)
 
 
-@skip_no_respx
-@respx.mock
 async def test_medium_effort_iteration_sources_present(tmp_path, monkeypatch):
     """MEDIUM effort: verify the deepening loop ran by checking for sections
     from both iteration 0 and iteration 1.
@@ -258,29 +214,27 @@ async def test_medium_effort_iteration_sources_present(tmp_path, monkeypatch):
         tmp_path / "data" / "research",
     )
 
-    call_count = [0]
-
-    def openrouter_handler(request):
-        body = json.loads(request.content)
-        if _is_enrichment_request(body):
-            return _make_enrichment_response()
-
-        call_count[0] += 1
-        if call_count[0] == 1:
-            qs = ["init a", "init b", "init c", "init d", "init e"]
-        else:
-            qs = ["followup a", "followup b", "followup c"]
-        return _make_queries_response(qs)
-
-    respx.post("https://openrouter.ai/api/v1/chat/completions").mock(
-        side_effect=openrouter_handler
+    query_client = FakeLLMClient(
+        responses=[
+            {"queries": ["init a", "init b", "init c", "init d", "init e"]},
+            {"queries": ["followup a", "followup b", "followup c"]},
+        ]
+    )
+    enrich_client = FakeLLMClient(
+        responses=[_make_enrichment_payload() for _ in range(200)]
     )
 
     def fake_search_and_contents(**kwargs):
         # Two results per query for a tighter medium run.
         return _make_exa_response(kwargs["query"], num_results=2)
 
-    with patch("king_context.research.exa.Exa") as mock_exa_cls:
+    with patch(
+        "king_context.research.queries.get_client",
+        return_value=query_client,
+    ), patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(enrich_client),
+    ), patch("king_context.research.exa.Exa") as mock_exa_cls:
         mock_exa_cls.return_value.search_and_contents.side_effect = (
             fake_search_and_contents
         )

--- a/tests/test_research/test_pipeline.py
+++ b/tests/test_research/test_pipeline.py
@@ -172,7 +172,7 @@ async def test_missing_exa_key_fails_fast(tmp_path, monkeypatch):
     export_mock.assert_not_called()
 
 
-async def test_missing_openrouter_key_fails_fast(tmp_path, monkeypatch):
+async def test_missing_openrouter_key_not_validated_at_pipeline_start(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "king_context.research.pipeline.TEMP_DOCS_DIR", tmp_path
     )
@@ -185,11 +185,12 @@ async def test_missing_openrouter_key_fails_fast(tmp_path, monkeypatch):
     with patch(
         "king_context.research.pipeline.run_deepening_loop",
         new_callable=AsyncMock,
+        return_value=[],
     ) as deepen_mock:
-        with pytest.raises(ConfigError, match="OPENROUTER_API_KEY"):
+        with pytest.raises(RuntimeError, match="No sources"):
             await run_pipeline(make_args(), config)
 
-    deepen_mock.assert_not_called()
+    deepen_mock.assert_awaited_once()
 
 
 async def test_zero_sources_raises_user_friendly_error(tmp_path, monkeypatch):

--- a/tests/test_research/test_queries.py
+++ b/tests/test_research/test_queries.py
@@ -44,6 +44,24 @@ async def test_initial_generation_returns_requested_count(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_research_generation_does_not_use_enrichment_model(monkeypatch):
+    client = FakeLLMClient(responses=[{"queries": ["q1"]}])
+    calls = []
+
+    def fake_get_client(*args, **kwargs):
+        calls.append((args, kwargs))
+        return client
+
+    monkeypatch.setattr("king_context.research.queries.get_client", fake_get_client)
+
+    result = await generate_queries("semantic search", 1, make_config())
+
+    assert result == ["q1"]
+    assert calls[0][0] == ("research",)
+    assert calls[0][1]["model_override"] is None
+
+
+@pytest.mark.asyncio
 async def test_followup_dedupes_against_previous_queries(monkeypatch):
     client = FakeLLMClient(
         responses=[{"queries": ["new angle A", "Semantic Search Basics.", "new angle B"]}]

--- a/tests/test_research/test_queries.py
+++ b/tests/test_research/test_queries.py
@@ -1,21 +1,19 @@
 import json
 
-import httpx
 import pytest
-import respx
 
+from conftest import FakeLLMClient
 from king_context.research.config import ResearchConfig
 from king_context.research.queries import (
     QueryGenerationError,
     SourceSummary,
     _RETRY_DELAYS,
+    _extract_queries,
     _normalize,
     generate_queries,
 )
 from king_context.scraper.config import ScraperConfig
-
-
-OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+from llm_providers.base import ProviderError
 
 
 def make_config() -> ResearchConfig:
@@ -28,51 +26,35 @@ def make_config() -> ResearchConfig:
     )
 
 
-def openrouter_payload(queries: list[str]) -> dict:
-    return {
-        "choices": [
-            {"message": {"content": json.dumps({"queries": queries})}}
-        ]
-    }
-
-
-def openrouter_raw(content: str) -> dict:
-    return {"choices": [{"message": {"content": content}}]}
+def _patch_client(monkeypatch, client: FakeLLMClient) -> None:
+    monkeypatch.setattr(
+        "king_context.research.queries.get_client",
+        lambda *args, **kwargs: client,
+    )
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_initial_generation_returns_requested_count():
-    config = make_config()
-    respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(
-            200, json=openrouter_payload(["q1", "q2", "q3"])
-        )
-    )
+async def test_initial_generation_returns_requested_count(monkeypatch):
+    client = FakeLLMClient(responses=[{"queries": ["q1", "q2", "q3"]}])
+    _patch_client(monkeypatch, client)
 
-    result = await generate_queries("semantic search", 3, config)
+    result = await generate_queries("semantic search", 3, make_config())
 
     assert result == ["q1", "q2", "q3"]
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_followup_dedupes_against_previous_queries():
-    config = make_config()
-    respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json=openrouter_payload(
-                ["new angle A", "Semantic Search Basics.", "new angle B"]
-            ),
-        )
+async def test_followup_dedupes_against_previous_queries(monkeypatch):
+    client = FakeLLMClient(
+        responses=[{"queries": ["new angle A", "Semantic Search Basics.", "new angle B"]}]
     )
+    _patch_client(monkeypatch, client)
 
     previous = ["semantic search basics"]
     result = await generate_queries(
         "semantic search",
         5,
-        config,
+        make_config(),
         previous_queries=previous,
     )
 
@@ -84,117 +66,94 @@ async def test_followup_dedupes_against_previous_queries():
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_malformed_llm_output_raises():
-    config = make_config()
-    respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(200, json=openrouter_raw("not-json {"))
-    )
+async def test_malformed_llm_output_raises(monkeypatch):
+    client = FakeLLMClient(responses=[{"not_queries": ["x"]}])
+    _patch_client(monkeypatch, client)
 
     with pytest.raises(QueryGenerationError):
-        await generate_queries("topic", 3, config)
+        await generate_queries("topic", 3, make_config())
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_retries_on_429_then_succeeds(monkeypatch):
+async def test_retries_on_transient_provider_error_then_succeeds(monkeypatch):
     monkeypatch.setattr(
         "king_context.research.queries._RETRY_DELAYS", [0.0, 0.0]
     )
-    config = make_config()
-
-    route = respx.post(OPENROUTER_URL).mock(
-        side_effect=[
-            httpx.Response(429, json={"error": "rate limited"}),
-            httpx.Response(200, json=openrouter_payload(["a", "b"])),
+    client = FakeLLMClient(
+        responses=[
+            ProviderError(
+                "rate_limit",
+                transient=True,
+                message="limited",
+                provider="openrouter",
+            ),
+            {"queries": ["a", "b"]},
         ]
     )
+    _patch_client(monkeypatch, client)
 
-    result = await generate_queries("topic", 2, config)
+    result = await generate_queries("topic", 2, make_config())
 
     assert result == ["a", "b"]
-    assert route.call_count == 2
+    assert len(client.calls) == 2
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_fails_fast_on_401():
-    config = make_config()
-    route = respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(401, json={"error": "unauthorized"})
+async def test_fails_fast_on_non_transient_provider_error(monkeypatch):
+    client = FakeLLMClient(
+        responses=[
+            ProviderError(
+                "auth_error",
+                transient=False,
+                message="unauthorized",
+                provider="openrouter",
+            )
+        ]
     )
+    _patch_client(monkeypatch, client)
 
     with pytest.raises(QueryGenerationError):
-        await generate_queries("topic", 3, config)
+        await generate_queries("topic", 3, make_config())
 
-    assert route.call_count == 1
+    assert len(client.calls) == 1
 
 
-@pytest.mark.asyncio
-@respx.mock
-async def test_handles_markdown_wrapped_json():
-    config = make_config()
+def test_handles_markdown_wrapped_json():
     wrapped = "```json\n" + json.dumps({"queries": ["x", "y"]}) + "\n```"
-    respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(200, json=openrouter_raw(wrapped))
-    )
 
-    result = await generate_queries("topic", 2, config)
+    result = _extract_queries(wrapped)
 
     assert result == ["x", "y"]
 
 
-@pytest.mark.asyncio
-@respx.mock
-async def test_bare_list_response_accepted():
-    config = make_config()
-    respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(
-            200, json=openrouter_raw(json.dumps(["only", "list"]))
-        )
-    )
-
-    result = await generate_queries("topic", 5, config)
-
-    assert result == ["only", "list"]
+def test_bare_list_response_accepted_by_extractor():
+    assert _extract_queries(json.dumps(["only", "list"])) == ["only", "list"]
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_caps_returned_list_to_count():
-    config = make_config()
-    respx.post(OPENROUTER_URL).mock(
-        return_value=httpx.Response(
-            200, json=openrouter_payload(["a", "b", "c", "d", "e"])
-        )
-    )
+async def test_caps_returned_list_to_count(monkeypatch):
+    client = FakeLLMClient(responses=[{"queries": ["a", "b", "c", "d", "e"]}])
+    _patch_client(monkeypatch, client)
 
-    result = await generate_queries("topic", 2, config)
+    result = await generate_queries("topic", 2, make_config())
 
     assert result == ["a", "b"]
 
 
 @pytest.mark.asyncio
-@respx.mock
-async def test_previous_results_included_in_prompt():
-    config = make_config()
-    captured: dict = {}
-
-    def capture(request):
-        captured["body"] = json.loads(request.content)
-        return httpx.Response(200, json=openrouter_payload(["followup1"]))
-
-    respx.post(OPENROUTER_URL).mock(side_effect=capture)
+async def test_previous_results_included_in_prompt(monkeypatch):
+    client = FakeLLMClient(responses=[{"queries": ["followup1"]}])
+    _patch_client(monkeypatch, client)
 
     summaries = [
         SourceSummary(title="Paper A", top_highlight="Key insight about X"),
     ]
     result = await generate_queries(
-        "topic", 1, config, previous_results=summaries
+        "topic", 1, make_config(), previous_results=summaries
     )
 
     assert result == ["followup1"]
-    user_msg = captured["body"]["messages"][-1]["content"]
+    user_msg = client.calls[0]["prompt"]
     assert "Paper A" in user_msg
     assert "Key insight about X" in user_msg
 

--- a/tests/test_scraper/test_cli.py
+++ b/tests/test_scraper/test_cli.py
@@ -99,7 +99,7 @@ def test_cli_parse_args_basic():
     assert args.url == "https://docs.stripe.com"
     assert args.name is None
     assert args.step is None
-    assert args.model == "google/gemini-3-flash-preview"
+    assert args.model is None
     assert args.chunk_max_tokens == 800
     assert args.chunk_min_tokens == 50
     assert args.concurrency == 5

--- a/tests/test_scraper/test_config.py
+++ b/tests/test_scraper/test_config.py
@@ -1,11 +1,11 @@
 import pytest
+from king_context.env import load_project_env
 from king_context.scraper.config import (
     ScraperConfig,
     load_config,
     ConfigError,
     get_firecrawl_key,
     get_openrouter_key,
-    _load_env_files,
 )
 
 
@@ -55,31 +55,34 @@ def test_config_defaults():
 
 
 def test_load_env_files_only_root_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
     monkeypatch.delenv("KING_TEST_ROOT_ONLY", raising=False)
     monkeypatch.delenv("KING_TEST_INSTALLER_ONLY", raising=False)
 
     (tmp_path / ".env").write_text("KING_TEST_ROOT_ONLY=root-value\n")
 
-    _load_env_files(project_root=tmp_path)
+    load_project_env(project_root=tmp_path)
 
     import os
     assert os.environ.get("KING_TEST_ROOT_ONLY") == "root-value"
 
 
 def test_load_env_files_only_installer_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
     monkeypatch.delenv("KING_TEST_INSTALLER_VAR", raising=False)
 
     installer_dir = tmp_path / ".king-context"
     installer_dir.mkdir()
     (installer_dir / ".env").write_text("KING_TEST_INSTALLER_VAR=installer-value\n")
 
-    _load_env_files(project_root=tmp_path)
+    load_project_env(project_root=tmp_path)
 
     import os
     assert os.environ.get("KING_TEST_INSTALLER_VAR") == "installer-value"
 
 
 def test_load_env_files_root_overrides_installer(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
     monkeypatch.delenv("KING_TEST_SHARED_VAR", raising=False)
 
     installer_dir = tmp_path / ".king-context"
@@ -87,16 +90,17 @@ def test_load_env_files_root_overrides_installer(tmp_path, monkeypatch):
     (installer_dir / ".env").write_text("KING_TEST_SHARED_VAR=installer-value\n")
     (tmp_path / ".env").write_text("KING_TEST_SHARED_VAR=root-value\n")
 
-    _load_env_files(project_root=tmp_path)
+    load_project_env(project_root=tmp_path)
 
     import os
     assert os.environ.get("KING_TEST_SHARED_VAR") == "root-value"
 
 
 def test_load_env_files_neither_exists(tmp_path, monkeypatch):
+    monkeypatch.delenv("KING_CONTEXT_DISABLE_DOTENV", raising=False)
     monkeypatch.delenv("KING_TEST_NEITHER_VAR", raising=False)
 
-    _load_env_files(project_root=tmp_path)
+    load_project_env(project_root=tmp_path)
 
     import os
     assert os.environ.get("KING_TEST_NEITHER_VAR") is None

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -1,6 +1,7 @@
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
+from conftest import FakeLLMClient, fake_stage_clients
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.enrich import (
@@ -40,12 +41,16 @@ def test_enrich_batch_processing():
 
     call_count = 0
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         nonlocal call_count
         call_count += 1
         return make_valid_enrichment()
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = asyncio.run(enrich_chunks(chunks, config))
 
     assert len(result) == 12
@@ -86,13 +91,17 @@ def test_enrich_retry_on_validation_fail():
     }
     valid = make_valid_enrichment()
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         attempt["count"] += 1
         if attempt["count"] == 1:
             return invalid
         return valid
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = asyncio.run(enrich_chunks([chunk], config))
 
     assert len(result) == 1

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -1,6 +1,8 @@
 import asyncio
 from unittest.mock import patch
 
+import pytest
+
 from conftest import FakeLLMClient, fake_stage_clients
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
@@ -10,6 +12,8 @@ from king_context.scraper.enrich import (
     estimate_cost,
     validate_enrichment,
 )
+from llm_providers.base import ProviderError
+from llm_providers.fallback import FallbackClient
 
 
 def make_chunk(title: str = "Test Section", content: str = "Some content here.") -> Chunk:
@@ -107,6 +111,41 @@ def test_enrich_retry_on_validation_fail():
     assert len(result) == 1
     assert attempt["count"] == 2  # failed once, succeeded on retry
     assert len(result[0].keywords) == 5
+
+
+def test_enrich_surfaces_provider_error_from_fallback_client():
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+    primary_error = ProviderError(
+        "timeout",
+        transient=True,
+        message="timeout",
+        provider="ollama",
+    )
+    fallback_error = ProviderError(
+        "rate_limit",
+        transient=True,
+        message="limited",
+        provider="openrouter",
+    )
+    client = FallbackClient(
+        primary=FakeLLMClient(responses=[primary_error], name="ollama"),
+        fallback=FakeLLMClient(responses=[fallback_error], name="openrouter"),
+        stage="enrich",
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
+        with pytest.raises(ProviderError) as exc:
+            asyncio.run(enrich_chunks([chunk], config))
+
+    assert exc.value.primary_error is primary_error
+    assert exc.value.fallback_error is fallback_error
 
 
 def test_estimate_cost():

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -113,27 +113,136 @@ def test_enrich_retry_on_validation_fail():
     assert len(result[0].keywords) == 5
 
 
+def test_enrich_retries_transient_provider_error():
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+    provider_error = ProviderError(
+        "timeout",
+        transient=True,
+        message="timeout",
+        provider="openrouter",
+    )
+    client = FakeLLMClient(responses=[provider_error, make_valid_enrichment()])
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
+        result = asyncio.run(enrich_chunks([chunk], config))
+
+    assert len(result) == 1
+    assert len(client.calls) == 2
+
+
+def test_enrich_raises_transient_provider_error_after_retries():
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+    provider_errors = [
+        ProviderError(
+            "timeout",
+            transient=True,
+            message="timeout",
+            provider="openrouter",
+        )
+        for _ in range(3)
+    ]
+    client = FakeLLMClient(responses=provider_errors)
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
+        with pytest.raises(ProviderError):
+            asyncio.run(enrich_chunks([chunk], config))
+
+    assert len(client.calls) == 3
+
+
+def test_enrich_respects_fallback_provider_concurrency():
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=3,
+    )
+    chunks = [make_chunk(f"Section {i}") for i in range(3)]
+    in_flight = 0
+    max_in_flight = 0
+
+    async def fail_primary(prompt, *, system=None, json_mode=True):
+        raise ProviderError(
+            "timeout",
+            transient=True,
+            message="timeout",
+            provider="ollama",
+        )
+
+    async def fallback_complete(prompt, *, system=None, json_mode=True):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            await asyncio.sleep(0.01)
+            return make_valid_enrichment()
+        finally:
+            in_flight -= 1
+
+    fallback = FakeLLMClient(
+        name="openrouter",
+        concurrency=1,
+        side_effect=fallback_complete,
+    )
+    client = FallbackClient(
+        primary=FakeLLMClient(
+            name="ollama",
+            concurrency=3,
+            side_effect=fail_primary,
+        ),
+        fallback=fallback,
+        stage="enrich",
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client, fallback),
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    assert len(result) == 3
+    assert max_in_flight == 1
+
+
 def test_enrich_surfaces_provider_error_from_fallback_client():
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
     )
     chunk = make_chunk("Auth Section")
-    primary_error = ProviderError(
-        "timeout",
-        transient=True,
-        message="timeout",
-        provider="ollama",
-    )
-    fallback_error = ProviderError(
-        "rate_limit",
-        transient=True,
-        message="limited",
-        provider="openrouter",
-    )
+    primary_errors = [
+        ProviderError(
+            "timeout",
+            transient=True,
+            message="timeout",
+            provider="ollama",
+        )
+        for _ in range(3)
+    ]
+    fallback_errors = [
+        ProviderError(
+            "rate_limit",
+            transient=True,
+            message="limited",
+            provider="openrouter",
+        )
+        for _ in range(3)
+    ]
     client = FallbackClient(
-        primary=FakeLLMClient(responses=[primary_error], name="ollama"),
-        fallback=FakeLLMClient(responses=[fallback_error], name="openrouter"),
+        primary=FakeLLMClient(responses=primary_errors, name="ollama"),
+        fallback=FakeLLMClient(responses=fallback_errors, name="openrouter"),
         stage="enrich",
     )
 
@@ -144,8 +253,8 @@ def test_enrich_surfaces_provider_error_from_fallback_client():
         with pytest.raises(ProviderError) as exc:
             asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.primary_error is primary_error
-    assert exc.value.fallback_error is fallback_error
+    assert exc.value.primary_error is primary_errors[-1]
+    assert exc.value.fallback_error is fallback_errors[-1]
 
 
 def test_estimate_cost():

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -257,6 +257,44 @@ def test_enrich_surfaces_provider_error_from_fallback_client():
     assert exc.value.fallback_error is fallback_errors[-1]
 
 
+def test_enrich_does_not_retry_non_transient_fallback_error():
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+    primary_error = ProviderError(
+        "timeout",
+        transient=True,
+        message="timeout",
+        provider="ollama",
+    )
+    fallback_error = ProviderError(
+        "auth_error",
+        transient=False,
+        message="unauthorized",
+        provider="openrouter",
+    )
+    primary = FakeLLMClient(responses=[primary_error], name="ollama")
+    fallback = FakeLLMClient(responses=[fallback_error], name="openrouter")
+    client = FallbackClient(
+        primary=primary,
+        fallback=fallback,
+        stage="enrich",
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client, fallback),
+    ):
+        with pytest.raises(ProviderError) as exc:
+            asyncio.run(enrich_chunks([chunk], config))
+
+    assert exc.value.transient is False
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+
+
 def test_estimate_cost():
     config = ScraperConfig(
         enrichment_model="openai/gpt-4o-mini",

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -295,6 +295,34 @@ def test_enrich_does_not_retry_non_transient_fallback_error():
     assert len(fallback.calls) == 1
 
 
+def test_enrich_raises_when_schema_fallback_returns_invalid_metadata():
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+    invalid = {
+        "keywords": ["one"],
+        "use_cases": ["Use when needed", "Configure when required"],
+        "tags": ["auth"],
+        "priority": 7,
+    }
+    primary = FakeLLMClient(responses=[invalid, invalid, invalid], name="ollama")
+    fallback = FakeLLMClient(responses=[invalid], name="openrouter")
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(primary, fallback),
+    ):
+        with pytest.raises(ProviderError) as exc:
+            asyncio.run(enrich_chunks([chunk], config))
+
+    assert exc.value.reason == "validation_failed_3x"
+    assert exc.value.provider == "openrouter"
+    assert len(primary.calls) == 3
+    assert len(fallback.calls) == 1
+
+
 def test_estimate_cost():
     config = ScraperConfig(
         enrichment_model="openai/gpt-4o-mini",

--- a/tests/test_scraper/test_filter.py
+++ b/tests/test_scraper/test_filter.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
+import pytest
+
+from king_context.errors import ConfigError
 from king_context.scraper.filter import filter_urls, FilterResult
 from king_context.scraper.config import ScraperConfig
+from llm_providers import ProviderError
 
 
 def _api_urls(n: int = 15) -> list[str]:
@@ -73,6 +77,38 @@ def test_filter_llm_fallback_disabled(tmp_path, monkeypatch):
 
     mock_llm.assert_not_called()
     assert result.llm_fallback_used is False
+
+
+def test_filter_llm_fallback_surfaces_config_error(tmp_path, monkeypatch):
+    monkeypatch.setattr("king_context.scraper.discover.TEMP_DOCS_DIR", tmp_path)
+    config = ScraperConfig(filter_llm_fallback=True)
+    urls = ["https://docs.example.com/misc/page-1"]
+
+    with patch(
+        "king_context.scraper.filter._call_llm",
+        side_effect=ConfigError("FILTER_PROVIDER is invalid"),
+    ):
+        with pytest.raises(ConfigError, match="FILTER_PROVIDER"):
+            filter_urls(urls, "https://docs.example.com", config)
+
+
+def test_filter_llm_fallback_surfaces_provider_error(tmp_path, monkeypatch):
+    monkeypatch.setattr("king_context.scraper.discover.TEMP_DOCS_DIR", tmp_path)
+    config = ScraperConfig(filter_llm_fallback=True)
+    urls = ["https://docs.example.com/misc/page-1"]
+    provider_error = ProviderError(
+        "http_error",
+        transient=True,
+        message="Ollama request failed",
+        provider="ollama",
+    )
+
+    with patch(
+        "king_context.scraper.filter._call_llm",
+        side_effect=provider_error,
+    ):
+        with pytest.raises(ProviderError, match="Ollama request failed"):
+            filter_urls(urls, "https://docs.example.com", config)
 
 
 def test_filter_removes_duplicates(tmp_path, monkeypatch):

--- a/tests/test_scraper_enrich_resume.py
+++ b/tests/test_scraper_enrich_resume.py
@@ -1,15 +1,15 @@
 """Tests for enrich_chunks() resume support."""
 
-import asyncio
 import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from conftest import FakeLLMClient, fake_stage_clients
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
-from king_context.scraper.enrich import EnrichedChunk, enrich_chunks
+from king_context.scraper.enrich import enrich_chunks
 
 
 def _make_chunk(index: int) -> Chunk:
@@ -72,12 +72,16 @@ async def test_partial_resume(tmp_path: Path):
 
     call_count = 0
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         nonlocal call_count
         call_count += 1
         return VALID_ENRICHMENT
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
     # Should have called the API only for the remaining 30 chunks
@@ -108,12 +112,16 @@ async def test_full_resume_no_api_calls(tmp_path: Path):
 
     call_count = 0
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         nonlocal call_count
         call_count += 1
         return VALID_ENRICHMENT
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
     assert call_count == 0
@@ -135,12 +143,16 @@ async def test_fresh_start_no_existing_batches(tmp_path: Path):
 
     call_count = 0
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         nonlocal call_count
         call_count += 1
         return VALID_ENRICHMENT
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
     assert call_count == 15
@@ -179,10 +191,14 @@ async def test_batch_numbering_continues(tmp_path: Path):
         enrichment_batch_size=5,  # 10 remaining / 5 = 2 new batches
     )
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         return VALID_ENRICHMENT
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
     assert len(result) == total
@@ -222,10 +238,14 @@ async def test_new_batches_are_cumulative(tmp_path: Path):
         enrichment_batch_size=3,
     )
 
-    async def mock_openrouter(prompt, cfg):
+    async def mock_complete(prompt, *, system=None, json_mode=True):
         return VALID_ENRICHMENT
 
-    with patch("king_context.scraper.enrich.call_openrouter", side_effect=mock_openrouter):
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
         result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
     batch_files = sorted(enriched_dir.glob("batch_*.json"))

--- a/tests/test_scraper_manifest.py
+++ b/tests/test_scraper_manifest.py
@@ -5,10 +5,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from conftest import FakeLLMClient, fake_stage_clients
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.fetch import FetchResult, PageResult, fetch_pages
-from king_context.scraper.enrich import enrich_chunks, EnrichedChunk
+from king_context.scraper.enrich import enrich_chunks
 
 
 def _make_config() -> ScraperConfig:
@@ -117,10 +118,10 @@ class TestEnrichManifestProgress:
             "priority": 5,
         }
 
+        client = FakeLLMClient(responses=[enrichment] * len(chunks))
         with patch(
-            "king_context.scraper.enrich.call_openrouter",
-            new_callable=AsyncMock,
-            return_value=enrichment,
+            "king_context.scraper.enrich.get_stage_clients",
+            return_value=fake_stage_clients(client),
         ):
             result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
@@ -145,10 +146,10 @@ class TestEnrichManifestProgress:
             "priority": 5,
         }
 
+        client = FakeLLMClient(responses=[enrichment])
         with patch(
-            "king_context.scraper.enrich.call_openrouter",
-            new_callable=AsyncMock,
-            return_value=enrichment,
+            "king_context.scraper.enrich.get_stage_clients",
+            return_value=fake_stage_clients(client),
         ):
             result = await enrich_chunks(chunks, config, output_dir=tmp_path)
 
@@ -181,10 +182,10 @@ class TestEnrichManifestProgress:
             "priority": 5,
         }
 
+        client = FakeLLMClient(responses=[enrichment] * len(chunks))
         with patch(
-            "king_context.scraper.enrich.call_openrouter",
-            new_callable=AsyncMock,
-            return_value=enrichment,
+            "king_context.scraper.enrich.get_stage_clients",
+            return_value=fake_stage_clients(client),
         ), patch(
             "king_context.scraper.enrich._update_step",
             side_effect=_capture_update,

--- a/tests/test_scraper_resume_integration.py
+++ b/tests/test_scraper_resume_integration.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from conftest import FakeLLMClient, fake_stage_clients
 from king_context.scraper.chunk import Chunk
 from king_context.scraper.cli import run_pipeline
 from king_context.scraper.config import ScraperConfig
@@ -211,7 +212,7 @@ class TestEnrichResumeIntegration:
 
         api_call_count = 0
 
-        async def mock_call_openrouter(prompt, config):
+        async def mock_complete(prompt, *, system=None, json_mode=True):
             nonlocal api_call_count
             api_call_count += 1
             return {
@@ -221,9 +222,10 @@ class TestEnrichResumeIntegration:
                 "priority": 5,
             }
 
+        client = FakeLLMClient(side_effect=mock_complete)
         with patch(
-            "king_context.scraper.enrich.call_openrouter",
-            side_effect=mock_call_openrouter,
+            "king_context.scraper.enrich.get_stage_clients",
+            return_value=fake_stage_clients(client),
         ):
             args = _make_args(stop_after="enrich", yes=True)
             await run_pipeline(args, _make_config())
@@ -261,7 +263,7 @@ class TestFullPipelineResumeIntegration:
             total_chunks=total_chunks, enriched_chunks=already_enriched,
         )
 
-        async def mock_call_openrouter(prompt, config):
+        async def mock_complete(prompt, *, system=None, json_mode=True):
             return {
                 "keywords": [f"kw{j}" for j in range(5)],
                 "use_cases": [f"Use when {j}" for j in range(2)],
@@ -269,9 +271,10 @@ class TestFullPipelineResumeIntegration:
                 "priority": 5,
             }
 
+        client = FakeLLMClient(side_effect=mock_complete)
         with patch(
-            "king_context.scraper.enrich.call_openrouter",
-            side_effect=mock_call_openrouter,
+            "king_context.scraper.enrich.get_stage_clients",
+            return_value=fake_stage_clients(client),
         ), patch(
             "king_context.scraper.export.seed_data",
         ):


### PR DESCRIPTION
## Summary

Adds beta Ollama/local model support for LLM-backed King Context stages
through a shared provider layer in `src/llm_providers/`. `king-scrape`,
`king-research`, and the new `kctx llm-doctor` can now use OpenRouter,
Ollama local (OpenAI-compatible), Ollama native/cloud, and optional
Ollama to OpenRouter fallback. Default behavior for existing OpenRouter
users is unchanged.

Spec: `.specs/features/local-models-enrichment/`
ADR: `0003-pluggable-llm-provider-abstraction-for-cli-tools`

## Scope

- New `src/llm_providers/` package: `LLMClient` ABC, OpenRouter and
  Ollama clients, registry, parser, fallback, stage-aware config.
- Stage-aware provider/model env vars: `ENRICH_*`, `FILTER_*`,
  `RESEARCH_*`, `OLLAMA_*`, `CONCURRENCY_*`, `ENABLE_FALLBACK`.
- `king-scrape` (enrich + LLM filter) and `king-research` query
  generation now go through `get_client(stage)` instead of hard-calling
  OpenRouter.
- New `kctx llm-doctor` and Node `doctor` Ollama hook (warning-only).
- Centralized env loading in `src/king_context/env.py` so
  `.king-context/.env` and `.env` are picked up consistently.
- ADR-0003, `docs/CLI_GUIDE.md` LLM section, `docs/ollama.md` setup
  guide, READMEs (EN and PT-BR), installer env template, and
  king-context skills updated.

## How it was tested

- `pytest -q` returned `466 passed`
- `python -m context_cli.cli adr status` returned index up to date
- `python -m context_cli.cli adr validate` passed
- `python -m context_cli.cli llm-doctor --json` returned no Ollama
  stages configured
- `ENRICH_PROVIDER=ollama ENRICH_MODEL=qwen2.5:7b OLLAMA_API_MODE=openai OLLAMA_BASE_URL=http://localhost:11434/v1 CONCURRENCY_OLLAMA=1 python -m context_cli.cli llm-doctor --json` returned Ollama reachable, model present
- Installer smoke in temp project: `npm pack --dry-run`,
  `king-context init`, `.king-context/bin/kctx llm-doctor --json`,
  `king-context doctor` returned `16 passed, 0 warnings, 0 failed`

## On PR size

This PR is intentionally large. I tested and reviewed the code heavily
while implementing. The spec, ADR, providers, integration sites, docs,
installer, and tests all landed together so each step could be
validated end-to-end against a real Ollama instance. If something turns
up later, the commits are cleanly separated by concern (provider layer,
scraper integration, research integration, doctor, docs, post-review
fixes), so a targeted revert or follow-up should be easy.

## Notes

- Ollama is shipped as **beta**. Manual validation covered local Ollama
  only. Ollama Cloud/native mode has not been exercised end-to-end.
  Users are asked to open issues for bugs and model-quality feedback.
- The npm installer installs the Python package from
  `git+https://github.com/deandevz/king-context.git`. **Merge this PR
  before publishing the npm package** so installed venvs include
  `kctx llm-doctor` and the provider layer.