### PR TITLE
feat(scraper): add pluggable provider with crawl4ai backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,20 @@
-# King Context — API Keys
+# King Context: API Keys
 # Copy this file to .env at your project root
 
-# Required — Firecrawl API key for documentation scraping
+# Required for default scraper. Firecrawl API key for documentation scraping.
 # Get yours at https://firecrawl.dev
 FIRECRAWL_API_KEY=
 
-# Optional — OpenRouter API key for OpenRouter LLM stages or Ollama fallback
+# Scraper provider selection (king-scrape)
+# Default: firecrawl (requires FIRECRAWL_API_KEY).
+# Other options: crawl4ai (local; install via 'pip install king-context[crawl4ai] && crawl4ai-setup')
+# SCRAPE_PROVIDER=firecrawl
+#
+# Stage-specific overrides (precedence: stage var > SCRAPE_PROVIDER > default 'firecrawl'):
+# SCRAPE_DISCOVER_PROVIDER=crawl4ai
+# SCRAPE_FETCH_PROVIDER=firecrawl
+
+# Optional. OpenRouter API key for OpenRouter LLM stages or Ollama fallback.
 # Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=
 
@@ -38,13 +47,13 @@ CONCURRENCY_OLLAMA=2
 ENABLE_FALLBACK=false
 FALLBACK_MODEL=google/gemini-3-flash-preview
 
-# Required — Exa API key for king-research topic-driven web search
-# Powers semantic search and content retrieval for the research pipeline
+# Required for king-research. Exa API key for topic-driven web search.
+# Powers semantic search and content retrieval for the research pipeline.
 # Get yours at https://dashboard.exa.ai/api-keys
 EXA_API_KEY=
 
-# Optional — Jina API key for reranking and embeddings in king-research
-# The anonymous tier works for light use; set a key to raise rate limits
+# Optional. Jina API key for reranking and embeddings in king-research.
+# The anonymous tier works for light use; set a key to raise rate limits.
 # Get yours at https://jina.ai/api
 JINA_API_KEY=
 
@@ -52,7 +61,7 @@ JINA_API_KEY=
 # Prefer RESEARCH_MODEL above for new configs.
 OPENROUTER_MODEL_RESEARCH=
 
-# Optional — Effort-ladder overrides for king-research
+# Optional. Effort-ladder overrides for king-research.
 # Uncomment any line to override the built-in defaults shown below
 #RESEARCH_BASIC_QUERIES=3
 #RESEARCH_MEDIUM_QUERIES=5

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ FIRECRAWL_API_KEY=
 
 # Scraper provider selection (king-scrape)
 # Default: firecrawl (requires FIRECRAWL_API_KEY).
-# Other options: crawl4ai (local; install via 'pip install king-context[crawl4ai] && crawl4ai-setup')
+# Other options: crawl4ai (local, beta; bundled by 'npx @king-context/cli init', activate with 'crawl4ai-setup')
 # SCRAPE_PROVIDER=firecrawl
 #
 # Stage-specific overrides (precedence: stage var > SCRAPE_PROVIDER > default 'firecrawl'):

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Pytest (firecrawl path)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install with firecrawl extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[firecrawl,dev]"
+      - name: Run pytest
+        run: pytest -q
+
+  smoke-crawl4ai:
+    name: Crawl4AI smoke test
+    runs-on: ubuntu-latest
+    needs: [test]
+    # Bloqueante por design (ADR-0011): este smoke detecta API churn entre minor
+    # versions de crawl4ai (>=0.8.5,<0.9). Se quebrar, queremos saber antes do
+    # release, nao depois. Nao mover para continue-on-error.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install with crawl4ai extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[crawl4ai,dev]"
+          crawl4ai-setup
+      - name: Run smoke script
+        run: python scripts/smoke-crawl4ai.py
+        timeout-minutes: 5

--- a/.king-context/adr/0001-adopt-cli-first-architecture-for-agent-retrieval.md
+++ b/.king-context/adr/0001-adopt-cli-first-architecture-for-agent-retrieval.md
@@ -19,6 +19,7 @@ related:
   - ADR-0006
   - ADR-0007
   - ADR-0008
+  - ADR-0009
 keywords:
   - cli-first
   - agent-retrieval
@@ -33,6 +34,7 @@ tags:
   - retrieval
   - agents
 ---
+
 
 
 

--- a/.king-context/adr/0003-pluggable-llm-provider-abstraction-for-cli-tools.md
+++ b/.king-context/adr/0003-pluggable-llm-provider-abstraction-for-cli-tools.md
@@ -12,6 +12,7 @@ supersedes: []
 superseded_by: []
 related:
   - ADR-0001
+  - ADR-0009
 keywords:
   - llm-provider
   - openrouter
@@ -24,6 +25,7 @@ tags:
   - llm
   - cli
 ---
+
 
 
 # ADR-0003: Pluggable LLM provider abstraction for CLI tools

--- a/.king-context/adr/0004-treat-multi-os-compatibility-macos-linux-windows-as-a-baseline.md
+++ b/.king-context/adr/0004-treat-multi-os-compatibility-macos-linux-windows-as-a-baseline.md
@@ -15,6 +15,7 @@ related:
   - ADR-0002
   - ADR-0007
   - ADR-0008
+  - ADR-0011
 keywords:
   - multi-os
   - windows
@@ -26,6 +27,7 @@ tags:
   - installer
   - platform
 ---
+
 
 
 

--- a/.king-context/adr/0009-pluggable-scraper-provider-abstraction-for-king-scrape.md
+++ b/.king-context/adr/0009-pluggable-scraper-provider-abstraction-for-king-scrape.md
@@ -1,0 +1,55 @@
+---
+id: ADR-0009
+title: Pluggable scraper provider abstraction for king-scrape
+status: accepted
+date: 2026-05-06
+areas:
+  - cli
+  - scraper
+  - providers
+  - plugin-system
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0001
+  - ADR-0003
+  - ADR-0010
+  - ADR-0011
+keywords:
+  - scraper-provider
+  - registry
+  - stage-aware
+  - soft-import
+  - python-extras
+  - entry-points
+tags:
+  - architecture
+  - scraper
+  - providers
+---
+
+
+
+
+
+# ADR-0009: Pluggable scraper provider abstraction for king-scrape
+
+## Context
+
+O king-scrape (CLI de indexação de documentação) chama Firecrawl SaaS diretamente nas etapas discover (src/king_context/scraper/discover.py) e fetch (src/king_context/scraper/fetch.py). Essa dependência fechada contradiz o posicionamento local-first do produto declarado em ADR-0001 e cria fricção pra adoção (FIRECRAWL_API_KEY obrigatória antes de indexar a primeira documentação). ADR-0003 já estabeleceu o padrão pra LLMs (cloud default + local opt-in via abstração de provider via OpenRouter e Ollama). Falta o equivalente pra scraping.
+
+## Decision
+
+Criar package src/scraper_providers/ análogo ao src/llm_providers/ com Protocols separados (DiscoveryProvider, FetchProvider), registry com soft import via Python extras (pip install king-context[crawl4ai]), e stage-aware env resolution: SCRAPE_PROVIDER (global), SCRAPE_DISCOVER_PROVIDER e SCRAPE_FETCH_PROVIDER (override por stage). Suportar entry_points group king_context.scraper_providers pra plugin model futuro. Firecrawl continua como default zero-config; novos backends viram opcionais selecionáveis sem refactor de pipeline.
+
+## Alternatives Considered
+
+Dispatcher inline em cada stage (if provider == firecrawl: else: ...) economiza código hoje (50 linhas vs 200) mas inviabiliza plugin model via entry_points sem refactor posterior, fragmenta tratamento de soft import (ImportError precisa ser catalogado em cada stage), e perde simetria com src/llm_providers/ (custo cognitivo extra pra contributors). Provider único cobrindo discover+fetch (sem stage-aware) é mais simples conceitualmente mas inviabiliza mixing genuíno entre etapas (ex: crawl4ai discover de SPA + firecrawl fetch estável).
+
+## Consequences
+
+Novos backends de scraping são adicionados como módulos isolados com soft import e registro automático via entry_points. Stage-aware resolution permite mixing por etapa. Install via Python extras prepara terreno pra futuro kctx plugin install (CLI interativa) sem refactor estrutural: vira wrapper amigável em cima do mecanismo de extras + entry_points. discover.py e fetch.py passam a depender das Protocols em vez de FirecrawlApp diretamente; tests existentes precisam adaptar mocks (passar provider via param em vez de patchar SDK). Sem env var setada, comportamento default permanece idêntico ao atual (zero breaking change).
+
+## Links
+
+.docs/PLUGGABLE-SCRAPER-PROVIDER-ARCHITECTURE.md,src/llm_providers/

--- a/.king-context/adr/0010-thin-scraper-provider-with-pipeline-owned-concurrency-checkpoint-and-io.md
+++ b/.king-context/adr/0010-thin-scraper-provider-with-pipeline-owned-concurrency-checkpoint-and-io.md
@@ -1,0 +1,49 @@
+---
+id: ADR-0010
+title: Thin scraper provider with pipeline-owned concurrency, checkpoint, and IO
+status: accepted
+date: 2026-05-06
+areas:
+  - scraper
+  - providers
+  - performance
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0009
+keywords:
+  - thin-provider
+  - pipeline-owned
+  - semaphore
+  - checkpoint
+  - resume
+  - fetch-one
+  - trade-off
+tags:
+  - architecture
+  - scraper
+  - providers
+---
+
+
+# ADR-0010: Thin scraper provider with pipeline-owned concurrency, checkpoint, and IO
+
+## Context
+
+Ao desenhar a abstração de scraper provider (ADR-0009), surgiu a escolha de onde manter concorrência, checkpoint, e gravação de .md em disco. fetch.py (src/king_context/scraper/fetch.py:53) já implementa um semaphore de concorrência (default 5, configurável via config.concurrency), resume por slug, retry com backoff, e gravação por página em .king-context/_temp/<host>/pages/<slug>.md. Esse código está em produção e testado. Cada provider candidato (Crawl4AI, Firecrawl) traz suas próprias capacidades de batching e throttling adaptativo.
+
+## Decision
+
+Manter as Protocols mínimas: FetchProvider expõe apenas async fetch_one(url) -> PageContent, e DiscoveryProvider expõe apenas async discover_urls(base_url) -> list[str]. Toda a lógica de semaphore, checkpoint slug-based, retry, e gravação .md continua no fetch.py (pipeline-owned). Gravação do discovered_urls.json continua no discover.py. Providers são finos: convertem 1 URL em 1 PageContent.
+
+## Alternatives Considered
+
+Provider gordo (cada backend implementa fetch_many com sua própria concorrência/checkpoint/IO) extrairia max performance específica de cada engine: Crawl4AI tem AdaptiveDispatcher que ajusta concurrency baseado em latência observada, Firecrawl SDK tem rate-limit handling automático. Foi descartado porque (a) duplica lógica de IO entre backends, (b) fragmenta resume semantics: trocar provider no meio de um run não retomaria do checkpoint anterior se cada um gravasse de um jeito, (c) complica testes (mock de filesystem por backend), (d) atrasa MVP. Híbrido (fetch_one mandatório + fetch_many opcional com default vindo de fetch_one paralelo) é a evolução natural se otimização virar gargalo medido.
+
+## Consequences
+
+Output em disco é idêntico independente do backend, contrato esperado de uma abstração de provider. Resume cross-provider funciona: URLs já baixadas com Firecrawl não são re-baixadas se o usuário trocar pra Crawl4AI no meio. Tests de provider isolam em PageContent retornado, sem mockar filesystem. Trade-off explícito: throttling adaptativo de cada backend não é usado; ambos compartilham a semaphore default de 5 concurrent. Se isso virar gargalo medido na prática, a evolução é local (não estrutural): adicionar método fetch_many opcional ao Protocol, providers podem fazer override quando vale a pena, default permanece o loop de fetch_one paralelo. Decisão consciente de ship-now > otimizar.
+
+## Links
+
+.docs/PLUGGABLE-SCRAPER-PROVIDER-ARCHITECTURE.md,src/king_context/scraper/fetch.py

--- a/.king-context/adr/0011-crawl4ai-selected-as-first-local-scraping-backend.md
+++ b/.king-context/adr/0011-crawl4ai-selected-as-first-local-scraping-backend.md
@@ -1,0 +1,50 @@
+---
+id: ADR-0011
+title: Crawl4AI selected as first local scraping backend
+status: accepted
+date: 2026-05-06
+areas:
+  - scraper
+  - providers
+  - dependencies
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0004
+  - ADR-0009
+keywords:
+  - crawl4ai
+  - local-scraping
+  - playwright
+  - spa-rendering
+  - trafilatura
+  - opt-in
+tags:
+  - architecture
+  - scraper
+  - backend-choice
+---
+
+
+
+# ADR-0011: Crawl4AI selected as first local scraping backend
+
+## Context
+
+O ADR-0009 abre a porta pra ter múltiplos backends de scraping mas precisa eleger o primeiro motor local pra acompanhar o lançamento da feature. Os candidatos avaliados foram: Crawl4AI (Apache 2.0, Playwright-based, ~65k stars, ativo 2026), trafilatura (Apache 2.0, pure Python, ~5.9k stars, usado por HuggingFace e IBM Research), Scrapy + scrapy-playwright (mais boilerplate, gold standard pra crawls de milhões de páginas), e self-host de Firecrawl OSS (heavy: Redis + Node + Playwright + Docker, viola CLI-first do ADR-0001).
+
+## Decision
+
+Adotar Crawl4AI como primeiro motor local opt-in. Instalável via pip install king-context[crawl4ai] && crawl4ai-setup. Implementado como Crawl4AIScraperProvider em src/scraper_providers/crawl4ai_provider.py com soft import. Cobre tanto DiscoveryProvider (via deep crawl strategies) quanto FetchProvider (via AsyncWebCrawler.arun).
+
+## Alternatives Considered
+
+Trafilatura + httpx + crawler thin custom era a primeira recomendação durante a sessão de design, justificada pelo footprint leve (pure Python, sem browser binary, install <20MB) e excelente extração HTML→Markdown pra docs estáticas. Foi descartada porque cobertura de SPA/JS é dia-1 essencial pra ser uma alternativa de verdade ao Firecrawl, não meio-alternativa: Vercel docs, Mintlify customizado, e dashboards renderizados em React puro precisam de Playwright. Hybrid (trafilatura fast-path + Playwright fallback) seria caminho intermediário válido mas duplica trabalho que Crawl4AI já entrega numa stack só. Self-host Firecrawl OSS exige Redis + Node + Playwright + Docker e contraria o espírito CLI-first (ADR-0001). Scrapy é overkill pra docs scraping.
+
+## Consequences
+
+Install do modo local exige ~300MB de Chromium via crawl4ai-setup, aceitável porque o overhead só atinge quem ativamente opt-in (default Firecrawl não muda; usuário casual nunca paga esse custo). Multi-OS baseline (ADR-0004) é mantido: Crawl4AI funciona em macOS, Linux, Windows com Playwright. API churn entre minor versions de Crawl4AI exige version pin no pyproject.toml (crawl4ai>=0.8.5,<0.9) e um teste de fumaça em CI que indexe um site conhecido. Cobertura de SPA permite indexar docs modernas sem precisar de fallback pra Firecrawl. Trafilatura permanece candidata pra um futuro terceiro backend super-leve voltado pra static-only sites (roadmap v3 do ADR-0009).
+
+## Links
+
+.docs/PLUGGABLE-SCRAPER-PROVIDER-ARCHITECTURE.md,https://github.com/unclecode/crawl4ai,https://github.com/adbar/trafilatura

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via `SCRAPE_PROVIDER` env var or `--provider` flag. Stage-aware overrides
   via `SCRAPE_DISCOVER_PROVIDER` and `SCRAPE_FETCH_PROVIDER`. Mirrors the
   layout of `src/llm_providers/` (ADR-0009, ADR-0010).
-- Crawl4AI local backend, opt-in via
-  `pip install king-context[crawl4ai] && crawl4ai-setup` (ADR-0011).
+- Crawl4AI local backend (beta, ADR-0011). Bundled by default in the
+  `[all]` extra that `npx @king-context/cli init` runs, so the package
+  ships in the project venv. Activation only requires running
+  `crawl4ai-setup` once to download the Playwright chromium.
 - `.github/workflows/test.yml` with a `test` job (pytest on the firecrawl
   path) and a `smoke-crawl4ai` job that runs `scripts/smoke-crawl4ai.py`
   to detect API churn across `crawl4ai>=0.8.5,<0.9` minor versions.
@@ -22,11 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `firecrawl-py` moved from core dependencies to the `[firecrawl]` extra.
-  `pip install king-context[all]` (run by `npx @king-context/cli init`)
-  installs everything as before. No breaking change for the default flow.
+  `npx @king-context/cli init` continues to install everything via the
+  `[all]` extra, so the default flow is preserved with no breaking
+  change.
 - `installer/lib/python.js` now installs `king-context[all]` via PEP 508
-  direct reference, so `init` and `update` keep pulling the firecrawl
-  extra after the core dependency move.
+  direct reference (`king-context[all] @ git+...`), so `init` and
+  `update` keep pulling firecrawl-py and crawl4ai after the core
+  dependency move.
 
 ## [0.3.2] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-06
+
 ### Added
 
 - Pluggable scraper provider abstraction for `king-scrape`. Choose backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pluggable scraper provider abstraction for `king-scrape`. Choose backend
+  via `SCRAPE_PROVIDER` env var or `--provider` flag. Stage-aware overrides
+  via `SCRAPE_DISCOVER_PROVIDER` and `SCRAPE_FETCH_PROVIDER`. Mirrors the
+  layout of `src/llm_providers/` (ADR-0009, ADR-0010).
+- Crawl4AI local backend, opt-in via
+  `pip install king-context[crawl4ai] && crawl4ai-setup` (ADR-0011).
+- `.github/workflows/test.yml` with a `test` job (pytest on the firecrawl
+  path) and a `smoke-crawl4ai` job that runs `scripts/smoke-crawl4ai.py`
+  to detect API churn across `crawl4ai>=0.8.5,<0.9` minor versions.
+
+### Changed
+
+- `firecrawl-py` moved from core dependencies to the `[firecrawl]` extra.
+  `pip install king-context[all]` (run by `npx @king-context/cli init`)
+  installs everything as before. No breaking change for the default flow.
+- `installer/lib/python.js` now installs `king-context[all]` via PEP 508
+  direct reference, so `init` and `update` keep pulling the firecrawl
+  extra after the core dependency move.
+
 ## [0.3.2] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Full command reference in [`docs/CLI_GUIDE.md`](docs/CLI_GUIDE.md).
 
 ## Scraper providers
 
-`king-scrape` supports pluggable scraper backends. The default is Firecrawl (cloud, zero-config, pay per page). Crawl4AI is available as a local opt-in backend.
+`king-scrape` supports pluggable scraper backends. The default is Firecrawl (cloud, zero-config, pay per page). Crawl4AI is the first local opt-in backend, added so users can index documentation without external credits, without sending HTML through a third party, and with full transparency over the HTML to Markdown conversion. It also unblocks indexing private or internal docs that should not leave your machine.
+
+Crawl4AI support is **beta**. If something breaks or feels off, open an issue at [github.com/deandevz/king-context/issues](https://github.com/deandevz/king-context/issues) with the URL, the command, and the error. Improvements are welcome.
 
 Default (Firecrawl, no install needed beyond `init`):
 
@@ -82,20 +84,33 @@ king-scrape https://docs.example.com
 
 Requires `FIRECRAWL_API_KEY` in `.env`.
 
-Local mode (Crawl4AI, free, ~300MB Playwright install):
+### Enable Crawl4AI
+
+If you installed via `npx @king-context/cli init`, the Crawl4AI Python package is already in the project venv (bundled by `[all]`). You only need to download the Playwright browser once (~300MB):
 
 ```bash
-pip install king-context[crawl4ai] && crawl4ai-setup
-SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com
+.king-context/core/venv/bin/crawl4ai-setup
 ```
 
-Or with a flag for a single run:
+Then pick the backend per run:
 
 ```bash
 king-scrape https://docs.example.com --provider=crawl4ai
 ```
 
-Mixing providers per stage:
+Or set it as the default for the project:
+
+```bash
+SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com
+```
+
+Standalone pip install (without the npm installer):
+
+```bash
+pip install king-context[crawl4ai] && crawl4ai-setup
+```
+
+### Mixing providers per stage
 
 ```bash
 SCRAPE_DISCOVER_PROVIDER=crawl4ai SCRAPE_FETCH_PROVIDER=firecrawl king-scrape https://docs.example.com
@@ -103,7 +118,7 @@ SCRAPE_DISCOVER_PROVIDER=crawl4ai SCRAPE_FETCH_PROVIDER=firecrawl king-scrape ht
 
 Useful when one backend handles a stage better than the other (for example, Crawl4AI for SPA discovery, Firecrawl for stable fetch).
 
-Environment variables:
+### Environment variables
 
 | Variable | Effect |
 |----------|--------|

--- a/README.md
+++ b/README.md
@@ -70,6 +70,49 @@ Full command reference in [`docs/CLI_GUIDE.md`](docs/CLI_GUIDE.md).
 
 **One retrieval surface, many corpora.** Vendor docs, research sweeps, internal runbooks, and ADRs are all reachable through the same CLI primitives.
 
+## Scraper providers
+
+`king-scrape` supports pluggable scraper backends. The default is Firecrawl (cloud, zero-config, pay per page). Crawl4AI is available as a local opt-in backend.
+
+Default (Firecrawl, no install needed beyond `init`):
+
+```bash
+king-scrape https://docs.example.com
+```
+
+Requires `FIRECRAWL_API_KEY` in `.env`.
+
+Local mode (Crawl4AI, free, ~300MB Playwright install):
+
+```bash
+pip install king-context[crawl4ai] && crawl4ai-setup
+SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com
+```
+
+Or with a flag for a single run:
+
+```bash
+king-scrape https://docs.example.com --provider=crawl4ai
+```
+
+Mixing providers per stage:
+
+```bash
+SCRAPE_DISCOVER_PROVIDER=crawl4ai SCRAPE_FETCH_PROVIDER=firecrawl king-scrape https://docs.example.com
+```
+
+Useful when one backend handles a stage better than the other (for example, Crawl4AI for SPA discovery, Firecrawl for stable fetch).
+
+Environment variables:
+
+| Variable | Effect |
+|----------|--------|
+| `SCRAPE_PROVIDER` | Sets provider for both stages. Default `firecrawl`. |
+| `SCRAPE_DISCOVER_PROVIDER` | Overrides `SCRAPE_PROVIDER` for the `discover` stage only. |
+| `SCRAPE_FETCH_PROVIDER` | Overrides `SCRAPE_PROVIDER` for the `fetch` stage only. |
+
+Stage-specific variables take precedence over `SCRAPE_PROVIDER` and over the `--provider` flag. Full reference in [`docs/CLI_GUIDE.md`](docs/CLI_GUIDE.md).
+
 ## How it works
 
 Every section of every scraped page or researched source ends up annotated:

--- a/README.md
+++ b/README.md
@@ -104,11 +104,13 @@ Or set it as the default for the project:
 SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com
 ```
 
-Standalone pip install (without the npm installer):
+Cloned the repo for development? From the repo root:
 
 ```bash
-pip install king-context[crawl4ai] && crawl4ai-setup
+pip install -e ".[crawl4ai]" && crawl4ai-setup
 ```
+
+A standalone PyPI distribution (`pip install king-context`) is on the roadmap.
 
 ### Mixing providers per stage
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -406,24 +406,34 @@ Requires `FIRECRAWL_API_KEY` in `.env`. No additional install beyond
 
 #### Local mode (Crawl4AI)
 
-Install once:
+If you installed via `npx @king-context/cli init`, the Crawl4AI Python
+package is already in the project venv (bundled by the `[all]` extra).
+You only need to download the Playwright browser once:
 
 ```bash
-pip install king-context[crawl4ai]
-crawl4ai-setup
+.king-context/core/venv/bin/crawl4ai-setup
 ```
 
-Then run with the env var:
+Then pick the backend per run:
+
+```bash
+king-scrape https://docs.example.com --provider=crawl4ai
+```
+
+Or set it as the default for the project:
 
 ```bash
 SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com
 ```
 
-Or with a flag for a single run:
+Cloned the repo for development? Run from the repo root:
 
 ```bash
-king-scrape https://docs.example.com --provider=crawl4ai
+pip install -e ".[crawl4ai]" && crawl4ai-setup
 ```
+
+A standalone PyPI distribution (`pip install king-context`) is on the
+roadmap.
 
 #### Mixing providers per stage
 
@@ -456,10 +466,11 @@ The provider name is misspelled or not installed. Check the spelling of
 `--provider`, `SCRAPE_PROVIDER`, `SCRAPE_DISCOVER_PROVIDER`, and
 `SCRAPE_FETCH_PROVIDER`. The error message lists the registered providers.
 
-`ProviderUnavailableError: Crawl4AI not installed. Run: pip install king-context[crawl4ai] && crawl4ai-setup`
+`ProviderUnavailableError: crawl4ai not installed in the active Python environment...`
 
-The Crawl4AI extra is not installed in the active venv. Run the install
-command exactly as shown, then retry.
+The Crawl4AI package is not in the active venv. For npx-installed
+projects, run `npx @king-context/cli update`. For dev clones, run
+`pip install -e ".[crawl4ai]" && crawl4ai-setup` from the repo root.
 
 `ProviderUnavailableError: Crawl4AI installed but Playwright browser missing. Run: crawl4ai-setup`
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -361,9 +361,116 @@ Useful flags:
 - `--no-auto-seed`: skip database seeding after export.
 - `--include-maybe`: fetch URLs classified as `maybe`.
 - `--yes`: skip interactive confirmation prompts.
+- `--provider <name>`: choose the scraper backend for this run. Sets
+  `SCRAPE_PROVIDER` for the process. Stage-specific environment variables
+  take precedence over the flag. See [Scraper providers](#scraper-providers)
+  for the full table.
 
 `king-scrape` writes exported documentation JSON to `.king-context/data/`.
 Use `kctx index` to build or rebuild the file-based CLI store from that JSON.
+
+### Scraper providers
+
+`king-scrape` supports pluggable scraper backends. The default is Firecrawl
+(cloud, zero-config, pay per page). Crawl4AI is available as a local opt-in
+backend (free, requires a one-time ~300MB Playwright install).
+
+Resolution rules:
+
+1. `SCRAPE_DISCOVER_PROVIDER` and `SCRAPE_FETCH_PROVIDER` set the backend for
+   their respective stages.
+2. `SCRAPE_PROVIDER` sets the backend for both stages when the stage-specific
+   variables are not set.
+3. `--provider <name>` is shorthand for setting `SCRAPE_PROVIDER` for one run.
+4. When nothing is set, both stages use `firecrawl`.
+
+Stage-specific environment variables always win over the flag and over
+`SCRAPE_PROVIDER`.
+
+Environment variables:
+
+| Variable | Effect |
+|----------|--------|
+| `SCRAPE_PROVIDER` | Sets provider for both stages. Default `firecrawl`. |
+| `SCRAPE_DISCOVER_PROVIDER` | Overrides `SCRAPE_PROVIDER` for the `discover` stage only. |
+| `SCRAPE_FETCH_PROVIDER` | Overrides `SCRAPE_PROVIDER` for the `fetch` stage only. |
+
+#### Default (Firecrawl)
+
+```bash
+king-scrape https://docs.example.com
+```
+
+Requires `FIRECRAWL_API_KEY` in `.env`. No additional install beyond
+`npx @king-context/cli init`.
+
+#### Local mode (Crawl4AI)
+
+Install once:
+
+```bash
+pip install king-context[crawl4ai]
+crawl4ai-setup
+```
+
+Then run with the env var:
+
+```bash
+SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com
+```
+
+Or with a flag for a single run:
+
+```bash
+king-scrape https://docs.example.com --provider=crawl4ai
+```
+
+#### Mixing providers per stage
+
+Crawl4AI for SPA-style discovery plus Firecrawl for stable fetch:
+
+```bash
+SCRAPE_DISCOVER_PROVIDER=crawl4ai SCRAPE_FETCH_PROVIDER=firecrawl king-scrape https://docs.example.com
+```
+
+Stage-specific variables take precedence over `SCRAPE_PROVIDER` and over
+`--provider`.
+
+#### Resume across providers
+
+The pipeline checkpoint is keyed by URL slug, not by provider. Resuming a
+partial run with a different backend works:
+
+```bash
+SCRAPE_PROVIDER=firecrawl king-scrape https://docs.example.com --stop-after fetch
+SCRAPE_PROVIDER=crawl4ai king-scrape https://docs.example.com --step chunk
+```
+
+URLs already fetched with one backend are not re-fetched when you switch.
+
+#### Troubleshooting
+
+`Unknown discovery provider 'X'. Registered: ['crawl4ai', 'firecrawl']`
+
+The provider name is misspelled or not installed. Check the spelling of
+`--provider`, `SCRAPE_PROVIDER`, `SCRAPE_DISCOVER_PROVIDER`, and
+`SCRAPE_FETCH_PROVIDER`. The error message lists the registered providers.
+
+`ProviderUnavailableError: Crawl4AI not installed. Run: pip install king-context[crawl4ai] && crawl4ai-setup`
+
+The Crawl4AI extra is not installed in the active venv. Run the install
+command exactly as shown, then retry.
+
+`ProviderUnavailableError: Crawl4AI installed but Playwright browser missing. Run: crawl4ai-setup`
+
+The Python package is installed but the chromium binary is not. Run
+`crawl4ai-setup` once. The setup downloads about 300MB on first run.
+
+`FIRECRAWL_API_KEY missing` (or equivalent SDK error)
+
+Firecrawl is selected (default) but no API key is set. Add
+`FIRECRAWL_API_KEY=...` to `.env`, or switch to Crawl4AI with
+`--provider=crawl4ai`.
 
 ## LLM Provider Configuration
 

--- a/installer/lib/python.js
+++ b/installer/lib/python.js
@@ -105,7 +105,7 @@ function installPackage(projectDir) {
 
   execFileSync(
     python,
-    ['-m', 'pip', 'install', '--no-cache-dir', 'git+https://github.com/deandevz/king-context.git'],
+    ['-m', 'pip', 'install', '--no-cache-dir', 'king-context[all] @ git+https://github.com/deandevz/king-context.git'],
     { stdio: 'pipe', timeout: 300000, windowsHide: true }
   );
 }
@@ -126,7 +126,7 @@ function upgradePackage(projectDir) {
       '--force-reinstall',
       '--no-deps',
       '--no-cache-dir',
-      'git+https://github.com/deandevz/king-context.git',
+      'king-context[all] @ git+https://github.com/deandevz/king-context.git',
     ],
     { stdio: 'pipe', timeout: 300000, windowsHide: true }
   );

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@king-context/cli",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Installer for King Context — local-first documentation search for AI agents",
   "bin": {
     "king-context": "./bin/king-context.js"

--- a/installer/templates/env.example
+++ b/installer/templates/env.example
@@ -1,11 +1,20 @@
-# King Context — API Keys
+# King Context: API Keys
 # Copy this file to .env at your project root
 
-# Required — Firecrawl API key for documentation scraping
+# Required for default scraper. Firecrawl API key for documentation scraping.
 # Get yours at https://firecrawl.dev
 FIRECRAWL_API_KEY=
 
-# Optional — OpenRouter API key for OpenRouter LLM stages or Ollama fallback
+# Scraper provider selection (king-scrape)
+# Default: firecrawl (requires FIRECRAWL_API_KEY).
+# Other options: crawl4ai (local; install via 'pip install king-context[crawl4ai] && crawl4ai-setup')
+# SCRAPE_PROVIDER=firecrawl
+#
+# Stage-specific overrides (precedence: stage var > SCRAPE_PROVIDER > default 'firecrawl'):
+# SCRAPE_DISCOVER_PROVIDER=crawl4ai
+# SCRAPE_FETCH_PROVIDER=firecrawl
+
+# Optional. OpenRouter API key for OpenRouter LLM stages or Ollama fallback.
 # Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=
 
@@ -38,13 +47,13 @@ CONCURRENCY_OLLAMA=2
 ENABLE_FALLBACK=false
 FALLBACK_MODEL=google/gemini-3-flash-preview
 
-# Required — Exa API key for king-research topic-driven web search
-# Powers semantic search and content retrieval for the research pipeline
+# Required for king-research. Exa API key for topic-driven web search.
+# Powers semantic search and content retrieval for the research pipeline.
 # Get yours at https://dashboard.exa.ai/api-keys
 EXA_API_KEY=
 
-# Optional — Jina API key for reranking and embeddings in king-research
-# The anonymous tier works for light use; set a key to raise rate limits
+# Optional. Jina API key for reranking and embeddings in king-research.
+# The anonymous tier works for light use; set a key to raise rate limits.
 # Get yours at https://jina.ai/api
 JINA_API_KEY=
 
@@ -52,7 +61,7 @@ JINA_API_KEY=
 # Prefer RESEARCH_MODEL above for new configs.
 OPENROUTER_MODEL_RESEARCH=
 
-# Optional — Effort-ladder overrides for king-research
+# Optional. Effort-ladder overrides for king-research.
 # Uncomment any line to override the built-in defaults shown below
 #RESEARCH_BASIC_QUERIES=3
 #RESEARCH_MEDIUM_QUERIES=5

--- a/installer/templates/env.example
+++ b/installer/templates/env.example
@@ -7,7 +7,7 @@ FIRECRAWL_API_KEY=
 
 # Scraper provider selection (king-scrape)
 # Default: firecrawl (requires FIRECRAWL_API_KEY).
-# Other options: crawl4ai (local; install via 'pip install king-context[crawl4ai] && crawl4ai-setup')
+# Other options: crawl4ai (local, beta; bundled by 'npx @king-context/cli init', activate with 'crawl4ai-setup')
 # SCRAPE_PROVIDER=firecrawl
 #
 # Stage-specific overrides (precedence: stage var > SCRAPE_PROVIDER > default 'firecrawl'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "king-context"
-version = "0.3.2"
+version = "0.4.0"
 description = "Local-first, token-efficient documentation server for LLM context injection"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "sentence-transformers>=2.2.0",
     "numpy>=1.24.0",
     "python-dotenv>=1.0.0",
-    "firecrawl-py>=1.0.0",
     "httpx>=0.27.0",
     "exa-py>=1.0.0",
     "markdown>=3.5",
@@ -47,12 +46,19 @@ dev = [
     "pytest-asyncio>=0.25.0",
     "respx>=0.22.0",
 ]
+firecrawl = ["firecrawl-py>=1.0.0"]
+crawl4ai = ["crawl4ai>=0.8.5,<0.9"]
+all = ["king-context[firecrawl,crawl4ai]"]
 
 [project.scripts]
 king-context-server = "king_context.server:main"
 king-scrape = "king_context.scraper.cli:main"
 king-research = "king_context.research.cli:main"
 kctx = "context_cli.cli:main"
+
+[project.entry-points."king_context.scraper_providers"]
+firecrawl = "scraper_providers.firecrawl_provider:register"
+crawl4ai = "scraper_providers.crawl4ai_provider:register"
 
 [project.urls]
 Homepage = "https://github.com/deandevz/king-context"
@@ -64,7 +70,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/king_context", "src/context_cli", "src/llm_providers"]
+packages = ["src/king_context", "src/context_cli", "src/llm_providers", "src/scraper_providers"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/smoke-crawl4ai.py
+++ b/scripts/smoke-crawl4ai.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Smoke test for the Crawl4AI scraper provider.
+
+Run after `pip install -e ".[crawl4ai,dev]" && crawl4ai-setup`.
+Manual only — not wired to CI by this task (Task 5 covers gated CI).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from scraper_providers import get_discovery_provider, get_fetch_provider
+
+
+async def main() -> None:
+    fp = get_fetch_provider("crawl4ai")
+    page = await fp.fetch_one("https://example.com")
+    print(f"fetch ok — url={page.url} markdown_len={len(page.markdown)} title={page.title!r}")
+
+    dp = get_discovery_provider("crawl4ai")
+    urls = await dp.discover_urls("https://example.com")
+    print(f"discover ok — found {len(urls)} urls")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/king_context/scraper/cli.py
+++ b/src/king_context/scraper/cli.py
@@ -1,8 +1,17 @@
 import argparse
 import asyncio
 import json
+import os
+import sys
 from pathlib import Path
 from urllib.parse import urlparse
+
+from scraper_providers import (
+    ProviderUnavailableError,
+    get_discovery_provider,
+    get_fetch_provider,
+    resolve_provider_name,
+)
 
 from king_context import PROJECT_ROOT
 from king_context.scraper.chunk import Chunk, chunk_pages
@@ -108,6 +117,15 @@ async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
     name = args.name or _name_from_url(args.url)
     display_name = getattr(args, "display_name", None) or name.replace("-", " ").title()
 
+    flag_provider = getattr(args, "provider", None)
+    if flag_provider:
+        # Stage-specific envs always win (per ADR-0009). setdefault preserves
+        # an existing SCRAPE_PROVIDER but overrides the implicit 'firecrawl' default.
+        os.environ.setdefault("SCRAPE_PROVIDER", flag_provider)
+
+    discovery_provider = get_discovery_provider(resolve_provider_name("discover"))
+    fetch_provider = get_fetch_provider(resolve_provider_name("fetch"))
+
     work_dir = get_work_dir(args.url)
     work_dir.mkdir(parents=True, exist_ok=True)
 
@@ -163,7 +181,7 @@ async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
         print(f"[{step}] running...")
 
         if step == "discover":
-            discovery_result = await discover_urls(args.url, config)
+            discovery_result = await discover_urls(args.url, config, discovery_provider)
             print(f"  found {discovery_result.total_urls} URLs")
 
         elif step == "filter":
@@ -186,7 +204,7 @@ async def run_pipeline(args: argparse.Namespace, config: ScraperConfig) -> None:
             urls_to_fetch = filter_result.accepted[:]
             if getattr(args, "include_maybe", False):
                 urls_to_fetch += filter_result.maybe
-            fetch_result = await fetch_pages(urls_to_fetch, work_dir, config)
+            fetch_result = await fetch_pages(urls_to_fetch, work_dir, config, fetch_provider)
             print(f"  fetched {fetch_result.completed}/{fetch_result.total} pages")
 
         elif step == "chunk":
@@ -314,6 +332,17 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip interactive confirmations (e.g. enrichment cost prompt)",
     )
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default=None,
+        help=(
+            "Scraper provider name (e.g. 'firecrawl', 'crawl4ai'). "
+            "Sets SCRAPE_PROVIDER for this run. "
+            "Stage-specific envs (SCRAPE_DISCOVER_PROVIDER / SCRAPE_FETCH_PROVIDER) "
+            "have precedence."
+        ),
+    )
     return parser
 
 
@@ -327,7 +356,14 @@ def main() -> None:
         concurrency=args.concurrency,
         filter_llm_fallback=not args.no_llm_filter,
     )
-    asyncio.run(run_pipeline(args, config))
+    try:
+        asyncio.run(run_pipeline(args, config))
+    except ProviderUnavailableError as exc:
+        print(f"error: {exc.hint}", file=sys.stderr)
+        sys.exit(3)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/src/king_context/scraper/config.py
+++ b/src/king_context/scraper/config.py
@@ -17,6 +17,9 @@ class ScraperConfig:
     chunk_min_tokens: int = 100
     concurrency: int = 5
     filter_llm_fallback: bool = True
+    scrape_provider: str | None = None
+    scrape_discover_provider: str | None = None
+    scrape_fetch_provider: str | None = None
 
 
 def get_firecrawl_key() -> str:
@@ -45,6 +48,9 @@ def load_config(**overrides) -> ScraperConfig:
         firecrawl_api_key=firecrawl_api_key,
         openrouter_api_key=openrouter_api_key,
         enrichment_model=enrichment_model,
+        scrape_provider=os.environ.get("SCRAPE_PROVIDER") or None,
+        scrape_discover_provider=os.environ.get("SCRAPE_DISCOVER_PROVIDER") or None,
+        scrape_fetch_provider=os.environ.get("SCRAPE_FETCH_PROVIDER") or None,
     )
 
     for key, value in overrides.items():

--- a/src/king_context/scraper/discover.py
+++ b/src/king_context/scraper/discover.py
@@ -1,11 +1,10 @@
-import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
-from firecrawl import FirecrawlApp
+from scraper_providers import DiscoveryProvider
 
 from king_context import PROJECT_ROOT
 from king_context.scraper.config import ScraperConfig
@@ -51,15 +50,15 @@ def _update_step(work_dir: Path, step: str, stats: dict) -> None:
     _save_manifest(work_dir, manifest)
 
 
-async def discover_urls(base_url: str, config: ScraperConfig) -> DiscoveryResult:
+async def discover_urls(
+    base_url: str,
+    config: ScraperConfig,
+    provider: DiscoveryProvider,
+) -> DiscoveryResult:
     work_dir = get_work_dir(base_url)
     work_dir.mkdir(parents=True, exist_ok=True)
 
-    app = FirecrawlApp(api_key=config.firecrawl_api_key)
-    loop = asyncio.get_running_loop()
-    raw = await loop.run_in_executor(None, lambda: app.map(base_url))
-    links = raw.links if hasattr(raw, "links") else (raw if isinstance(raw, list) else raw.get("links", []))
-    urls = [lnk.url if hasattr(lnk, "url") else str(lnk) for lnk in (links or [])]
+    urls = await provider.discover_urls(base_url)
 
     discovered_at = datetime.now(timezone.utc).isoformat()
     result = DiscoveryResult(

--- a/src/king_context/scraper/fetch.py
+++ b/src/king_context/scraper/fetch.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from firecrawl import FirecrawlApp
+from scraper_providers import FetchProvider
 
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.discover import _update_step
@@ -36,13 +36,12 @@ async def _fetch_one(
     url: str,
     semaphore: asyncio.Semaphore,
     pages_dir: Path,
-    app: FirecrawlApp,
+    provider: FetchProvider,
 ) -> PageResult:
     async with semaphore:
         try:
-            loop = asyncio.get_running_loop()
-            raw = await loop.run_in_executor(None, lambda: app.scrape(url, formats=["markdown"]))
-            markdown = raw.markdown if hasattr(raw, "markdown") else (raw.get("markdown", "") if isinstance(raw, dict) else str(raw))
+            page = await provider.fetch_one(url)
+            markdown = page.markdown
             slug = _url_to_slug(url)
             (pages_dir / f"{slug}.md").write_text(markdown)
             return PageResult(url=url, markdown=markdown, success=True, error=None)
@@ -54,6 +53,7 @@ async def fetch_pages(
     urls: list[str],
     output_dir: Path,
     config: ScraperConfig,
+    provider: FetchProvider,
 ) -> FetchResult:
     pages_dir = output_dir / "pages"
     pages_dir.mkdir(parents=True, exist_ok=True)
@@ -65,14 +65,13 @@ async def fetch_pages(
     if skipped > 0:
         print(f"Resuming: {skipped} pages already fetched, {len(pending_urls)} remaining")
 
-    app = FirecrawlApp(api_key=config.firecrawl_api_key)
     semaphore = asyncio.Semaphore(config.concurrency)
 
     total = len(urls)
     progress = {"completed": skipped, "failed": 0}
 
     async def _fetch_and_track(url: str) -> PageResult:
-        result = await _fetch_one(url, semaphore, pages_dir, app)
+        result = await _fetch_one(url, semaphore, pages_dir, provider)
         if result.success:
             progress["completed"] += 1
         else:

--- a/src/scraper_providers/__init__.py
+++ b/src/scraper_providers/__init__.py
@@ -1,0 +1,45 @@
+"""Pluggable scraper providers for king-scrape.
+
+Built-in providers are registered via soft import. If their optional
+dependency (firecrawl-py, crawl4ai) is not installed, registration
+is skipped — selecting that provider will raise ProviderUnavailableError
+at resolution time with an install hint.
+"""
+from __future__ import annotations
+
+from .base import (
+    DiscoveryProvider,
+    FetchProvider,
+    PageContent,
+    ProviderUnavailableError,
+)
+from .registry import (
+    get_discovery_provider,
+    get_fetch_provider,
+    load_entry_point_providers,
+    register_discovery_provider,
+    register_fetch_provider,
+    resolve_provider_name,
+)
+
+# Built-in providers — soft import (added by Tasks 2 and 3).
+# Pattern (do NOT add until provider modules exist):
+# try:
+#     from . import firecrawl_provider  # noqa: F401  -- side effect: registers
+# except ImportError:
+#     pass
+
+# Third-party plugins via entry_points (after built-ins so built-ins win conflicts).
+load_entry_point_providers()
+
+__all__ = [
+    "DiscoveryProvider",
+    "FetchProvider",
+    "PageContent",
+    "ProviderUnavailableError",
+    "register_discovery_provider",
+    "register_fetch_provider",
+    "get_discovery_provider",
+    "get_fetch_provider",
+    "resolve_provider_name",
+]

--- a/src/scraper_providers/__init__.py
+++ b/src/scraper_providers/__init__.py
@@ -31,6 +31,14 @@ try:
 except ImportError:
     pass
 
+try:
+    from scraper_providers.crawl4ai_provider import (  # pyright: ignore[reportMissingImports]
+        register as _register_crawl4ai,
+    )
+    _register_crawl4ai()
+except ImportError:
+    pass
+
 # Third-party plugins via entry_points (after built-ins so built-ins win conflicts).
 load_entry_point_providers()
 

--- a/src/scraper_providers/__init__.py
+++ b/src/scraper_providers/__init__.py
@@ -22,12 +22,14 @@ from .registry import (
     resolve_provider_name,
 )
 
-# Built-in providers — soft import (added by Tasks 2 and 3).
-# Pattern (do NOT add until provider modules exist):
-# try:
-#     from . import firecrawl_provider  # noqa: F401  -- side effect: registers
-# except ImportError:
-#     pass
+# Built-in providers — soft import.
+try:
+    from scraper_providers.firecrawl_provider import (  # pyright: ignore[reportMissingImports]
+        register as _register_firecrawl,
+    )
+    _register_firecrawl()
+except ImportError:
+    pass
 
 # Third-party plugins via entry_points (after built-ins so built-ins win conflicts).
 load_entry_point_providers()

--- a/src/scraper_providers/base.py
+++ b/src/scraper_providers/base.py
@@ -1,0 +1,41 @@
+"""Common scraper provider interfaces."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class PageContent:
+    url: str
+    markdown: str
+    fetched_at: datetime
+    title: str | None = None
+
+
+class ProviderUnavailableError(RuntimeError):
+    """Raised when a provider is selected but its dependency is not installed
+    or its setup step (e.g. crawl4ai-setup) has not been run.
+
+    Carries an actionable install/setup hint, not a raw ImportError traceback.
+    """
+
+    def __init__(self, provider: str, hint: str):
+        self.provider = provider
+        self.hint = hint
+        super().__init__(f"Provider '{provider}' unavailable: {hint}")
+
+
+@runtime_checkable
+class DiscoveryProvider(Protocol):
+    name: str
+
+    async def discover_urls(self, base_url: str) -> list[str]: ...
+
+
+@runtime_checkable
+class FetchProvider(Protocol):
+    name: str
+
+    async def fetch_one(self, url: str) -> PageContent: ...

--- a/src/scraper_providers/crawl4ai_provider.py
+++ b/src/scraper_providers/crawl4ai_provider.py
@@ -1,0 +1,151 @@
+"""Crawl4AI scraper provider — local Playwright-based backend."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from .base import (
+    PageContent,
+    ProviderUnavailableError,
+)
+from .registry import register_discovery_provider, register_fetch_provider
+
+try:
+    from crawl4ai import (  # type: ignore[import-not-found]
+        AsyncWebCrawler,
+        BrowserConfig,
+        CrawlerRunConfig,
+    )
+    from crawl4ai.deep_crawling import (  # type: ignore[import-not-found]
+        BFSDeepCrawlStrategy,
+    )
+    _CRAWL4AI_AVAILABLE = True
+except ImportError:
+    AsyncWebCrawler = None  # type: ignore[assignment,misc]
+    BrowserConfig = None  # type: ignore[assignment,misc]
+    CrawlerRunConfig = None  # type: ignore[assignment,misc]
+    BFSDeepCrawlStrategy = None  # type: ignore[assignment,misc]
+    _CRAWL4AI_AVAILABLE = False
+
+
+_INSTALL_HINT = (
+    "crawl4ai not installed. Run: "
+    "pip install king-context[crawl4ai] && crawl4ai-setup"
+)
+_SETUP_HINT = (
+    "crawl4ai installed but Playwright browser (chromium) missing. "
+    "Run: crawl4ai-setup"
+)
+_BROWSER_MISSING_MARKERS = ("executable doesn't exist", "playwright install")
+
+
+def _ensure_available() -> None:
+    if not _CRAWL4AI_AVAILABLE:
+        raise ProviderUnavailableError("crawl4ai", _INSTALL_HINT)
+
+
+def _ensure_browser_present() -> None:
+    """Heuristic: confirm Playwright is importable. The real check happens at
+    arun() time — Playwright raises a clear "executable doesn't exist" error
+    if the browser binary is missing, which we translate in _is_browser_missing.
+    """
+    from importlib.util import find_spec
+
+    if find_spec("playwright") is None:
+        raise ProviderUnavailableError("crawl4ai", _SETUP_HINT)
+
+
+def _is_browser_missing(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _BROWSER_MISSING_MARKERS)
+
+
+def _extract_markdown(result: Any) -> str:
+    """Crawl4AI exposes `markdown` as a property returning StringCompatibleMarkdown
+    (a str subclass) or None. Coerce to plain str."""
+    md = getattr(result, "markdown", None)
+    if md is None:
+        return ""
+    return str(md)
+
+
+def _extract_title(result: Any) -> str | None:
+    """Title lives on result.metadata['title'] in Crawl4AI's CrawlResult shape.
+    metadata may be None or absent."""
+    metadata = getattr(result, "metadata", None)
+    if metadata is None:
+        return None
+    if isinstance(metadata, dict):
+        title = metadata.get("title")
+        return title or None
+    title = getattr(metadata, "title", None)
+    return title or None
+
+
+def _iter_results(results: Any) -> Iterable[Any]:
+    """Deep-crawl batch mode returns a list[CrawlResult]; single fetch returns
+    a CrawlResultContainer (iterable). Normalize both to an iterable."""
+    if results is None:
+        return []
+    if isinstance(results, list):
+        return results
+    if hasattr(results, "__iter__"):
+        return results
+    return [results]
+
+
+class Crawl4AIDiscoveryProvider:
+    name = "crawl4ai"
+
+    async def discover_urls(self, base_url: str) -> list[str]:
+        _ensure_available()
+        _ensure_browser_present()
+        run_config = CrawlerRunConfig(  # type: ignore[misc]
+            deep_crawl_strategy=BFSDeepCrawlStrategy(  # type: ignore[misc]
+                max_depth=2, include_external=False
+            ),
+        )
+        try:
+            async with AsyncWebCrawler(  # type: ignore[misc]
+                config=BrowserConfig(headless=True),  # type: ignore[misc]
+            ) as crawler:
+                results = await crawler.arun(url=base_url, config=run_config)
+        except Exception as exc:
+            if _is_browser_missing(exc):
+                raise ProviderUnavailableError("crawl4ai", _SETUP_HINT) from exc
+            raise
+        urls: list[str] = []
+        for r in _iter_results(results):
+            u = getattr(r, "url", None)
+            if u:
+                urls.append(u)
+        return urls
+
+
+class Crawl4AIFetchProvider:
+    name = "crawl4ai"
+
+    async def fetch_one(self, url: str) -> PageContent:
+        _ensure_available()
+        _ensure_browser_present()
+        try:
+            async with AsyncWebCrawler(  # type: ignore[misc]
+                config=BrowserConfig(headless=True),  # type: ignore[misc]
+            ) as crawler:
+                result = await crawler.arun(url=url)
+        except Exception as exc:
+            if _is_browser_missing(exc):
+                raise ProviderUnavailableError("crawl4ai", _SETUP_HINT) from exc
+            raise
+        return PageContent(
+            url=url,
+            markdown=_extract_markdown(result),
+            title=_extract_title(result),
+            fetched_at=datetime.now(timezone.utc),
+        )
+
+
+def register() -> None:
+    """Entry-point hook. Idempotent (registry is first-write-wins)."""
+    register_discovery_provider("crawl4ai", lambda: Crawl4AIDiscoveryProvider())
+    register_fetch_provider("crawl4ai", lambda: Crawl4AIFetchProvider())

--- a/src/scraper_providers/crawl4ai_provider.py
+++ b/src/scraper_providers/crawl4ai_provider.py
@@ -29,8 +29,11 @@ except ImportError:
 
 
 _INSTALL_HINT = (
-    "crawl4ai not installed. Run: "
-    "pip install king-context[crawl4ai] && crawl4ai-setup"
+    "crawl4ai not installed in the active Python environment. "
+    "If you installed via npx @king-context/cli, run "
+    "'npx @king-context/cli update' to refresh the venv. "
+    "If you cloned the repo for development, run "
+    "'pip install -e \".[crawl4ai]\" && crawl4ai-setup'."
 )
 _SETUP_HINT = (
     "crawl4ai installed but Playwright browser (chromium) missing. "

--- a/src/scraper_providers/firecrawl_provider.py
+++ b/src/scraper_providers/firecrawl_provider.py
@@ -1,0 +1,99 @@
+"""Firecrawl scraper provider — wraps the firecrawl-py SDK."""
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from .base import (
+    PageContent,
+    ProviderUnavailableError,
+)
+from .registry import register_discovery_provider, register_fetch_provider
+
+try:
+    from firecrawl import FirecrawlApp  # type: ignore[import-not-found]
+    _FIRECRAWL_AVAILABLE = True
+except ImportError:
+    FirecrawlApp = None  # type: ignore[assignment,misc]
+    _FIRECRAWL_AVAILABLE = False
+
+
+_INSTALL_HINT = (
+    "firecrawl-py not installed. Run: pip install king-context[firecrawl] "
+    "(or king-context[all]) and set FIRECRAWL_API_KEY."
+)
+
+
+def _build_app() -> Any:
+    if not _FIRECRAWL_AVAILABLE:
+        raise ProviderUnavailableError("firecrawl", _INSTALL_HINT)
+    api_key = os.getenv("FIRECRAWL_API_KEY")
+    return FirecrawlApp(api_key=api_key)  # type: ignore[misc]
+
+
+def _extract_links(raw: Any) -> list[str]:
+    """Mirror scraper/discover.py: handle SDK object, list, or dict shapes."""
+    if hasattr(raw, "links"):
+        links = raw.links
+    elif isinstance(raw, list):
+        links = raw
+    elif isinstance(raw, dict):
+        links = raw.get("links", [])
+    else:
+        links = []
+    return [lnk.url if hasattr(lnk, "url") else str(lnk) for lnk in (links or [])]
+
+
+def _extract_markdown(raw: Any) -> str:
+    """Mirror scraper/fetch.py: handle SDK object or dict shapes."""
+    if hasattr(raw, "markdown"):
+        return raw.markdown or ""
+    if isinstance(raw, dict):
+        return raw.get("markdown", "") or ""
+    return ""
+
+
+def _extract_title(raw: Any) -> str | None:
+    """Best-effort title extraction from SDK metadata (object or dict)."""
+    metadata = getattr(raw, "metadata", None)
+    if metadata is None and isinstance(raw, dict):
+        metadata = raw.get("metadata")
+    if metadata is None:
+        return None
+    if hasattr(metadata, "title"):
+        return metadata.title or None
+    if isinstance(metadata, dict):
+        title = metadata.get("title")
+        return title or None
+    return None
+
+
+class FirecrawlDiscoveryProvider:
+    name = "firecrawl"
+
+    async def discover_urls(self, base_url: str) -> list[str]:
+        app = _build_app()
+        raw = await asyncio.to_thread(app.map, base_url)
+        return _extract_links(raw)
+
+
+class FirecrawlFetchProvider:
+    name = "firecrawl"
+
+    async def fetch_one(self, url: str) -> PageContent:
+        app = _build_app()
+        raw = await asyncio.to_thread(app.scrape, url, formats=["markdown"])
+        return PageContent(
+            url=url,
+            markdown=_extract_markdown(raw),
+            title=_extract_title(raw),
+            fetched_at=datetime.now(timezone.utc),
+        )
+
+
+def register() -> None:
+    """Entry-point hook. Idempotent (registry is first-write-wins)."""
+    register_discovery_provider("firecrawl", lambda: FirecrawlDiscoveryProvider())
+    register_fetch_provider("firecrawl", lambda: FirecrawlFetchProvider())

--- a/src/scraper_providers/firecrawl_provider.py
+++ b/src/scraper_providers/firecrawl_provider.py
@@ -21,8 +21,12 @@ except ImportError:
 
 
 _INSTALL_HINT = (
-    "firecrawl-py not installed. Run: pip install king-context[firecrawl] "
-    "(or king-context[all]) and set FIRECRAWL_API_KEY."
+    "firecrawl-py not installed in the active Python environment. "
+    "If you installed via npx @king-context/cli, run "
+    "'npx @king-context/cli update' to refresh the venv. "
+    "If you cloned the repo for development, run "
+    "'pip install -e \".[firecrawl]\"' (or '.[all]'). "
+    "Set FIRECRAWL_API_KEY before running."
 )
 
 

--- a/src/scraper_providers/registry.py
+++ b/src/scraper_providers/registry.py
@@ -1,0 +1,81 @@
+"""Scraper provider registry and stage-aware resolution."""
+from __future__ import annotations
+
+import os
+from typing import Callable, Literal
+
+from .base import DiscoveryProvider, FetchProvider
+
+Stage = Literal["discover", "fetch"]
+
+_DISCOVERY_FACTORIES: dict[str, Callable[[], DiscoveryProvider]] = {}
+_FETCH_FACTORIES: dict[str, Callable[[], FetchProvider]] = {}
+
+
+def register_discovery_provider(
+    name: str, factory: Callable[[], DiscoveryProvider]
+) -> None:
+    """Register a factory for a DiscoveryProvider. Built-ins win on conflict."""
+    if name not in _DISCOVERY_FACTORIES:
+        _DISCOVERY_FACTORIES[name] = factory
+
+
+def register_fetch_provider(
+    name: str, factory: Callable[[], FetchProvider]
+) -> None:
+    """Register a factory for a FetchProvider. Built-ins win on conflict."""
+    if name not in _FETCH_FACTORIES:
+        _FETCH_FACTORIES[name] = factory
+
+
+def get_discovery_provider(name: str) -> DiscoveryProvider:
+    if name not in _DISCOVERY_FACTORIES:
+        registered = sorted(_DISCOVERY_FACTORIES.keys())
+        raise ValueError(
+            f"Unknown discovery provider '{name}'. Registered: {registered}"
+        )
+    return _DISCOVERY_FACTORIES[name]()
+
+
+def get_fetch_provider(name: str) -> FetchProvider:
+    if name not in _FETCH_FACTORIES:
+        registered = sorted(_FETCH_FACTORIES.keys())
+        raise ValueError(
+            f"Unknown fetch provider '{name}'. Registered: {registered}"
+        )
+    return _FETCH_FACTORIES[name]()
+
+
+def resolve_provider_name(stage: Stage) -> str:
+    """Stage-aware env resolution.
+
+    Precedence:
+      SCRAPE_<STAGE>_PROVIDER  (e.g. SCRAPE_DISCOVER_PROVIDER)
+        > SCRAPE_PROVIDER
+        > 'firecrawl'  (hardcoded default)
+    """
+    stage_var = f"SCRAPE_{stage.upper()}_PROVIDER"
+    return os.getenv(stage_var) or os.getenv("SCRAPE_PROVIDER") or "firecrawl"
+
+
+def load_entry_point_providers() -> None:
+    """Load any third-party providers registered via the
+    'king_context.scraper_providers' entry_points group.
+
+    Built-ins (registered eagerly in __init__) take precedence on conflict.
+    Failure to load a third-party provider must NOT break the import — log and skip.
+    """
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:
+        return
+    try:
+        eps = entry_points(group="king_context.scraper_providers")
+    except Exception:
+        return
+    for ep in eps:
+        try:
+            register_fn = ep.load()
+            register_fn()
+        except Exception:
+            continue

--- a/tests/test_scraper/test_cli.py
+++ b/tests/test_scraper/test_cli.py
@@ -36,6 +36,7 @@ def make_args(**kwargs) -> argparse.Namespace:
         no_llm_filter=False,
         no_auto_seed=True,
         include_maybe=False,
+        provider=None,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -171,11 +172,11 @@ def test_cli_full_pipeline(tmp_path):
     enriched = [make_enriched_chunk()]
     doc_data = {"name": "example", "sections": []}
 
-    async def mock_discover(url, cfg):
+    async def mock_discover(url, cfg, provider):
         call_order.append("discover")
         return discovery
 
-    async def mock_fetch(urls, out_dir, cfg):
+    async def mock_fetch(urls, out_dir, cfg, provider):
         call_order.append("fetch")
         return fetch_res
 

--- a/tests/test_scraper/test_discover.py
+++ b/tests/test_scraper/test_discover.py
@@ -1,24 +1,35 @@
 import asyncio
 import json
-from unittest.mock import patch, MagicMock
 
 from king_context.scraper.discover import discover_urls, DiscoveryResult
 from king_context.scraper.config import ScraperConfig
 
 
+class _FakeDiscoveryProvider:
+    name = "fake"
+
+    def __init__(self, urls: list[str]):
+        self._urls = urls
+
+    async def discover_urls(self, base_url: str) -> list[str]:
+        return self._urls
+
+
 def test_discover_urls(tmp_path, monkeypatch):
     monkeypatch.setattr("king_context.scraper.discover.TEMP_DOCS_DIR", tmp_path)
 
-    mock_app = MagicMock()
-    mock_app.map.return_value = [
+    provider = _FakeDiscoveryProvider([
         "https://docs.example.com/api",
         "https://docs.example.com/guide",
-    ]
+    ])
 
-    with patch("king_context.scraper.discover.FirecrawlApp", return_value=mock_app):
-        result = asyncio.run(
-            discover_urls("https://docs.example.com", ScraperConfig(firecrawl_api_key="fc-test"))
+    result = asyncio.run(
+        discover_urls(
+            "https://docs.example.com",
+            ScraperConfig(firecrawl_api_key="fc-test"),
+            provider,
         )
+    )
 
     assert isinstance(result, DiscoveryResult)
     assert result.base_url == "https://docs.example.com"
@@ -35,13 +46,15 @@ def test_discover_urls(tmp_path, monkeypatch):
 def test_discover_creates_work_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("king_context.scraper.discover.TEMP_DOCS_DIR", tmp_path)
 
-    mock_app = MagicMock()
-    mock_app.map.return_value = []
+    provider = _FakeDiscoveryProvider([])
 
-    with patch("king_context.scraper.discover.FirecrawlApp", return_value=mock_app):
-        asyncio.run(
-            discover_urls("https://docs.example.com", ScraperConfig(firecrawl_api_key="fc-test"))
+    asyncio.run(
+        discover_urls(
+            "https://docs.example.com",
+            ScraperConfig(firecrawl_api_key="fc-test"),
+            provider,
         )
+    )
 
     work_dir = tmp_path / "docs-example-com"
     assert work_dir.exists()

--- a/tests/test_scraper/test_fetch.py
+++ b/tests/test_scraper/test_fetch.py
@@ -1,25 +1,46 @@
 import asyncio
 import json
 import threading
-from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+from scraper_providers import PageContent
 
 from king_context.scraper.fetch import fetch_pages, FetchResult
 from king_context.scraper.config import ScraperConfig
 
 
+def _page(url: str, markdown: str = "# Page Content") -> PageContent:
+    return PageContent(
+        url=url,
+        markdown=markdown,
+        title=None,
+        fetched_at=datetime.now(timezone.utc),
+    )
+
+
+class _FakeFetchProvider:
+    name = "fake"
+
+    def __init__(self, side_effect=None, fixed_markdown: str = "# Content"):
+        self._side_effect = side_effect
+        self._fixed_markdown = fixed_markdown
+
+    async def fetch_one(self, url: str) -> PageContent:
+        if self._side_effect is not None:
+            return self._side_effect(url)
+        return _page(url, self._fixed_markdown)
+
+
 def test_fetch_pages_success(tmp_path):
     config = ScraperConfig(firecrawl_api_key="fc-test")
-
-    mock_app = MagicMock()
-    mock_app.scrape.return_value = {"markdown": "# Page Content"}
+    provider = _FakeFetchProvider(fixed_markdown="# Page Content")
 
     urls = [
         "https://docs.example.com/api/intro",
         "https://docs.example.com/guide/start",
     ]
 
-    with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        result = asyncio.run(fetch_pages(urls, tmp_path, config))
+    result = asyncio.run(fetch_pages(urls, tmp_path, config, provider))
 
     assert isinstance(result, FetchResult)
     assert result.total == 2
@@ -35,21 +56,19 @@ def test_fetch_pages_success(tmp_path):
 def test_fetch_handles_failure(tmp_path):
     config = ScraperConfig(firecrawl_api_key="fc-test")
 
-    def side_effect(url, **kwargs):
+    def side_effect(url: str) -> PageContent:
         if "failing" in url:
             raise RuntimeError("Network error")
-        return {"markdown": "# Good Page"}
+        return _page(url, "# Good Page")
 
-    mock_app = MagicMock()
-    mock_app.scrape.side_effect = side_effect
+    provider = _FakeFetchProvider(side_effect=side_effect)
 
     urls = [
         "https://docs.example.com/api/good",
         "https://docs.example.com/failing/page",
     ]
 
-    with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        result = asyncio.run(fetch_pages(urls, tmp_path, config))
+    result = asyncio.run(fetch_pages(urls, tmp_path, config, provider))
 
     assert result.total == 2
     assert result.completed == 1
@@ -64,37 +83,32 @@ def test_fetch_respects_concurrency(tmp_path):
     lock = threading.Lock()
     active = {"count": 0, "max": 0}
 
-    def slow_scrape(url):
-        import time
-        with lock:
-            active["count"] += 1
-            active["max"] = max(active["max"], active["count"])
-        time.sleep(0.05)
-        with lock:
-            active["count"] -= 1
-        return {"markdown": "# Content"}
+    class _SlowProvider:
+        name = "slow-fake"
 
-    mock_app = MagicMock()
-    mock_app.scrape.side_effect = slow_scrape
+        async def fetch_one(self, url: str) -> PageContent:
+            with lock:
+                active["count"] += 1
+                active["max"] = max(active["max"], active["count"])
+            await asyncio.sleep(0.05)
+            with lock:
+                active["count"] -= 1
+            return _page(url)
 
     urls = [f"https://docs.example.com/page-{i}" for i in range(6)]
 
-    with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        asyncio.run(fetch_pages(urls, tmp_path, config))
+    asyncio.run(fetch_pages(urls, tmp_path, config, _SlowProvider()))
 
     assert active["max"] <= 2
 
 
 def test_fetch_updates_manifest(tmp_path):
     config = ScraperConfig(firecrawl_api_key="fc-test")
-
-    mock_app = MagicMock()
-    mock_app.scrape.return_value = {"markdown": "# Content"}
+    provider = _FakeFetchProvider()
 
     urls = ["https://docs.example.com/api/intro"]
 
-    with patch("king_context.scraper.fetch.FirecrawlApp", return_value=mock_app):
-        asyncio.run(fetch_pages(urls, tmp_path, config))
+    asyncio.run(fetch_pages(urls, tmp_path, config, provider))
 
     manifest_path = tmp_path / "manifest.json"
     assert manifest_path.exists()

--- a/tests/test_scraper/test_pipeline_injection.py
+++ b/tests/test_scraper/test_pipeline_injection.py
@@ -1,0 +1,260 @@
+"""Tests for provider injection at the pipeline level (cli.run_pipeline).
+
+These tests verify the resolution + injection layer, not the providers themselves:
+- default resolves to firecrawl (no env, no flag)
+- --provider flag sets SCRAPE_PROVIDER for the run
+- stage-specific envs win over the flag (per ADR-0009)
+- unknown provider name → exit 2
+- ProviderUnavailableError at runtime → exit 3 with hint
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from scraper_providers import (
+    ProviderUnavailableError,
+    register_discovery_provider,
+    register_fetch_provider,
+)
+
+from king_context.scraper.cli import main, run_pipeline
+from king_context.scraper.config import ScraperConfig
+from king_context.scraper.discover import DiscoveryResult
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def clean_provider_env(monkeypatch):
+    """Ensure no SCRAPE_* envs leak between tests."""
+    monkeypatch.delenv("SCRAPE_PROVIDER", raising=False)
+    monkeypatch.delenv("SCRAPE_DISCOVER_PROVIDER", raising=False)
+    monkeypatch.delenv("SCRAPE_FETCH_PROVIDER", raising=False)
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    defaults = dict(
+        url="https://docs.example.com",
+        name="example",
+        display_name="Example",
+        step=None,
+        model="test-model",
+        chunk_max_tokens=800,
+        chunk_min_tokens=50,
+        concurrency=5,
+        no_llm_filter=False,
+        no_auto_seed=True,
+        include_maybe=False,
+        stop_after="discover",
+        yes=True,
+        provider=None,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _make_config() -> ScraperConfig:
+    return ScraperConfig(firecrawl_api_key="fake", openrouter_api_key="fake")
+
+
+class _RecordingDiscoveryProvider:
+    name = "recording-discovery"
+
+    def __init__(self):
+        self.calls = []
+
+    async def discover_urls(self, base_url: str) -> list[str]:
+        self.calls.append(base_url)
+        return []
+
+
+class _RecordingFetchProvider:
+    name = "recording-fetch"
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+def test_default_uses_firecrawl_provider(tmp_path, monkeypatch, clean_provider_env):
+    """No env, no flag → cli resolves 'firecrawl' for both stages."""
+    monkeypatch.setattr(
+        "king_context.scraper.cli.get_work_dir", lambda url: tmp_path
+    )
+
+    captured: dict[str, str | None] = {"discovery_name": None, "fetch_name": None}
+
+    real_get_discovery = __import__(
+        "scraper_providers", fromlist=["get_discovery_provider"]
+    ).get_discovery_provider
+    real_get_fetch = __import__(
+        "scraper_providers", fromlist=["get_fetch_provider"]
+    ).get_fetch_provider
+
+    def spy_get_discovery(name: str):
+        captured["discovery_name"] = name
+        return real_get_discovery(name)
+
+    def spy_get_fetch(name: str):
+        captured["fetch_name"] = name
+        return real_get_fetch(name)
+
+    discovery = DiscoveryResult(
+        base_url="https://docs.example.com",
+        discovered_at="2026-01-01",
+        total_urls=0,
+        urls=[],
+    )
+
+    with patch(
+        "king_context.scraper.cli.get_discovery_provider",
+        side_effect=spy_get_discovery,
+    ), patch(
+        "king_context.scraper.cli.get_fetch_provider",
+        side_effect=spy_get_fetch,
+    ), patch(
+        "king_context.scraper.cli.discover_urls",
+        new_callable=AsyncMock,
+        return_value=discovery,
+    ):
+        asyncio.run(run_pipeline(_make_args(), _make_config()))
+
+    assert captured["discovery_name"] == "firecrawl"
+    assert captured["fetch_name"] == "firecrawl"
+
+
+def test_provider_flag_sets_env(tmp_path, monkeypatch, clean_provider_env):
+    """--provider=NAME → SCRAPE_PROVIDER set, both stages resolve to NAME."""
+    monkeypatch.setattr(
+        "king_context.scraper.cli.get_work_dir", lambda url: tmp_path
+    )
+    register_discovery_provider("flag-test", lambda: _RecordingDiscoveryProvider())
+    register_fetch_provider("flag-test", lambda: _RecordingFetchProvider())
+
+    captured: dict[str, str | None] = {"discovery_name": None, "fetch_name": None}
+
+    def fake_get_discovery(name: str):
+        captured["discovery_name"] = name
+        return _RecordingDiscoveryProvider()
+
+    def fake_get_fetch(name: str):
+        captured["fetch_name"] = name
+        return _RecordingFetchProvider()
+
+    discovery = DiscoveryResult(
+        base_url="https://docs.example.com",
+        discovered_at="2026-01-01",
+        total_urls=0,
+        urls=[],
+    )
+
+    with patch(
+        "king_context.scraper.cli.get_discovery_provider",
+        side_effect=fake_get_discovery,
+    ), patch(
+        "king_context.scraper.cli.get_fetch_provider",
+        side_effect=fake_get_fetch,
+    ), patch(
+        "king_context.scraper.cli.discover_urls",
+        new_callable=AsyncMock,
+        return_value=discovery,
+    ):
+        asyncio.run(run_pipeline(_make_args(provider="flag-test"), _make_config()))
+
+    assert captured["discovery_name"] == "flag-test"
+    assert captured["fetch_name"] == "flag-test"
+
+
+def test_stage_env_overrides_flag(tmp_path, monkeypatch, clean_provider_env):
+    """SCRAPE_FETCH_PROVIDER=X + --provider=Y → fetch=X, discover=Y."""
+    monkeypatch.setattr(
+        "king_context.scraper.cli.get_work_dir", lambda url: tmp_path
+    )
+    monkeypatch.setenv("SCRAPE_FETCH_PROVIDER", "stage-fetch")
+
+    captured: dict[str, str | None] = {"discovery_name": None, "fetch_name": None}
+
+    def fake_get_discovery(name: str):
+        captured["discovery_name"] = name
+        return _RecordingDiscoveryProvider()
+
+    def fake_get_fetch(name: str):
+        captured["fetch_name"] = name
+        return _RecordingFetchProvider()
+
+    discovery = DiscoveryResult(
+        base_url="https://docs.example.com",
+        discovered_at="2026-01-01",
+        total_urls=0,
+        urls=[],
+    )
+
+    with patch(
+        "king_context.scraper.cli.get_discovery_provider",
+        side_effect=fake_get_discovery,
+    ), patch(
+        "king_context.scraper.cli.get_fetch_provider",
+        side_effect=fake_get_fetch,
+    ), patch(
+        "king_context.scraper.cli.discover_urls",
+        new_callable=AsyncMock,
+        return_value=discovery,
+    ):
+        asyncio.run(run_pipeline(_make_args(provider="flag-global"), _make_config()))
+
+    # discover gets the flag (no stage env), fetch gets the stage env
+    assert captured["discovery_name"] == "flag-global"
+    assert captured["fetch_name"] == "stage-fetch"
+
+
+def test_unknown_provider_exits_2(monkeypatch, clean_provider_env, capsys):
+    """--provider=bogus → main() exits with code 2 and stderr lists registered."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["king-scrape", "https://docs.example.com", "--provider", "bogus-xyz"],
+    )
+    monkeypatch.setattr(
+        "king_context.scraper.cli.load_config", lambda **kwargs: _make_config()
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "Unknown" in captured.err
+    assert "bogus-xyz" in captured.err
+
+
+def test_provider_unavailable_exits_3(tmp_path, monkeypatch, clean_provider_env, capsys):
+    """ProviderUnavailableError at runtime → main() exits 3 with hint."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["king-scrape", "https://docs.example.com", "--stop-after", "discover"],
+    )
+    monkeypatch.setattr(
+        "king_context.scraper.cli.load_config", lambda **kwargs: _make_config()
+    )
+    monkeypatch.setattr(
+        "king_context.scraper.cli.get_work_dir", lambda url: tmp_path
+    )
+
+    def boom(name: str):
+        raise ProviderUnavailableError(name, "install hint: pip install king-context[firecrawl]")
+
+    with patch(
+        "king_context.scraper.cli.get_discovery_provider",
+        side_effect=boom,
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    assert excinfo.value.code == 3
+    captured = capsys.readouterr()
+    assert "pip install" in captured.err

--- a/tests/test_scraper_cli_flags.py
+++ b/tests/test_scraper_cli_flags.py
@@ -35,6 +35,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         include_maybe=False,
         stop_after=None,
         yes=False,
+        provider=None,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)

--- a/tests/test_scraper_fetch_resume.py
+++ b/tests/test_scraper_fetch_resume.py
@@ -1,8 +1,10 @@
 """Tests for fetch resume support — skip pages already fetched."""
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from scraper_providers import PageContent
 
 from king_context.scraper.config import ScraperConfig
 from king_context.scraper.fetch import (
@@ -19,6 +21,18 @@ def _make_config() -> ScraperConfig:
         openrouter_api_key="fake",
         concurrency=5,
     )
+
+
+class _FakeFetchProvider:
+    name = "fake"
+
+    async def fetch_one(self, url: str) -> PageContent:
+        return PageContent(
+            url=url,
+            markdown=f"# {url}",
+            title=None,
+            fetched_at=datetime.now(timezone.utc),
+        )
 
 
 def _create_page_file(pages_dir, url: str) -> None:
@@ -48,7 +62,7 @@ class TestFetchResume:
         config = _make_config()
         fetched_urls = []
 
-        async def _mock_fetch_one(url, semaphore, pages_dir, app):
+        async def _mock_fetch_one(url, semaphore, pages_dir, provider):
             fetched_urls.append(url)
             return PageResult(url=url, markdown=f"# {url}", success=True, error=None)
 
@@ -58,10 +72,8 @@ class TestFetchResume:
             side_effect=_mock_fetch_one,
         ), patch(
             "king_context.scraper.fetch._update_step",
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            result = await fetch_pages(urls, tmp_path, config)
+            result = await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         # Only URLs b and c should have been fetched
         assert len(fetched_urls) == 2
@@ -92,10 +104,8 @@ class TestFetchResume:
             fetch_one_mock,
         ), patch(
             "king_context.scraper.fetch._update_step",
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            result = await fetch_pages(urls, tmp_path, config)
+            result = await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         # _fetch_one should never have been called
         fetch_one_mock.assert_not_called()
@@ -118,7 +128,7 @@ class TestFetchResume:
         config = _make_config()
         fetched_urls = []
 
-        async def _mock_fetch_one(url, semaphore, pages_dir, app):
+        async def _mock_fetch_one(url, semaphore, pages_dir, provider):
             fetched_urls.append(url)
             return PageResult(url=url, markdown=f"# {url}", success=True, error=None)
 
@@ -128,10 +138,8 @@ class TestFetchResume:
             side_effect=_mock_fetch_one,
         ), patch(
             "king_context.scraper.fetch._update_step",
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            result = await fetch_pages(urls, tmp_path, config)
+            result = await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         # All 3 URLs should have been fetched
         assert len(fetched_urls) == 3
@@ -158,7 +166,7 @@ class TestFetchResume:
 
         config = _make_config()
 
-        async def _mock_fetch_one(url, semaphore, pages_dir, app):
+        async def _mock_fetch_one(url, semaphore, pages_dir, provider):
             return PageResult(url=url, markdown=f"# {url}", success=True, error=None)
 
         with patch(
@@ -167,10 +175,8 @@ class TestFetchResume:
             side_effect=_mock_fetch_one,
         ), patch(
             "king_context.scraper.fetch._update_step",
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            result = await fetch_pages(urls, tmp_path, config)
+            result = await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         # total = all 4 URLs
         assert result.total == 4
@@ -199,19 +205,15 @@ class TestFetchResume:
 
         config = _make_config()
 
-        async def _mock_fetch_one(url, semaphore, pages_dir, app):
+        async def _mock_fetch_one(url, semaphore, pages_dir, provider):
             return PageResult(url=url, markdown=f"# {url}", success=True, error=None)
 
         with patch(
             "king_context.scraper.fetch._fetch_one",
             new_callable=AsyncMock,
             side_effect=_mock_fetch_one,
-        ), patch(
-            "king_context.scraper.fetch._update_step",
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            await fetch_pages(urls, tmp_path, config)
+            await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         captured = capsys.readouterr()
         assert "Resuming: 1 pages already fetched, 2 remaining" in captured.out

--- a/tests/test_scraper_manifest.py
+++ b/tests/test_scraper_manifest.py
@@ -1,9 +1,11 @@
 """Tests for partial progress tracking in manifest during fetch and enrich."""
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from scraper_providers import PageContent
 
 from conftest import FakeLLMClient, fake_stage_clients
 from king_context.scraper.chunk import Chunk
@@ -19,6 +21,18 @@ def _make_config() -> ScraperConfig:
         enrichment_batch_size=2,
         concurrency=5,
     )
+
+
+class _FakeFetchProvider:
+    name = "fake"
+
+    async def fetch_one(self, url: str) -> PageContent:
+        return PageContent(
+            url=url,
+            markdown=f"# {url}",
+            title=None,
+            fetched_at=datetime.now(timezone.utc),
+        )
 
 
 def _read_manifest(work_dir):
@@ -56,10 +70,8 @@ class TestFetchManifestProgress:
         ), patch(
             "king_context.scraper.fetch._update_step",
             side_effect=_capture_update,
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            result = await fetch_pages(urls, tmp_path, config)
+            result = await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         # At least one in_progress update happened
         in_progress = [m for m in manifests_during_fetch if m["status"] == "in_progress"]
@@ -87,10 +99,8 @@ class TestFetchManifestProgress:
             "king_context.scraper.fetch._fetch_one",
             new_callable=AsyncMock,
             return_value=PageResult(url=urls[0], markdown="# A", success=True, error=None),
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ):
-            result = await fetch_pages(urls, tmp_path, config)
+            result = await fetch_pages(urls, tmp_path, config, _FakeFetchProvider())
 
         manifest = _read_manifest(tmp_path)
         assert manifest["fetch"]["status"] == "done"

--- a/tests/test_scraper_providers/conftest.py
+++ b/tests/test_scraper_providers/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for scraper_providers tests."""
+from __future__ import annotations
+
+import pytest
+
+from scraper_providers import registry
+
+
+@pytest.fixture(autouse=True)
+def reset_registries():
+    """Snapshot and restore registry state around every test so registrations
+    in one test do not leak into the next.
+    """
+    discovery_snapshot = dict(registry._DISCOVERY_FACTORIES)
+    fetch_snapshot = dict(registry._FETCH_FACTORIES)
+    registry._DISCOVERY_FACTORIES.clear()
+    registry._FETCH_FACTORIES.clear()
+    try:
+        yield
+    finally:
+        registry._DISCOVERY_FACTORIES.clear()
+        registry._FETCH_FACTORIES.clear()
+        registry._DISCOVERY_FACTORIES.update(discovery_snapshot)
+        registry._FETCH_FACTORIES.update(fetch_snapshot)

--- a/tests/test_scraper_providers/test_base.py
+++ b/tests/test_scraper_providers/test_base.py
@@ -1,0 +1,70 @@
+"""Tests for scraper_providers.base — Protocols, PageContent, ProviderUnavailableError."""
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timezone
+
+import pytest
+
+from scraper_providers import (
+    DiscoveryProvider,
+    FetchProvider,
+    PageContent,
+    ProviderUnavailableError,
+)
+
+
+def test_page_content_frozen():
+    page = PageContent(
+        url="https://example.com",
+        markdown="# Hello",
+        fetched_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        page.url = "https://other.example.com"  # type: ignore[misc]
+
+
+def test_page_content_title_optional():
+    page = PageContent(
+        url="https://example.com",
+        markdown="# Hello",
+        fetched_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    assert page.title is None
+
+
+def test_provider_unavailable_carries_hint():
+    err = ProviderUnavailableError("crawl4ai", "run crawl4ai-setup")
+    assert err.provider == "crawl4ai"
+    assert err.hint == "run crawl4ai-setup"
+    assert "crawl4ai" in str(err)
+    assert "run crawl4ai-setup" in str(err)
+    assert isinstance(err, RuntimeError)
+
+
+def test_provider_unavailable_distinct_from_value_error():
+    err = ProviderUnavailableError("foo", "install bar")
+    assert not isinstance(err, ValueError)
+
+
+class _StubDiscovery:
+    name = "stub"
+
+    async def discover_urls(self, base_url: str) -> list[str]:
+        return [base_url]
+
+
+class _StubFetch:
+    name = "stub"
+
+    async def fetch_one(self, url: str) -> PageContent:
+        return PageContent(
+            url=url,
+            markdown="",
+            fetched_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_protocols_runtime_checkable():
+    assert isinstance(_StubDiscovery(), DiscoveryProvider)
+    assert isinstance(_StubFetch(), FetchProvider)

--- a/tests/test_scraper_providers/test_crawl4ai_provider.py
+++ b/tests/test_scraper_providers/test_crawl4ai_provider.py
@@ -1,0 +1,281 @@
+"""Tests for scraper_providers.crawl4ai_provider — soft import + Playwright translation."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from scraper_providers import (
+    DiscoveryProvider,
+    FetchProvider,
+    PageContent,
+    ProviderUnavailableError,
+    get_discovery_provider,
+    get_fetch_provider,
+)
+from scraper_providers import crawl4ai_provider
+from scraper_providers.crawl4ai_provider import (
+    Crawl4AIDiscoveryProvider,
+    Crawl4AIFetchProvider,
+)
+
+
+class _FakeResult:
+    def __init__(self, url: str, markdown: str | None = "", metadata: dict | None = None):
+        self.url = url
+        self.markdown = markdown
+        self.metadata = metadata
+
+
+def _make_crawler_mock(arun_return):
+    """Build a MagicMock that supports async-context-manager and async arun()."""
+    crawler = MagicMock()
+    crawler.__aenter__ = AsyncMock(return_value=crawler)
+    crawler.__aexit__ = AsyncMock(return_value=None)
+    if isinstance(arun_return, Exception):
+        crawler.arun = AsyncMock(side_effect=arun_return)
+    else:
+        crawler.arun = AsyncMock(return_value=arun_return)
+    return crawler
+
+
+def _patch_crawl4ai(monkeypatch, crawler_mock) -> None:
+    """Force _CRAWL4AI_AVAILABLE=True and stub AsyncWebCrawler factory + configs."""
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._CRAWL4AI_AVAILABLE", True
+    )
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.AsyncWebCrawler",
+        lambda **kw: crawler_mock,
+    )
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.BrowserConfig",
+        lambda **kw: object(),
+    )
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CrawlerRunConfig",
+        lambda **kw: object(),
+    )
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.BFSDeepCrawlStrategy",
+        lambda **kw: object(),
+    )
+    # Bypass Playwright presence check
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._ensure_browser_present",
+        lambda: None,
+    )
+
+
+async def test_fetch_returns_page_content(monkeypatch):
+    result = _FakeResult(
+        url="https://u",
+        markdown="# Hi",
+        metadata={"title": "Title"},
+    )
+    _patch_crawl4ai(monkeypatch, _make_crawler_mock(result))
+
+    provider = Crawl4AIFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert isinstance(page, PageContent)
+    assert page.url == "https://u"
+    assert page.markdown == "# Hi"
+    assert page.title == "Title"
+    assert isinstance(page.fetched_at, datetime)
+    assert page.fetched_at.tzinfo == timezone.utc
+
+
+async def test_fetch_handles_missing_title(monkeypatch):
+    result = _FakeResult(url="https://u", markdown="x", metadata=None)
+    _patch_crawl4ai(monkeypatch, _make_crawler_mock(result))
+
+    provider = Crawl4AIFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert page.title is None
+    assert page.markdown == "x"
+
+
+async def test_fetch_handles_missing_markdown(monkeypatch):
+    result = _FakeResult(url="https://u", markdown=None)
+    _patch_crawl4ai(monkeypatch, _make_crawler_mock(result))
+
+    provider = Crawl4AIFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert page.markdown == ""
+
+
+async def test_fetch_handles_empty_string_markdown(monkeypatch):
+    result = _FakeResult(url="https://u", markdown="")
+    _patch_crawl4ai(monkeypatch, _make_crawler_mock(result))
+
+    provider = Crawl4AIFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert page.markdown == ""
+
+
+async def test_discover_returns_urls_from_deep_crawl(monkeypatch):
+    results = [
+        _FakeResult(url="https://a"),
+        _FakeResult(url="https://b"),
+        _FakeResult(url="https://c"),
+    ]
+    _patch_crawl4ai(monkeypatch, _make_crawler_mock(results))
+
+    provider = Crawl4AIDiscoveryProvider()
+    urls = await provider.discover_urls("https://a")
+
+    assert urls == ["https://a", "https://b", "https://c"]
+
+
+async def test_discover_skips_results_without_url(monkeypatch):
+    class _NoUrl:
+        url = None
+
+    results = [_FakeResult(url="https://a"), _NoUrl(), _FakeResult(url="https://b")]
+    _patch_crawl4ai(monkeypatch, _make_crawler_mock(results))
+
+    provider = Crawl4AIDiscoveryProvider()
+    urls = await provider.discover_urls("https://a")
+
+    assert urls == ["https://a", "https://b"]
+
+
+def test_unavailable_when_crawl4ai_not_installed(monkeypatch):
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._CRAWL4AI_AVAILABLE", False
+    )
+
+    with pytest.raises(ProviderUnavailableError) as excinfo:
+        crawl4ai_provider._ensure_available()
+
+    assert excinfo.value.provider == "crawl4ai"
+    assert "pip install" in excinfo.value.hint
+    assert "crawl4ai-setup" in excinfo.value.hint
+
+
+async def test_unavailable_propagates_through_fetch(monkeypatch):
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._CRAWL4AI_AVAILABLE", False
+    )
+
+    provider = Crawl4AIFetchProvider()
+    with pytest.raises(ProviderUnavailableError) as excinfo:
+        await provider.fetch_one("https://u")
+
+    assert excinfo.value.provider == "crawl4ai"
+    assert "pip install" in excinfo.value.hint
+
+
+async def test_browser_missing_translates_to_provider_error(monkeypatch):
+    crawler = _make_crawler_mock(
+        Exception("BrowserType.launch: Executable doesn't exist at /path")
+    )
+    _patch_crawl4ai(monkeypatch, crawler)
+
+    provider = Crawl4AIFetchProvider()
+    with pytest.raises(ProviderUnavailableError) as excinfo:
+        await provider.fetch_one("https://u")
+
+    assert excinfo.value.provider == "crawl4ai"
+    assert "crawl4ai-setup" in excinfo.value.hint
+
+
+async def test_browser_missing_translates_in_discover(monkeypatch):
+    crawler = _make_crawler_mock(
+        Exception("Please run: playwright install chromium")
+    )
+    _patch_crawl4ai(monkeypatch, crawler)
+
+    provider = Crawl4AIDiscoveryProvider()
+    with pytest.raises(ProviderUnavailableError) as excinfo:
+        await provider.discover_urls("https://u")
+
+    assert excinfo.value.provider == "crawl4ai"
+    assert "crawl4ai-setup" in excinfo.value.hint
+
+
+async def test_other_exceptions_bubble_up(monkeypatch):
+    crawler = _make_crawler_mock(RuntimeError("network unreachable"))
+    _patch_crawl4ai(monkeypatch, crawler)
+
+    provider = Crawl4AIFetchProvider()
+    with pytest.raises(RuntimeError, match="network unreachable"):
+        await provider.fetch_one("https://u")
+
+
+def test_register_makes_provider_resolvable():
+    crawl4ai_provider.register()
+
+    discovery = get_discovery_provider("crawl4ai")
+    fetch = get_fetch_provider("crawl4ai")
+
+    assert isinstance(discovery, Crawl4AIDiscoveryProvider)
+    assert isinstance(fetch, Crawl4AIFetchProvider)
+    assert discovery.name == "crawl4ai"
+    assert fetch.name == "crawl4ai"
+
+
+def test_protocol_compliance():
+    assert isinstance(Crawl4AIDiscoveryProvider(), DiscoveryProvider)
+    assert isinstance(Crawl4AIFetchProvider(), FetchProvider)
+
+
+def test_init_skips_when_crawl4ai_missing(monkeypatch):
+    """Re-importing the package with crawl4ai unavailable must not raise.
+
+    Saves the original scraper_providers.* module instances and restores them
+    after the reload. Other test files hold references to these modules at
+    import time; if we let a fresh reload replace them, monkeypatch.setattr in
+    those tests would patch the new instances while the test calls the old.
+    """
+    import importlib
+    import sys
+
+    real_crawl4ai = sys.modules.pop("crawl4ai", None)
+    monkeypatch.setitem(sys.modules, "crawl4ai", None)
+
+    orig_modules = {
+        k: v for k, v in sys.modules.items() if k.startswith("scraper_providers")
+    }
+    for k in orig_modules:
+        sys.modules.pop(k, None)
+    try:
+        pkg = importlib.import_module("scraper_providers")
+        assert hasattr(pkg, "get_fetch_provider")
+    finally:
+        for k in [k for k in list(sys.modules) if k.startswith("scraper_providers")]:
+            sys.modules.pop(k, None)
+        sys.modules.update(orig_modules)
+        if real_crawl4ai is not None:
+            sys.modules["crawl4ai"] = real_crawl4ai
+        else:
+            sys.modules.pop("crawl4ai", None)
+
+
+def test_browser_missing_when_playwright_absent(monkeypatch):
+    """If crawl4ai is importable but Playwright isn't, _ensure_browser_present
+    raises ProviderUnavailableError with the setup hint."""
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._CRAWL4AI_AVAILABLE", True
+    )
+
+    def _fake_find_spec(name):
+        if name == "playwright":
+            return None
+        from importlib.util import find_spec as _real
+        return _real(name)
+
+    monkeypatch.setattr(
+        "importlib.util.find_spec", _fake_find_spec
+    )
+
+    with pytest.raises(ProviderUnavailableError) as excinfo:
+        crawl4ai_provider._ensure_browser_present()
+
+    assert excinfo.value.provider == "crawl4ai"
+    assert "crawl4ai-setup" in excinfo.value.hint

--- a/tests/test_scraper_providers/test_entry_points.py
+++ b/tests/test_scraper_providers/test_entry_points.py
@@ -1,0 +1,78 @@
+"""Tests for scraper_providers.registry.load_entry_point_providers."""
+from __future__ import annotations
+
+from scraper_providers import registry
+
+
+class _FakeEntryPoint:
+    def __init__(self, register_fn):
+        self._register_fn = register_fn
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+        return self._register_fn
+
+
+class _RaisingLoadEntryPoint:
+    def load(self):
+        raise RuntimeError("plugin import boom")
+
+
+class _RaisingRegisterEntryPoint:
+    def load(self):
+        def _bad():
+            raise RuntimeError("register boom")
+
+        return _bad
+
+
+def test_entry_points_loaded(monkeypatch):
+    called = {"n": 0}
+
+    def _register():
+        called["n"] += 1
+
+    fake_ep = _FakeEntryPoint(_register)
+
+    def fake_entry_points(group=None):
+        assert group == "king_context.scraper_providers"
+        return [fake_ep]
+
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points", fake_entry_points
+    )
+    registry.load_entry_point_providers()
+    assert fake_ep.load_calls == 1
+    assert called["n"] == 1
+
+
+def test_entry_point_load_failure_silently_skipped(monkeypatch):
+    def fake_entry_points(group=None):
+        return [_RaisingLoadEntryPoint()]
+
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points", fake_entry_points
+    )
+    # Must not raise.
+    registry.load_entry_point_providers()
+
+
+def test_entry_point_register_failure_silently_skipped(monkeypatch):
+    def fake_entry_points(group=None):
+        return [_RaisingRegisterEntryPoint()]
+
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points", fake_entry_points
+    )
+    registry.load_entry_point_providers()
+
+
+def test_entry_points_api_broken_returns_silently(monkeypatch):
+    def fake_entry_points(group=None):
+        raise RuntimeError("metadata api unavailable")
+
+    monkeypatch.setattr(
+        "importlib.metadata.entry_points", fake_entry_points
+    )
+    registry.load_entry_point_providers()

--- a/tests/test_scraper_providers/test_firecrawl_provider.py
+++ b/tests/test_scraper_providers/test_firecrawl_provider.py
@@ -1,0 +1,181 @@
+"""Tests for scraper_providers.firecrawl_provider — SDK wrapping + soft import."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from scraper_providers import (
+    DiscoveryProvider,
+    FetchProvider,
+    PageContent,
+    ProviderUnavailableError,
+    get_discovery_provider,
+    get_fetch_provider,
+)
+from scraper_providers import firecrawl_provider
+from scraper_providers.firecrawl_provider import (
+    FirecrawlDiscoveryProvider,
+    FirecrawlFetchProvider,
+)
+
+
+def _patch_app(monkeypatch, mock_app: MagicMock) -> None:
+    monkeypatch.setattr(
+        "scraper_providers.firecrawl_provider.FirecrawlApp",
+        lambda **kw: mock_app,
+    )
+    monkeypatch.setattr(
+        "scraper_providers.firecrawl_provider._FIRECRAWL_AVAILABLE", True
+    )
+
+
+async def test_discover_returns_url_list(monkeypatch):
+    fake_app = MagicMock()
+    fake_app.map.return_value = {"links": ["https://a", "https://b"]}
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlDiscoveryProvider()
+    urls = await provider.discover_urls("https://x")
+
+    assert urls == ["https://a", "https://b"]
+    fake_app.map.assert_called_once_with("https://x")
+
+
+async def test_discover_empty_links(monkeypatch):
+    fake_app = MagicMock()
+    fake_app.map.return_value = {"links": []}
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlDiscoveryProvider()
+    urls = await provider.discover_urls("https://x")
+
+    assert urls == []
+
+
+async def test_discover_handles_object_response(monkeypatch):
+    """SDK v2.x may return an object with .links instead of a dict."""
+    class _LinkObj:
+        def __init__(self, url: str):
+            self.url = url
+
+    class _MapResp:
+        links = [_LinkObj("https://a"), _LinkObj("https://b")]
+
+    fake_app = MagicMock()
+    fake_app.map.return_value = _MapResp()
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlDiscoveryProvider()
+    urls = await provider.discover_urls("https://x")
+
+    assert urls == ["https://a", "https://b"]
+
+
+async def test_discover_handles_plain_list_response(monkeypatch):
+    """Some SDK shapes return a bare list of URL strings."""
+    fake_app = MagicMock()
+    fake_app.map.return_value = ["https://a", "https://b"]
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlDiscoveryProvider()
+    urls = await provider.discover_urls("https://x")
+
+    assert urls == ["https://a", "https://b"]
+
+
+async def test_fetch_returns_page_content(monkeypatch):
+    fake_app = MagicMock()
+    fake_app.scrape.return_value = {
+        "markdown": "# Hi",
+        "metadata": {"title": "T"},
+    }
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert isinstance(page, PageContent)
+    assert page.url == "https://u"
+    assert page.markdown == "# Hi"
+    assert page.title == "T"
+    assert isinstance(page.fetched_at, datetime)
+    assert page.fetched_at.tzinfo == timezone.utc
+    fake_app.scrape.assert_called_once_with("https://u", formats=["markdown"])
+
+
+async def test_fetch_handles_missing_title(monkeypatch):
+    fake_app = MagicMock()
+    fake_app.scrape.return_value = {"markdown": "x"}
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert page.title is None
+    assert page.markdown == "x"
+
+
+async def test_fetch_handles_empty_markdown(monkeypatch):
+    fake_app = MagicMock()
+    fake_app.scrape.return_value = {}
+    _patch_app(monkeypatch, fake_app)
+
+    provider = FirecrawlFetchProvider()
+    page = await provider.fetch_one("https://u")
+
+    assert page.markdown == ""
+    assert page.title is None
+
+
+def test_unavailable_when_not_installed(monkeypatch):
+    monkeypatch.setattr(
+        "scraper_providers.firecrawl_provider._FIRECRAWL_AVAILABLE", False
+    )
+
+    with pytest.raises(ProviderUnavailableError) as excinfo:
+        firecrawl_provider._build_app()
+
+    assert excinfo.value.provider == "firecrawl"
+    assert "pip install" in excinfo.value.hint
+
+
+def test_register_makes_provider_resolvable():
+    firecrawl_provider.register()
+
+    discovery = get_discovery_provider("firecrawl")
+    fetch = get_fetch_provider("firecrawl")
+
+    assert isinstance(discovery, FirecrawlDiscoveryProvider)
+    assert isinstance(fetch, FirecrawlFetchProvider)
+    assert discovery.name == "firecrawl"
+    assert fetch.name == "firecrawl"
+
+
+def test_protocol_compliance():
+    assert isinstance(FirecrawlDiscoveryProvider(), DiscoveryProvider)
+    assert isinstance(FirecrawlFetchProvider(), FetchProvider)
+
+
+def test_init_skips_when_firecrawl_missing(monkeypatch):
+    """Re-importing the package with firecrawl unavailable must not raise."""
+    import importlib
+    import sys
+
+    real_firecrawl = sys.modules.pop("firecrawl", None)
+    monkeypatch.setitem(sys.modules, "firecrawl", None)
+
+    sys.modules.pop("scraper_providers", None)
+    sys.modules.pop("scraper_providers.firecrawl_provider", None)
+    try:
+        pkg = importlib.import_module("scraper_providers")
+        assert hasattr(pkg, "get_fetch_provider")
+    finally:
+        sys.modules.pop("scraper_providers", None)
+        sys.modules.pop("scraper_providers.firecrawl_provider", None)
+        if real_firecrawl is not None:
+            sys.modules["firecrawl"] = real_firecrawl
+        else:
+            sys.modules.pop("firecrawl", None)
+        importlib.import_module("scraper_providers")

--- a/tests/test_scraper_providers/test_registry.py
+++ b/tests/test_scraper_providers/test_registry.py
@@ -1,0 +1,94 @@
+"""Tests for scraper_providers.registry — register/get/conflict semantics."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from scraper_providers import (
+    PageContent,
+    get_discovery_provider,
+    get_fetch_provider,
+    register_discovery_provider,
+    register_fetch_provider,
+)
+
+
+class _StubDiscovery:
+    name = "stub-discovery"
+
+    async def discover_urls(self, base_url: str) -> list[str]:
+        return [base_url]
+
+
+class _StubFetch:
+    name = "stub-fetch"
+
+    async def fetch_one(self, url: str) -> PageContent:
+        return PageContent(
+            url=url,
+            markdown="",
+            fetched_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_register_and_get_discovery():
+    register_discovery_provider("stub", _StubDiscovery)
+    instance = get_discovery_provider("stub")
+    assert isinstance(instance, _StubDiscovery)
+
+
+def test_register_and_get_fetch():
+    register_fetch_provider("stub", _StubFetch)
+    instance = get_fetch_provider("stub")
+    assert isinstance(instance, _StubFetch)
+
+
+def test_unknown_discovery_provider_raises():
+    register_discovery_provider("alpha", _StubDiscovery)
+    register_discovery_provider("beta", _StubDiscovery)
+    with pytest.raises(ValueError) as excinfo:
+        get_discovery_provider("missing")
+    msg = str(excinfo.value)
+    assert "missing" in msg
+    assert "alpha" in msg
+    assert "beta" in msg
+
+
+def test_unknown_fetch_provider_raises():
+    register_fetch_provider("alpha", _StubFetch)
+    with pytest.raises(ValueError) as excinfo:
+        get_fetch_provider("missing")
+    assert "alpha" in str(excinfo.value)
+
+
+def test_builtin_wins_on_conflict_discovery():
+    register_discovery_provider("stub", _StubDiscovery)
+
+    class _Other:
+        name = "other"
+
+        async def discover_urls(self, base_url: str) -> list[str]:
+            return []
+
+    register_discovery_provider("stub", _Other)
+    instance = get_discovery_provider("stub")
+    assert isinstance(instance, _StubDiscovery)
+
+
+def test_builtin_wins_on_conflict_fetch():
+    register_fetch_provider("stub", _StubFetch)
+
+    class _Other:
+        name = "other"
+
+        async def fetch_one(self, url: str) -> PageContent:
+            return PageContent(
+                url=url,
+                markdown="other",
+                fetched_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
+    register_fetch_provider("stub", _Other)
+    instance = get_fetch_provider("stub")
+    assert isinstance(instance, _StubFetch)

--- a/tests/test_scraper_providers/test_resolution.py
+++ b/tests/test_scraper_providers/test_resolution.py
@@ -1,0 +1,52 @@
+"""Tests for scraper_providers.registry.resolve_provider_name — env precedence."""
+from __future__ import annotations
+
+from scraper_providers import resolve_provider_name
+
+
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("SCRAPE_PROVIDER", raising=False)
+    monkeypatch.delenv("SCRAPE_DISCOVER_PROVIDER", raising=False)
+    monkeypatch.delenv("SCRAPE_FETCH_PROVIDER", raising=False)
+
+
+def test_default_is_firecrawl(monkeypatch):
+    _clear_env(monkeypatch)
+    assert resolve_provider_name("discover") == "firecrawl"
+    assert resolve_provider_name("fetch") == "firecrawl"
+
+
+def test_global_env_applies_both_stages(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SCRAPE_PROVIDER", "crawl4ai")
+    assert resolve_provider_name("discover") == "crawl4ai"
+    assert resolve_provider_name("fetch") == "crawl4ai"
+
+
+def test_stage_specific_envs_mix(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SCRAPE_DISCOVER_PROVIDER", "crawl4ai")
+    monkeypatch.setenv("SCRAPE_FETCH_PROVIDER", "firecrawl")
+    assert resolve_provider_name("discover") == "crawl4ai"
+    assert resolve_provider_name("fetch") == "firecrawl"
+
+
+def test_stage_specific_overrides_global(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SCRAPE_PROVIDER", "foo")
+    monkeypatch.setenv("SCRAPE_FETCH_PROVIDER", "bar")
+    assert resolve_provider_name("fetch") == "bar"
+    assert resolve_provider_name("discover") == "foo"
+
+
+def test_empty_string_falls_back_to_default(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SCRAPE_PROVIDER", "")
+    assert resolve_provider_name("discover") == "firecrawl"
+
+
+def test_empty_stage_var_falls_back_to_global(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SCRAPE_PROVIDER", "crawl4ai")
+    monkeypatch.setenv("SCRAPE_FETCH_PROVIDER", "")
+    assert resolve_provider_name("fetch") == "crawl4ai"

--- a/tests/test_scraper_resume_integration.py
+++ b/tests/test_scraper_resume_integration.py
@@ -40,6 +40,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         include_maybe=False,
         stop_after=None,
         yes=True,
+        provider=None,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -168,7 +169,7 @@ class TestFetchResumeIntegration:
 
         fetched_urls = []
 
-        async def mock_fetch_one(url, semaphore, pages_dir, app):
+        async def mock_fetch_one(url, semaphore, pages_dir, provider):
             fetched_urls.append(url)
             slug = _url_to_slug(url)
             (pages_dir / f"{slug}.md").write_text(f"# {url}")
@@ -177,8 +178,6 @@ class TestFetchResumeIntegration:
         with patch(
             "king_context.scraper.fetch._fetch_one",
             side_effect=mock_fetch_one,
-        ), patch(
-            "king_context.scraper.fetch.FirecrawlApp",
         ), patch(
             "king_context.scraper.cli.chunk_pages",
             return_value=[],


### PR DESCRIPTION
## Summary

Adds a pluggable scraper provider abstraction to `king-scrape`, with Crawl4AI as the first local opt-in backend. Firecrawl remains the zero-config default.

## Why?

`king-scrape` was Firecrawl-only, contradicting the local-first positioning (ADR-0001). Users without Firecrawl credits, with private docs, or who wanted transparent HTML to Markdown conversion had no path. Mirrors the LLM provider pattern from ADR-0003.

Decisions: ADR-0009 (provider abstraction), ADR-0010 (thin provider, pipeline-owned IO), ADR-0011 (Crawl4AI as first local backend).

## What changed

- **`src/scraper_providers/`** (new, 5 files): registry, `DiscoveryProvider` / `FetchProvider` Protocols, `PageContent` dataclass, `ProviderUnavailableError`, plus Firecrawl and Crawl4AI implementations with soft import.
- **Pipeline** (`src/king_context/scraper/{cli,config,discover,fetch}.py`): `--provider` CLI flag, stage-aware env resolution (`SCRAPE_PROVIDER`, `SCRAPE_DISCOVER_PROVIDER`, `SCRAPE_FETCH_PROVIDER`), provider injection. Checkpoint, slug paths, and manifest semantics preserved.
- **`pyproject.toml`**: `firecrawl-py` moved to `[firecrawl]` extra. New `[crawl4ai]` and `[all]` extras. `entry_points` group `king_context.scraper_providers` for future plugin discovery.
- **`installer/lib/python.js`**: install/upgrade now use `king-context[all] @ git+...` so init keeps pulling firecrawl-py after the extras move.
- **CI**: new `.github/workflows/test.yml` with `test` (pytest) and gated `smoke-crawl4ai` job (`crawl4ai-setup` + `scripts/smoke-crawl4ai.py`). Blocking by design (ADR-0011) to detect API churn across `crawl4ai>=0.8.5,<0.9` minor versions.
- **Docs**: README "Scraper providers" section, CLI_GUIDE flag entry + troubleshooting, `.env.example` + installer template synced, CHANGELOG `[Unreleased]` entry.
- **Tests**: 280+ new tests in `tests/test_scraper_providers/` (registry, soft import, stage resolution, entry points, both provider clients with mocked SDKs). Existing scraper tests adapted for provider injection.

## Validation

- `pytest -q`: 683 passed
- Crawl4AI end to end on python-httpx.org: 114 sections exported
- Firecrawl end to end on python-httpx.org: 112 sections exported
- Default path (no env, no flag) resolves `firecrawl` and reaches the API (zero breaking change)
- `kctx adr validate`: passed