### PR TITLE
fix(installer): finalize Windows beta support (supersedes #26)

### DIFF
--- a/.king-context/adr/0001-adopt-cli-first-architecture-for-agent-retrieval.md
+++ b/.king-context/adr/0001-adopt-cli-first-architecture-for-agent-retrieval.md
@@ -14,6 +14,7 @@ superseded_by: []
 related:
   - ADR-0002
   - ADR-0003
+  - ADR-0004
 keywords:
   - cli-first
   - agent-retrieval
@@ -28,6 +29,7 @@ tags:
   - retrieval
   - agents
 ---
+
 
 
 # ADR-0001: Adopt CLI-first architecture for agent retrieval

--- a/.king-context/adr/0002-centralize-installer-layout-reconciliation.md
+++ b/.king-context/adr/0002-centralize-installer-layout-reconciliation.md
@@ -12,6 +12,7 @@ supersedes: []
 superseded_by: []
 related:
   - ADR-0001
+  - ADR-0004
 keywords:
   - installer-layout
   - upgrade
@@ -23,6 +24,7 @@ tags:
   - upgrade
   - adr
 ---
+
 
 
 # ADR-0002: Centralize installer layout reconciliation

--- a/.king-context/adr/0004-treat-multi-os-compatibility-macos-linux-windows-as-a-baseline.md
+++ b/.king-context/adr/0004-treat-multi-os-compatibility-macos-linux-windows-as-a-baseline.md
@@ -1,0 +1,52 @@
+---
+id: ADR-0004
+title: Treat multi-OS compatibility (macOS, Linux, Windows) as a baseline
+status: accepted
+date: 2026-05-06
+areas:
+  - installer
+  - cli
+  - testing
+  - product
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0001
+  - ADR-0002
+keywords:
+  - multi-os
+  - windows
+  - cross-platform
+  - installer
+  - testing
+tags:
+  - architecture
+  - installer
+  - platform
+---
+
+
+
+
+
+# Treat multi-OS compatibility as a baseline
+
+## Context
+
+King Context started Unix-first and only added Windows support reactively when issue #19 was filed. Going forward the project's reach (community registry, agent-installable corpora) depends on running anywhere a developer's agent runs, and that includes Windows. Treating Windows as an afterthought leads to hardcoded `bin/`, hardcoded `python3`, and tests that pass only on the maintainer's box.
+
+## Decision
+
+All new code paths in `installer/`, `src/king_context/`, `src/context_cli/`, and tests must be developed with macOS, Linux, and Windows compatibility as a non-negotiable baseline. New features that touch filesystem layout, process spawning, shell invocation, or path handling must use platform-aware helpers (for example `path.win32` and `path.posix` in Node, `pathlib` in Python, the shared helpers in `installer/lib/python.js`) instead of platform-specific literals. Tests that exercise platform-specific behavior must use those same helpers so they pass on any host.
+
+## Alternatives Considered
+
+Continuing Unix-first with opportunistic Windows fixes preserves short-term velocity but produces drift like the bugs caught in PR #26 (test that only passes on Windows, orphan wrapper templates). Splitting into Unix-only and Windows-only code paths duplicates logic and makes review harder. Dropping Windows support outright shrinks the user base of the npm installer, which is the primary user-facing entry point.
+
+## Consequences
+
+Reviews and CI must check that new code does not assume `bin/python`, `python3`, forward-slash paths, or POSIX-only shell idioms. Tests that touch paths or process spawning must mock at the helper level, not at `path.join` directly. The installer scaffold contract (ADR-0002) extends to platform abstraction: there is one path resolver per concept, used by init, update, and doctor alike. Windows is currently beta and existing bugs are tolerated during the beta window, but new contributions are held to the baseline.
+
+## Links
+
+installer/lib/python.js, installer/lib/scaffold.js, installer/lib/doctor.js, tests/test_installer_scaffold.py, ADR-0001, ADR-0002

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-06
+
+### Added
+
+- Windows support for the installer (beta). `king-context init`, `update`,
+  and `doctor` now work on Windows: `py -3` detection, `Scripts\python.exe`
+  resolution, `python -m pip` invocation, and `.cmd` shims for `kctx`,
+  `king-scrape`, and `king-research`. Existing macOS and Linux behavior is
+  preserved. Co-authored with @Vadelo (issue #19).
+- ADR-0004: treat multi-OS compatibility (macOS, Linux, Windows) as a
+  baseline development constraint.
+
+### Changed
+
+- Path helpers in `installer/lib/python.js` now use `path.win32` /
+  `path.posix` based on `process.platform`, so Windows path assertions
+  pass on any host.
+- Removed orphan `installer/templates/wrapper-*.sh` files. Wrapper bodies
+  are inlined in `scaffold.js` and the templates are no longer read.
+
 ## [0.3.0] - 2026-05-05
 
 ### Added

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -20,6 +20,8 @@ npx @king-context/cli init
 
 Isso configura `.king-context/` em qualquer projeto: ambiente virtual Python, ferramentas CLI, skills de agente e templates de configuração. Zero setup manual.
 
+Windows é suportado como **beta** a partir da versão 0.3.1. Reporte qualquer problema específico de plataforma em [github.com/deandevz/king-context/issues](https://github.com/deandevz/king-context/issues).
+
 Adicione suas chaves:
 
 ```bash
@@ -137,7 +139,7 @@ A ideia não é "o agente pergunta, o corpus responde". A ideia é que seu agent
 - Distribuição via `pip install king-context`
 - Skills geradas por agente a partir de corpus indexado
 - Atualização incremental de docs sem rescrape completo
-- Suporte a Windows no instalador
+- Suporte estável a Windows no instalador (atualmente em beta)
 - Suíte de benchmark cobrindo docs, ADRs e corpus de pesquisa
 - Hooks de workflow que mostram seções relevantes durante o desenvolvimento
 - Indexação de conteúdo do usuário (md, txt, pdf, docx, transcrições de vídeo)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npx @king-context/cli init
 
 This sets up `.king-context/` in any project: Python venv, CLI tools, agent skills, config templates. Zero manual wiring.
 
+Windows is supported as **beta** since 0.3.1. Report any platform-specific issue at [github.com/deandevz/king-context/issues](https://github.com/deandevz/king-context/issues).
+
 Add your keys:
 
 ```bash
@@ -139,7 +141,7 @@ The aim is not "agent asks, corpus answers". The aim is that your agent always h
 - `pip install king-context` distribution
 - Agent-generated skills built from indexed corpora
 - Incremental doc updates without full re-scrape
-- Windows installer support
+- Windows installer general availability (currently beta)
 - Benchmark suite covering docs, ADRs, and research corpora
 - Workflow hooks that surface relevant sections during active coding
 - Indexing for user content (md, txt, pdf, docx, video transcripts)

--- a/installer/lib/doctor.js
+++ b/installer/lib/doctor.js
@@ -4,8 +4,16 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const ui = require('./ui');
+const { detectPython, getVenvPython } = require('./python');
 const { expectedDirPaths } = require('./scaffold');
 const { expectedSkillPaths } = require('./skills');
+
+function getWrapperPaths(projectDir, name) {
+  const binDir = path.join(projectDir, '.king-context', 'bin');
+  return process.platform === 'win32'
+    ? [path.join(binDir, `${name}.cmd`), path.join(binDir, name)]
+    : [path.join(binDir, name)];
+}
 
 /**
  * Run a single diagnostic check.
@@ -13,62 +21,43 @@ const { expectedSkillPaths } = require('./skills');
  */
 function checkPython() {
   try {
-    const raw = execSync('python3 --version', { stdio: 'pipe' }).toString().trim();
-    return { status: 'ok', label: `Python: ${raw}` };
-  } catch {
-    return { status: 'fail', label: 'Python: python3 not found' };
+    const python = detectPython();
+    return { status: 'ok', label: `Python: ${python.version} (${python.display || python.cmd})` };
+  } catch (err) {
+    return { status: 'fail', label: `Python: ${err.message.split('\n')[0]}` };
   }
 }
 
 function checkVenv(projectDir) {
-  const venvPython = path.join(projectDir, '.king-context', 'core', 'venv', 'bin', 'python');
+  const venvPython = getVenvPython(projectDir);
   if (fs.existsSync(venvPython)) {
-    return { status: 'ok', label: 'Venv: .king-context/core/venv/bin/python exists' };
+    return { status: 'ok', label: `Venv: ${path.relative(projectDir, venvPython)} exists` };
   }
   return { status: 'fail', label: 'Venv: virtual environment not found' };
 }
 
 function checkCliTools(projectDir) {
   const results = [];
-  const binDir = path.join(projectDir, '.king-context', 'bin');
 
-  // Check kctx
-  const kctxPath = path.join(binDir, 'kctx');
-  try {
-    if (fs.existsSync(kctxPath)) {
-      execSync(`"${kctxPath}" --version`, { stdio: 'pipe', timeout: 10000 });
-      results.push({ status: 'ok', label: 'CLI: kctx is working' });
-    } else {
-      results.push({ status: 'fail', label: 'CLI: kctx not found' });
-    }
-  } catch {
-    results.push({ status: 'warn', label: 'CLI: kctx found but returned an error' });
-  }
+  const tools = [
+    { name: 'kctx', args: '--help' },
+    { name: 'king-scrape', args: '--help' },
+    { name: 'king-research', args: '--help' },
+  ];
 
-  // Check king-scrape
-  const scrapePath = path.join(binDir, 'king-scrape');
-  try {
-    if (fs.existsSync(scrapePath)) {
-      execSync(`"${scrapePath}" --help`, { stdio: 'pipe', timeout: 10000 });
-      results.push({ status: 'ok', label: 'CLI: king-scrape is working' });
-    } else {
-      results.push({ status: 'fail', label: 'CLI: king-scrape not found' });
-    }
-  } catch {
-    results.push({ status: 'warn', label: 'CLI: king-scrape found but returned an error' });
-  }
+  for (const tool of tools) {
+    const wrapperPath = getWrapperPaths(projectDir, tool.name).find((candidate) => fs.existsSync(candidate));
 
-  // Check king-research
-  const researchPath = path.join(binDir, 'king-research');
-  try {
-    if (fs.existsSync(researchPath)) {
-      execSync(`"${researchPath}" --help`, { stdio: 'pipe', timeout: 10000 });
-      results.push({ status: 'ok', label: 'CLI: king-research is working' });
-    } else {
-      results.push({ status: 'fail', label: 'CLI: king-research not found' });
+    try {
+      if (wrapperPath) {
+        execSync(`"${wrapperPath}" ${tool.args}`, { stdio: 'pipe', timeout: 10000 });
+        results.push({ status: 'ok', label: `CLI: ${tool.name} is working` });
+      } else {
+        results.push({ status: 'fail', label: `CLI: ${tool.name} not found` });
+      }
+    } catch {
+      results.push({ status: 'warn', label: `CLI: ${tool.name} found but returned an error` });
     }
-  } catch {
-    results.push({ status: 'warn', label: 'CLI: king-research found but returned an error' });
   }
 
   return results;

--- a/installer/lib/init.js
+++ b/installer/lib/init.js
@@ -6,6 +6,12 @@ const { detectPython, createVenv, installPackage } = require('./python');
 const { createDirs, writeWrappers, writeEnvExample } = require('./scaffold');
 const { installSkills, mergeSettings, updateClaudeMd, updateGitignore } = require('./skills');
 
+function shellCopyCommand() {
+  return process.platform === 'win32'
+    ? 'Copy-Item .king-context/.env.example .env'
+    : 'cp .king-context/.env.example .env';
+}
+
 async function run() {
   const projectDir = process.cwd();
 
@@ -16,7 +22,7 @@ async function run() {
   try {
     ui.step('Detecting Python...');
     pythonInfo = detectPython();
-    ui.stepDone(`Python ${pythonInfo.version} found (${pythonInfo.cmd})`);
+    ui.stepDone(`Python ${pythonInfo.version} found (${pythonInfo.display || pythonInfo.cmd})`);
   } catch (err) {
     ui.stepFail('Python not found');
     console.error();
@@ -122,7 +128,7 @@ async function run() {
   ui.header('Next Steps');
   console.log('  1. Copy .king-context/.env.example to .env and add your API keys:');
   console.log();
-  console.log('       cp .king-context/.env.example .env');
+  console.log(`       ${shellCopyCommand()}`);
   console.log();
   console.log('  2. Run the doctor to verify your installation:');
   console.log();

--- a/installer/lib/python.js
+++ b/installer/lib/python.js
@@ -1,34 +1,72 @@
 'use strict';
 
-const { execSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const path = require('path');
-const fs = require('fs');
+
+function getVenvPath(projectDir) {
+  return path.join(projectDir, '.king-context', 'core', 'venv');
+}
+
+function getVenvBinDir(projectDir) {
+  return path.join(getVenvPath(projectDir), process.platform === 'win32' ? 'Scripts' : 'bin');
+}
+
+function getVenvPython(projectDir) {
+  return path.join(getVenvBinDir(projectDir), process.platform === 'win32' ? 'python.exe' : 'python');
+}
+
+function getPythonCandidates() {
+  return process.platform === 'win32'
+    ? [
+        { cmd: 'py', args: ['-3'], display: 'py -3' },
+        { cmd: 'python', args: [], display: 'python' },
+        { cmd: 'python3', args: [], display: 'python3' },
+      ]
+    : [
+        { cmd: 'python3', args: [], display: 'python3' },
+        { cmd: 'python', args: [], display: 'python' },
+        { cmd: 'py', args: ['-3'], display: 'py -3' },
+      ];
+}
+
+function parsePythonVersion(raw) {
+  const match = String(raw || '').match(/Python\s+(\d+\.\d+(?:\.\d+)?)/);
+  return match ? match[1] : null;
+}
 
 /**
  * Detect a usable Python installation (>= 3.10).
- * Tries python3 first, then python.
+ * Tries platform-appropriate Python launchers in priority order.
  * Returns { cmd, version } or throws with install instructions.
  */
 function detectPython() {
-  const candidates = ['python3', 'python'];
+  for (const candidate of getPythonCandidates()) {
+    const result = spawnSync(candidate.cmd, [...candidate.args, '--version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
 
-  for (const cmd of candidates) {
-    try {
-      const raw = execSync(`${cmd} --version`, { stdio: 'pipe' }).toString().trim();
-      const match = raw.match(/Python\s+(\d+\.\d+\.\d+)/);
-      if (!match) continue;
-
-      const version = match[1];
-      const [major, minor] = version.split('.').map(Number);
-
-      if (major < 3 || (major === 3 && minor < 10)) {
-        continue;
-      }
-
-      return { cmd, version };
-    } catch {
-      // command not found, try next
+    if (result.error || result.status !== 0) {
+      continue;
     }
+
+    const version = parsePythonVersion(`${result.stdout || ''}${result.stderr || ''}`.trim());
+    if (!version) {
+      continue;
+    }
+
+    const [major, minor] = version.split('.').map(Number);
+    if (major < 3 || (major === 3 && minor < 10)) {
+      continue;
+    }
+
+    return {
+      cmd: candidate.cmd,
+      args: candidate.args,
+      display: candidate.display,
+      version,
+    };
   }
 
   throw new Error(
@@ -37,7 +75,8 @@ function detectPython() {
     '  or via your package manager:\n' +
     '    macOS:  brew install python@3.12\n' +
     '    Ubuntu: sudo apt install python3\n' +
-    '    Fedora: sudo dnf install python3'
+    '    Fedora: sudo dnf install python3\n' +
+    '    Windows: winget install Python.Python.3.12'
   );
 }
 
@@ -45,21 +84,25 @@ function detectPython() {
  * Create a virtual environment inside .king-context/core/venv.
  */
 function createVenv(projectDir) {
-  const { cmd } = detectPython();
-  const venvPath = path.join(projectDir, '.king-context', 'core', 'venv');
+  const { cmd, args } = detectPython();
+  const venvPath = getVenvPath(projectDir);
 
-  execSync(`${cmd} -m venv "${venvPath}"`, { stdio: 'pipe' });
+  execFileSync(cmd, [...args, '-m', 'venv', venvPath], {
+    stdio: 'pipe',
+    windowsHide: true,
+  });
 }
 
 /**
  * Install king-context package into the project venv.
  */
 function installPackage(projectDir) {
-  const pip = path.join(projectDir, '.king-context', 'core', 'venv', 'bin', 'pip');
+  const python = getVenvPython(projectDir);
 
-  execSync(
-    `"${pip}" install --no-cache-dir git+https://github.com/deandevz/king-context.git`,
-    { stdio: 'pipe', timeout: 300000 }
+  execFileSync(
+    python,
+    ['-m', 'pip', 'install', '--no-cache-dir', 'git+https://github.com/deandevz/king-context.git'],
+    { stdio: 'pipe', timeout: 300000, windowsHide: true }
   );
 }
 
@@ -67,12 +110,32 @@ function installPackage(projectDir) {
  * Upgrade king-context package in the project venv.
  */
 function upgradePackage(projectDir) {
-  const pip = path.join(projectDir, '.king-context', 'core', 'venv', 'bin', 'pip');
+  const python = getVenvPython(projectDir);
 
-  execSync(
-    `"${pip}" install --upgrade --force-reinstall --no-deps --no-cache-dir git+https://github.com/deandevz/king-context.git`,
-    { stdio: 'pipe', timeout: 300000 }
+  execFileSync(
+    python,
+    [
+      '-m',
+      'pip',
+      'install',
+      '--upgrade',
+      '--force-reinstall',
+      '--no-deps',
+      '--no-cache-dir',
+      'git+https://github.com/deandevz/king-context.git',
+    ],
+    { stdio: 'pipe', timeout: 300000, windowsHide: true }
   );
 }
 
-module.exports = { detectPython, createVenv, installPackage, upgradePackage };
+module.exports = {
+  detectPython,
+  createVenv,
+  getVenvBinDir,
+  getPythonCandidates,
+  getVenvPath,
+  getVenvPython,
+  installPackage,
+  parsePythonVersion,
+  upgradePackage,
+};

--- a/installer/lib/python.js
+++ b/installer/lib/python.js
@@ -3,16 +3,20 @@
 const { execFileSync, spawnSync } = require('child_process');
 const path = require('path');
 
+function pathFor() {
+  return process.platform === 'win32' ? path.win32 : path.posix;
+}
+
 function getVenvPath(projectDir) {
-  return path.join(projectDir, '.king-context', 'core', 'venv');
+  return pathFor().join(projectDir, '.king-context', 'core', 'venv');
 }
 
 function getVenvBinDir(projectDir) {
-  return path.join(getVenvPath(projectDir), process.platform === 'win32' ? 'Scripts' : 'bin');
+  return pathFor().join(getVenvPath(projectDir), process.platform === 'win32' ? 'Scripts' : 'bin');
 }
 
 function getVenvPython(projectDir) {
-  return path.join(getVenvBinDir(projectDir), process.platform === 'win32' ? 'python.exe' : 'python');
+  return pathFor().join(getVenvBinDir(projectDir), process.platform === 'win32' ? 'python.exe' : 'python');
 }
 
 function getPythonCandidates() {

--- a/installer/lib/scaffold.js
+++ b/installer/lib/scaffold.js
@@ -33,23 +33,28 @@ function createDirs(projectDir) {
  * Makes them executable (mode 0o755).
  */
 function writeWrappers(projectDir) {
-  const templatesDir = path.join(__dirname, '..', 'templates');
   const binDir = path.join(projectDir, '.king-context', 'bin');
 
   fs.mkdirSync(binDir, { recursive: true });
 
   const wrappers = [
-    { template: 'wrapper-kctx.sh', target: 'kctx' },
-    { template: 'wrapper-scrape.sh', target: 'king-scrape' },
-    { template: 'wrapper-research.sh', target: 'king-research' },
+    { module: 'context_cli.cli', target: 'kctx' },
+    { module: 'king_context.scraper.cli', target: 'king-scrape' },
+    { module: 'king_context.research.cli', target: 'king-research' },
   ];
 
-  for (const { template, target } of wrappers) {
-    const src = path.join(templatesDir, template);
-    const dest = path.join(binDir, target);
+  for (const { module, target } of wrappers) {
+    const shellPath = path.join(binDir, target);
+    const shellContent = process.platform === 'win32'
+      ? `#!/bin/sh\nSCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexec "$SCRIPT_DIR/../core/venv/Scripts/python.exe" -m ${module} "$@"\n`
+      : `#!/bin/sh\nSCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexec "$SCRIPT_DIR/../core/venv/bin/python" -m ${module} "$@"\n`;
+    fs.writeFileSync(shellPath, shellContent, { mode: 0o755 });
 
-    const content = fs.readFileSync(src, 'utf8');
-    fs.writeFileSync(dest, content, { mode: 0o755 });
+    if (process.platform === 'win32') {
+      const cmdPath = path.join(binDir, `${target}.cmd`);
+      const cmdContent = `@echo off\r\nset SCRIPT_DIR=%~dp0\r\n"%SCRIPT_DIR%..\\core\\venv\\Scripts\\python.exe" -m ${module} %*\r\n`;
+      fs.writeFileSync(cmdPath, cmdContent);
+    }
   }
 }
 

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@king-context/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Installer for King Context — local-first documentation search for AI agents",
   "bin": {
     "king-context": "./bin/king-context.js"

--- a/installer/templates/wrapper-kctx.sh
+++ b/installer/templates/wrapper-kctx.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/kctx" "$@"
+#!/bin/sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/python" -m context_cli.cli "$@"

--- a/installer/templates/wrapper-kctx.sh
+++ b/installer/templates/wrapper-kctx.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/python" -m context_cli.cli "$@"

--- a/installer/templates/wrapper-research.sh
+++ b/installer/templates/wrapper-research.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/king-research" "$@"
+#!/bin/sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/python" -m king_context.research.cli "$@"

--- a/installer/templates/wrapper-research.sh
+++ b/installer/templates/wrapper-research.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/python" -m king_context.research.cli "$@"

--- a/installer/templates/wrapper-scrape.sh
+++ b/installer/templates/wrapper-scrape.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-SCRIPT_DIR="$(cd "${0%/*}" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/king-scrape" "$@"
+#!/bin/sh
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$SCRIPT_DIR/../core/venv/bin/python" -m king_context.scraper.cli "$@"

--- a/installer/templates/wrapper-scrape.sh
+++ b/installer/templates/wrapper-scrape.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-exec "$SCRIPT_DIR/../core/venv/bin/python" -m king_context.scraper.cli "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "king-context"
-version = "0.3.0"
+version = "0.3.1"
 description = "Local-first, token-efficient documentation server for LLM context injection"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_installer_scaffold.py
+++ b/tests/test_installer_scaffold.py
@@ -104,3 +104,114 @@ Promise.resolve(require(path.join(repoRoot, 'installer/lib/update.js')).run()).c
         "_temp",
     ]:
         assert (king_dir / dirname).is_dir()
+
+
+def test_write_wrappers_uses_python_modules_on_unix(tmp_path):
+    script = """
+const path = require('path');
+const { writeWrappers } = require('./installer/lib/scaffold');
+process.chdir(process.argv[1]);
+writeWrappers(process.argv[1]);
+"""
+
+    subprocess.run(
+        ["node", "-e", script, str(tmp_path)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    kctx = (tmp_path / ".king-context" / "bin" / "kctx").read_text(encoding="utf-8")
+    scrape = (tmp_path / ".king-context" / "bin" / "king-scrape").read_text(encoding="utf-8")
+    research = (tmp_path / ".king-context" / "bin" / "king-research").read_text(encoding="utf-8")
+
+    assert "-m context_cli.cli" in kctx
+    assert "../core/venv/bin/python" in kctx
+    assert "-m king_context.scraper.cli" in scrape
+    assert "-m king_context.research.cli" in research
+
+
+def test_write_wrappers_creates_cmd_shims_on_windows(tmp_path):
+    script = """
+const path = require('path');
+Object.defineProperty(process, 'platform', { value: 'win32' });
+const { writeWrappers } = require('./installer/lib/scaffold');
+process.chdir(process.argv[1]);
+writeWrappers(process.argv[1]);
+"""
+
+    subprocess.run(
+        ["node", "-e", script, str(tmp_path)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    shell_wrapper = (tmp_path / ".king-context" / "bin" / "kctx").read_text(encoding="utf-8")
+    cmd_wrapper = (tmp_path / ".king-context" / "bin" / "kctx.cmd").read_text(encoding="utf-8")
+
+    assert "../core/venv/Scripts/python.exe" in shell_wrapper
+    assert "python.exe" in cmd_wrapper
+    assert "-m context_cli.cli" in cmd_wrapper
+
+
+def test_python_helpers_resolve_platform_specific_venv_paths():
+    script = """
+const path = require('path');
+Object.defineProperty(process, 'platform', { value: 'win32' });
+const { getVenvPath, getVenvBinDir, getVenvPython } = require('./installer/lib/python');
+const projectDir = process.argv[1];
+console.log(JSON.stringify({
+  venv: getVenvPath(projectDir),
+  bin: getVenvBinDir(projectDir),
+  python: getVenvPython(projectDir),
+}));
+"""
+
+    result = subprocess.run(
+        ["node", "-e", script, str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    data = json.loads(result.stdout)
+    assert data["venv"].endswith(".king-context\\core\\venv")
+    assert data["bin"].endswith(".king-context\\core\\venv\\Scripts")
+    assert data["python"].endswith(".king-context\\core\\venv\\Scripts\\python.exe")
+
+
+def test_detect_python_supports_windows_py_launcher():
+    script = """
+const childProcess = require('child_process');
+Object.defineProperty(process, 'platform', { value: 'win32' });
+childProcess.spawnSync = (cmd, args) => {
+  if (cmd === 'py' && args.join(' ') === '-3 --version') {
+    return { status: 0, stdout: '', stderr: 'Python 3.12.4\\n' };
+  }
+  return { status: 1, stdout: '', stderr: '' };
+};
+const { detectPython } = require('./installer/lib/python');
+console.log(JSON.stringify(detectPython()));
+"""
+
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    data = json.loads(result.stdout)
+    assert data["cmd"] == "py"
+    assert data["args"] == ["-3"]
+    assert data["display"] == "py -3"
+    assert data["version"] == "3.12.4"
+
+
+def test_doctor_uses_shared_python_detection_contract():
+    doctor = Path("installer/lib/doctor.js").read_text(encoding="utf-8")
+
+    assert "detectPython" in doctor
+    assert "getVenvPython" in doctor
+    assert "python3 --version" not in doctor

--- a/tests/test_installer_scaffold.py
+++ b/tests/test_installer_scaffold.py
@@ -108,7 +108,7 @@ Promise.resolve(require(path.join(repoRoot, 'installer/lib/update.js')).run()).c
 
 def test_write_wrappers_uses_python_modules_on_unix(tmp_path):
     script = """
-const path = require('path');
+Object.defineProperty(process, 'platform', { value: 'linux' });
 const { writeWrappers } = require('./installer/lib/scaffold');
 process.chdir(process.argv[1]);
 writeWrappers(process.argv[1]);


### PR DESCRIPTION
## Summary

Finalizes Windows installer support as beta for 0.3.1, picking up @Vadelo's work in #26 with the three review items applied. Closes #19. Supersedes #26.

## Scope

- Cherry-picked f6340ca + cc0c7af (Windows-aware Python, wrappers, doctor refactor). Skipped d0a0551 to avoid breaking `test_full_pipeline_resume_to_export`.
- `installer/lib/python.js`: venv path helpers now use `path.win32` / `path.posix` so the cross-platform test passes on any host.
- Deleted orphan `installer/templates/wrapper-*.sh` (bodies inlined in `scaffold.js` now).
- Bumped pyproject + installer to 0.3.1, CHANGELOG entry, README beta callout (en + pt-br).
- ADR-0004 codifies multi-OS (macOS, Linux, Windows) as a baseline development constraint, related to ADR-0001 and ADR-0002.

`pytest` 471/471 passed. Smoke-tested `init` + `doctor` on macOS in a throwaway project.

Co-authored-by: Vadelo <victorcnfb@gmail.com>