### PR TITLE
Add king-scrape update for incremental corpus refresh (ADR-0014)

### DIFF
--- a/.king-context/adr/0014-incremental-corpus-refresh.md
+++ b/.king-context/adr/0014-incremental-corpus-refresh.md
@@ -1,0 +1,89 @@
+---
+id: ADR-0014
+title: Incremental corpus refresh via `king-scrape update`
+status: accepted
+date: 2026-05-08
+areas:
+  - scraper
+  - corpus
+  - cli
+  - cost
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0010
+  - ADR-0012
+  - ADR-0013
+keywords:
+  - incremental-refresh
+  - content-hash
+  - reuse
+  - update-flow
+  - cost-preview
+  - chunk-identity
+tags:
+  - architecture
+  - scraper
+  - cli
+---
+
+
+# ADR-0014: Incremental corpus refresh via `king-scrape update`
+
+## Context
+
+A contributor who indexed a docs site months ago and wants to refresh has two options today: rerun `king-scrape <url> --name <name>`, which under the resume rules of fetch.py silently skips changed pages and produces a stale corpus; or wipe `.king-context/_temp/<host>/` and pay the full pipeline cost again, dominated by OpenRouter enrichment ($1 to $3 for a corpus of a few hundred chunks). Neither is acceptable.
+
+ADR-0012 added `content_hash` provenance to every chunk, every section, and every fetched page so that a third path becomes possible: refetch all pages, rechunk, and reuse every section whose chunked content is byte identical to the previous scrape. ADR-0013 added the read only audit subcommand that surfaces drift signals without spending LLM credits. The missing piece is the action that closes the loop: take an audited corpus and actually update it cheaply.
+
+## Decision
+
+Add `king-scrape update <name>`. The command is dispatched the same way as `audit` (a small `if argv[1] == "update": ...` branch in `cli.main`, no argparse subparser refactor) so the existing `king-scrape <url>` flow is unchanged.
+
+The flow:
+
+1. Locate the corpus at `data/<name>.json` or `.king-context/data/<name>.json`. Resolve the source URL from `_meta.source_url` (preferred) or the legacy `base_url` field. A corpus that has neither cannot be updated; the command exits with a clear error pointing at a from scratch rescrape.
+2. Build a reuse index from the existing corpus: `content_hash -> { keywords, use_cases, tags, priority }`. For corpora that predate ADR-0012 (no `_meta.content_hash`), recompute the hash from `content` so legacy corpora work without migration.
+3. Run discover, filter, fetch with `force_refresh=True`. The new flag bypasses the slug skip behaviour in fetch.py so a changed upstream page is actually redownloaded. Without it, the existing resume logic would mask exactly the drift we are trying to detect.
+4. Rechunk all fetched pages. Each fresh chunk carries its own `content_hash` from ADR-0012.
+5. For each fresh chunk, look up its `content_hash` in the reuse index. Hit means carry forward the enrichment values; miss means the chunk is genuinely new or changed and needs the LLM.
+6. Show a cost preview (reused / new / removed / added URL counts plus the OpenRouter dollar estimate from `enrich.estimate_cost`) and prompt for confirmation. `--yes` skips the prompt for scripted runs.
+7. Enrich only the new chunks. The enrichment cache from ADR-0012 catches any further reuse the chunk identity index could not see (different model swap recovery, prompt invariance).
+8. Compose the final section list in fresh chunk order. Reused sections keep their carried over enrichment values but adopt the fresh chunk's structural fields (`title`, `path`, `url`) so an upstream page reorganisation is reflected.
+9. Write the updated corpus back to the same JSON path. `auto_seed` is left to the user via `kctx index` because update writes to the corpus committed in the repo, not to the local indexed store the MCP server reads.
+
+The integrity unit is the chunk's `content_hash`, not the page or the section. Two changed paragraphs inside a 50 chunk page only re enrich those two chunks.
+
+## Alternatives Considered
+
+**Page level reuse.** Compare the per page sidecar's `content_hash` (ADR-0012) to a stored equivalent and skip the rechunk when the page is identical. Faster than rechunking everything, but rechunking is microseconds per page and the corpus does not currently store a per page hash; adding one for marginal speed up is premature optimisation. Chunk level reuse is correct without it. The page sidecar stays useful for the audit subcommand and for future PRs that want to short circuit the LLM cache lookup.
+
+**Force a full rescrape under a flag.** Considered as a stopgap. Rejected because the LLM cost ($1 to $3 per corpus per refresh) is the entire problem statement; a stopgap that does not solve it is not worth shipping.
+
+**Diff against the audit report from ADR-0013.** Considered as input. Rejected because audit is a snapshot of upstream URL health, not a fresh fetch. Update needs the actual fresh content to compute new hashes, so it duplicates a small amount of audit's URL traversal but with full GET. Audit and update remain orthogonal: audit answers "is this corpus aligned"; update acts on the answer.
+
+**Mutate `data/<name>.json` in place atomically.** Discussed. Current implementation writes through `save_and_index(..., auto_seed=False)`, which uses the same path the original export wrote to. Atomic write via tempfile + replace is a future hardening; the current `save_and_index` is consistent with how export works for fresh scrapes, and update should not diverge there.
+
+**Skip the cost preview by default.** Rejected. Even with cache hits, an unintended `--update` against a corpus with hundreds of changed chunks could silently spend $5+. Cost preview plus confirmation matches the existing fresh scrape ergonomics in `cli.run_pipeline`, where the same prompt fires before enrichment.
+
+## Consequences
+
+A contributor can now run `king-scrape audit my-corpus`, see broken URLs and orphans, then `king-scrape update my-corpus --yes` to actually refresh. The combined flow is one read only check followed by one cheap action.
+
+Cost scales with churn, not with corpus size. A 700 chunk corpus where 5 chunks changed costs the LLM call price for 5 chunks plus negligible disk I/O, vs. the previous full rescrape cost of all 700.
+
+The provider Protocols stay untouched (ADR-0010); `force_refresh` is an additive boolean on `fetch_pages`, not on the FetchProvider contract. Crawl4AI and Firecrawl handle update transparently.
+
+Update writes back to `data/<name>.json` at the same path the original lived. A contributor can `git diff data/<name>.json` to inspect exactly which sections changed before committing the refresh, which is a meaningful QA improvement for community corpus contributions.
+
+`auto_seed=False` on the export means the user's local MCP index is not automatically refreshed. They run `kctx index .king-context/data/<name>.json` (or `kctx index --all`) when they want the new corpus visible to retrieval. This matches the project's existing ethos: indexed retrieval state is reproducible from the JSON committed in the repo, never the source of truth.
+
+The dispatcher pattern grows to two subcommands (`audit`, `update`); a third or fourth would justify a real argparse subparser refactor. For now the four line `if argv[1] == "X":` branch is the right shape.
+
+## Links
+
+src/king_context/scraper/update.py
+src/king_context/scraper/fetch.py
+src/king_context/scraper/cli.py
+.king-context/adr/0012-content-hash-provenance-and-enrichment-cache.md
+.king-context/adr/0013-corpus-drift-audit-subcommand.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corpus file or the database. No LLM cost. Markdown report lands at
   `.king-context/audit/<name>-<ts>.md`. Exit code is `0` on clean,
   `2` when at least one section is broken, so it can gate a CI job.
+- `king-scrape update <name>` subcommand (ADR-0014). Refetches the
+  upstream of an indexed corpus, rechunks, and reuses every section
+  whose chunked content is byte identical to the previous scrape.
+  Only new or changed chunks are sent to the LLM, so a typical
+  refresh costs cents instead of dollars even on a large corpus.
+  Reused sections carry forward `keywords`, `use_cases`, `tags`,
+  `priority` from the existing corpus but adopt fresh `title`,
+  `path`, `url` so a page reorganisation upstream is reflected.
+  Cost preview before enrichment; `--yes` skips the prompt. Writes
+  back to the same `data/<name>.json` path so `git diff` shows
+  exactly what changed. Pre ADR-0012 corpora (no
+  `_meta.content_hash`) are handled by recomputing the hash from
+  `content`. The work directory is reset at the start of every
+  update and the corpus JSON is written atomically (tempfile plus
+  rename). `fetch_pages` gains a `force_refresh=True` flag so the
+  update flow can refetch every URL regardless of cached state.
 
 ## [0.4.0] - 2026-05-06
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -15,7 +15,9 @@ King Context installs three command-line tools:
 - `kctx`: search, read, index, and validate local retrieval stores.
 - `king-scrape`: scrape a documentation site and export indexed sections.
   Also exposes `king-scrape audit <name>` to check an indexed corpus
-  for broken, moved, or drifted URLs.
+  for broken, moved, or drifted URLs, and `king-scrape update <name>`
+  to incrementally refresh an existing corpus, paying LLM cost only
+  for new or changed chunks.
 - `king-research`: build and index a research corpus for a topic.
 
 The `kctx` command searches two content stores by default:
@@ -532,6 +534,53 @@ The optional discovery diff calls the configured `DiscoveryProvider`
 (Firecrawl or Crawl4AI) to remap the upstream and lists URLs added or
 removed since the corpus was indexed. Use `--no-discover` to skip the
 provider step entirely.
+
+## Refresh an indexed corpus
+
+Use `king-scrape update <name>` to bring an indexed corpus back in line with
+its upstream source. The command refetches every page, rechunks, and reuses
+every section whose chunked content is byte identical to the previous scrape.
+Only new or changed chunks are sent to the LLM, so a typical refresh costs
+cents instead of dollars even on a corpus with hundreds of pages.
+
+```bash
+king-scrape update elevenlabs-api
+```
+
+The flow:
+
+1. Locate `data/<name>.json` (or `.king-context/data/<name>.json`).
+2. Resolve the source URL from `_meta.source_url`, falling back to `base_url`.
+3. Run discover, filter, and fetch with `force_refresh=True` so changed pages
+   are actually re-downloaded instead of being skipped by the resume logic.
+4. Rechunk all fetched pages.
+5. For each fresh chunk, look up `content_hash` in the existing corpus. Hit:
+   carry forward the enrichment values. Miss: enqueue for the LLM.
+6. Show a cost preview (reused / new / removed / added URL counts plus the
+   OpenRouter dollar estimate) and prompt for confirmation. `--yes` skips
+   the prompt for scripted runs.
+7. Enrich only the new chunks. Reused sections take fresh `title`, `path`,
+   `url` so a page reorganisation upstream is reflected.
+8. Write the merged corpus back to the same JSON path. `git diff` then shows
+   exactly what changed.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--yes` | off | Skip the cost confirmation prompt before enrichment. |
+| `--corpus-path <path>` | inferred | Explicit corpus JSON path; bypasses the default lookup in `data/<name>.json` and `.king-context/data/<name>.json`. |
+| `--provider <name>` | env / inferred | Override the scraper provider for this run (always wins over `SCRAPE_PROVIDER`). |
+| `--model <id>` | env / default | Override the OpenRouter model for enrichment. |
+
+The work directory at `.king-context/_temp/<host>/` is reset at the start of
+every update so stale state from a prior run cannot leak into the new corpus.
+The corpus JSON is written atomically (tempfile plus rename) so an interrupted
+update never leaves a partial file. If discover or filter produces zero
+URLs, the update aborts before writing and the original corpus is preserved.
+
+`auto_seed` is intentionally off: update writes to the corpus committed in
+the repo, not to the local indexed store. After a successful update, refresh
+the local index with `kctx index .king-context/data/<name>.json` (or
+`kctx index --all`).
 
 ## LLM Provider Configuration
 

--- a/src/king_context/scraper/cli.py
+++ b/src/king_context/scraper/cli.py
@@ -258,7 +258,8 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="king-scrape",
         description=(
             "Scrape and index documentation for King Context. "
-            "Use `king-scrape audit <name>` to check an existing corpus for drift."
+            "Use `king-scrape audit <name>` to check an existing corpus for "
+            "drift, or `king-scrape update <name>` to refresh it cheaply."
         ),
     )
     parser.add_argument("url", help="Base URL of the documentation to scrape")
@@ -350,9 +351,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
-    if len(sys.argv) > 1 and sys.argv[1] == "audit":
-        from king_context.scraper.audit import audit_main
-        sys.exit(audit_main(sys.argv[2:]))
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "audit":
+            from king_context.scraper.audit import audit_main
+            sys.exit(audit_main(sys.argv[2:]))
+        if sys.argv[1] == "update":
+            from king_context.scraper.update import update_main
+            sys.exit(update_main(sys.argv[2:]))
 
     parser = _build_parser()
     args = parser.parse_args()

--- a/src/king_context/scraper/fetch.py
+++ b/src/king_context/scraper/fetch.py
@@ -70,16 +70,28 @@ async def fetch_pages(
     output_dir: Path,
     config: ScraperConfig,
     provider: FetchProvider,
+    *,
+    force_refresh: bool = False,
 ) -> FetchResult:
+    """Fetch ``urls`` into ``output_dir/pages/``.
+
+    By default the slug skip behaviour gives idempotent resume. Pass
+    ``force_refresh=True`` to refetch every URL regardless of cached state;
+    used by the update flow (ADR-0014) to detect upstream content drift.
+    """
     pages_dir = output_dir / "pages"
     pages_dir.mkdir(parents=True, exist_ok=True)
 
-    existing_slugs = {f.stem for f in pages_dir.glob("*.md")}
-    pending_urls = [u for u in urls if _url_to_slug(u) not in existing_slugs]
-    skipped = len(urls) - len(pending_urls)
+    if force_refresh:
+        pending_urls = list(urls)
+        skipped = 0
+    else:
+        existing_slugs = {f.stem for f in pages_dir.glob("*.md")}
+        pending_urls = [u for u in urls if _url_to_slug(u) not in existing_slugs]
+        skipped = len(urls) - len(pending_urls)
 
-    if skipped > 0:
-        print(f"Resuming: {skipped} pages already fetched, {len(pending_urls)} remaining")
+        if skipped > 0:
+            print(f"Resuming: {skipped} pages already fetched, {len(pending_urls)} remaining")
 
     semaphore = asyncio.Semaphore(config.concurrency)
 

--- a/src/king_context/scraper/update.py
+++ b/src/king_context/scraper/update.py
@@ -1,0 +1,365 @@
+"""Incremental refresh of an indexed corpus.
+
+Re-runs the scraper pipeline against the upstream of an existing
+``data/<name>.json`` corpus, but reuses every section whose chunked content
+is byte identical to what the previous scrape produced. Only chunks whose
+``content_hash`` is new (added or changed) get sent to the LLM, so a typical
+documentation refresh costs cents instead of dollars even on a large corpus.
+
+The integrity unit is the chunk's ``sha256(content)`` from ADR-0012. When a
+chunk's hash matches an existing section, the existing enrichment values
+(``keywords``, ``use_cases``, ``tags``, ``priority``) are carried forward but
+the structural fields (``title``, ``path``, ``url``) come from the fresh chunk
+so a page reorganisation upstream is reflected accurately.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from scraper_providers import (
+    ProviderUnavailableError,
+    get_discovery_provider,
+    get_fetch_provider,
+    resolve_provider_name,
+)
+
+from king_context import PROJECT_ROOT
+from king_context.scraper.chunk import Chunk, chunk_pages
+from king_context.scraper.config import ScraperConfig, load_config
+from king_context.scraper.discover import discover_urls, get_work_dir
+from king_context.scraper.enrich import (
+    EnrichedChunk,
+    enrich_chunks,
+    estimate_cost,
+)
+from king_context.scraper.export import export_to_json, save_and_index
+from king_context.scraper.fetch import fetch_pages
+from king_context.scraper.filter import filter_urls
+
+
+@dataclass
+class UpdatePlan:
+    """Result of comparing a fresh scrape against the existing corpus."""
+    reused_chunks: list[Chunk] = field(default_factory=list)
+    new_chunks: list[Chunk] = field(default_factory=list)
+    fresh_urls: set[str] = field(default_factory=set)
+    corpus_urls: set[str] = field(default_factory=set)
+
+    @property
+    def removed_urls(self) -> list[str]:
+        return sorted(self.corpus_urls - self.fresh_urls)
+
+    @property
+    def added_urls(self) -> list[str]:
+        return sorted(self.fresh_urls - self.corpus_urls)
+
+
+@dataclass
+class UpdateReport:
+    name: str
+    reused: int
+    enriched: int
+    removed_urls: list[str]
+    added_urls: list[str]
+    total_sections: int
+
+
+def _candidate_corpus_paths(name: str) -> list[Path]:
+    return [
+        PROJECT_ROOT / ".king-context" / "data" / f"{name}.json",
+        PROJECT_ROOT / "data" / f"{name}.json",
+    ]
+
+
+def find_corpus(name: str) -> Path:
+    for path in _candidate_corpus_paths(name):
+        if path.exists():
+            return path
+    searched = "\n  ".join(str(p) for p in _candidate_corpus_paths(name))
+    raise FileNotFoundError(f"Corpus '{name}' not found. Searched:\n  {searched}")
+
+
+def _load_corpus(corpus_path: Path) -> dict:
+    raw = corpus_path.read_text(encoding="utf-8")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"corpus at {corpus_path} is not valid JSON: {exc}") from exc
+
+
+def _section_hash(section: dict) -> str:
+    """Resolve a section's content hash, falling back to a recompute for legacy corpora."""
+    stored = section.get("_meta", {}).get("content_hash")
+    if stored:
+        return stored
+    return hashlib.sha256(section.get("content", "").encode("utf-8")).hexdigest()
+
+
+def _enrichment_from_section(section: dict) -> dict:
+    return {
+        "keywords": section["keywords"],
+        "use_cases": section["use_cases"],
+        "tags": section["tags"],
+        "priority": section["priority"],
+    }
+
+
+def _resolve_source_url(corpus: dict) -> str:
+    return (
+        corpus.get("_meta", {}).get("source_url")
+        or corpus.get("base_url")
+        or ""
+    )
+
+
+def _build_reuse_index(corpus: dict) -> dict[str, dict]:
+    """Map ``content_hash`` to its enrichment values, plus the URL that produced it."""
+    out: dict[str, dict] = {}
+    for s in corpus.get("sections", []):
+        out[_section_hash(s)] = {
+            **_enrichment_from_section(s),
+            "_url": s.get("url", ""),
+        }
+    return out
+
+
+def _plan_update(
+    fresh_chunks: list[Chunk],
+    fresh_urls: Iterable[str],
+    reuse_index: dict[str, dict],
+    corpus: dict,
+) -> UpdatePlan:
+    plan = UpdatePlan(
+        fresh_urls=set(fresh_urls),
+        corpus_urls={s.get("url", "") for s in corpus.get("sections", [])},
+    )
+    for chunk in fresh_chunks:
+        if chunk.content_hash in reuse_index:
+            plan.reused_chunks.append(chunk)
+        else:
+            plan.new_chunks.append(chunk)
+    return plan
+
+
+def _materialise_reused(
+    chunks: list[Chunk], reuse_index: dict[str, dict]
+) -> list[EnrichedChunk]:
+    """Build EnrichedChunk objects from carried over enrichment metadata."""
+    out: list[EnrichedChunk] = []
+    for chunk in chunks:
+        carried = reuse_index[chunk.content_hash]
+        out.append(EnrichedChunk(
+            title=chunk.title,
+            path=chunk.path,
+            url=chunk.source_url,
+            content=chunk.content,
+            keywords=list(carried["keywords"]),
+            use_cases=list(carried["use_cases"]),
+            tags=list(carried["tags"]),
+            priority=carried["priority"],
+            content_hash=chunk.content_hash,
+        ))
+    return out
+
+
+def _interleave_in_chunk_order(
+    fresh_chunks: list[Chunk],
+    reused: list[EnrichedChunk],
+    enriched: list[EnrichedChunk],
+) -> list[EnrichedChunk]:
+    """Return the merged enriched list in the order of ``fresh_chunks``."""
+    by_hash: dict[str, EnrichedChunk] = {}
+    for e in reused:
+        by_hash[e.content_hash] = e
+    for e in enriched:
+        by_hash[e.content_hash] = e
+    out: list[EnrichedChunk] = []
+    for chunk in fresh_chunks:
+        e = by_hash.get(chunk.content_hash)
+        if e is not None:
+            out.append(e)
+    return out
+
+
+async def _confirm_cost(plan: UpdatePlan, config: ScraperConfig, *, yes: bool) -> bool:
+    cost = estimate_cost(plan.new_chunks, config)
+    print(
+        f"  reused: {len(plan.reused_chunks)}, "
+        f"new: {len(plan.new_chunks)}, "
+        f"removed URLs: {len(plan.removed_urls)}, "
+        f"added URLs: {len(plan.added_urls)}"
+    )
+    if cost.get("provider") == "openrouter":
+        print(
+            f"  cost estimate: ${cost['estimated_cost']:.4f} "
+            f"({cost['total_chunks']} chunks, model: {cost['model']})"
+        )
+    else:
+        print(
+            f"  local model estimate: {cost['total_chunks']} chunks, "
+            f"model: {cost['model']} (no estimated OpenRouter cost)"
+        )
+    if yes:
+        return True
+    answer = input("Proceed with enrichment? [y/N] ").strip().lower()
+    return answer in ("y", "yes")
+
+
+async def update_corpus(
+    *,
+    name: str,
+    corpus_path: Path,
+    config: ScraperConfig,
+    yes: bool = False,
+) -> UpdateReport:
+    corpus = _load_corpus(corpus_path)
+    source_url = _resolve_source_url(corpus)
+    if not source_url:
+        raise ValueError(
+            "corpus has no source_url in _meta and no base_url. "
+            "Re-scrape from scratch with `king-scrape <url> --name <name>`."
+        )
+
+    discovery_provider = get_discovery_provider(resolve_provider_name("discover"))
+    fetch_provider = get_fetch_provider(resolve_provider_name("fetch"))
+
+    work_dir = get_work_dir(source_url)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[update] target: {name} ({source_url})")
+    print("[discover] running...")
+    discovery = await discover_urls(source_url, config, discovery_provider)
+    print(f"  found {discovery.total_urls} URLs")
+
+    print("[filter] running...")
+    filtered = filter_urls(discovery.urls, source_url, config)
+    print(
+        f"  accepted {len(filtered.accepted)}, "
+        f"rejected {len(filtered.rejected)}, "
+        f"maybe {len(filtered.maybe)}"
+    )
+
+    print("[fetch] running (force refresh)...")
+    fetch_result = await fetch_pages(
+        filtered.accepted,
+        work_dir,
+        config,
+        fetch_provider,
+        force_refresh=True,
+    )
+    print(f"  fetched {fetch_result.completed}, failed {fetch_result.failed}")
+
+    print("[chunk] running...")
+    fresh_chunks = chunk_pages(work_dir / "pages", work_dir, config)
+    print(f"  produced {len(fresh_chunks)} chunks")
+
+    reuse_index = _build_reuse_index(corpus)
+    plan = _plan_update(fresh_chunks, filtered.accepted, reuse_index, corpus)
+
+    print("[plan]")
+    proceed = await _confirm_cost(plan, config, yes=yes)
+    if not proceed:
+        print("aborted by user")
+        raise SystemExit(1)
+
+    print("[enrich] running...")
+    enriched_new = await enrich_chunks(plan.new_chunks, config, work_dir)
+    print(f"  enriched {len(enriched_new)} new chunks")
+
+    reused_enriched = _materialise_reused(plan.reused_chunks, reuse_index)
+    final = _interleave_in_chunk_order(fresh_chunks, reused_enriched, enriched_new)
+
+    doc = export_to_json(
+        final,
+        doc_name=corpus.get("name", name),
+        display_name=corpus.get("display_name", name),
+        base_url=corpus.get("base_url", source_url),
+        version=corpus.get("version", "v1"),
+    )
+
+    print("[export] running...")
+    save_and_index(doc, corpus_path, auto_seed=False)
+
+    return UpdateReport(
+        name=name,
+        reused=len(reused_enriched),
+        enriched=len(enriched_new),
+        removed_urls=plan.removed_urls,
+        added_urls=plan.added_urls,
+        total_sections=len(final),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="king-scrape update",
+        description=(
+            "Incrementally refresh an indexed corpus. Reuses every section "
+            "whose chunked content is unchanged; only new or changed chunks "
+            "are sent to the LLM."
+        ),
+    )
+    parser.add_argument("name", help="Doc name (matches data/<name>.json)")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the cost confirmation prompt before enrichment.",
+    )
+    parser.add_argument(
+        "--provider",
+        default=None,
+        help="Scraper provider name (e.g. 'firecrawl', 'crawl4ai').",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="OpenRouter model for enrichment.",
+    )
+    return parser
+
+
+def update_main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.provider:
+        os.environ.setdefault("SCRAPE_PROVIDER", args.provider)
+
+    try:
+        corpus_path = find_corpus(args.name)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    config = load_config(enrichment_model=args.model)
+
+    try:
+        report = asyncio.run(update_corpus(
+            name=args.name,
+            corpus_path=corpus_path,
+            config=config,
+            yes=args.yes,
+        ))
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ProviderUnavailableError as exc:
+        print(f"error: {exc.hint}", file=sys.stderr)
+        return 3
+    except SystemExit as exc:
+        return int(exc.code or 1)
+
+    print(
+        f"update {report.name}: "
+        f"{report.total_sections} sections "
+        f"(reused {report.reused}, enriched {report.enriched}, "
+        f"+{len(report.added_urls)} URLs / -{len(report.removed_urls)} URLs)"
+    )
+    return 0

--- a/src/king_context/scraper/update.py
+++ b/src/king_context/scraper/update.py
@@ -20,7 +20,9 @@ import asyncio
 import hashlib
 import json
 import os
+import shutil
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
@@ -41,7 +43,7 @@ from king_context.scraper.enrich import (
     enrich_chunks,
     estimate_cost,
 )
-from king_context.scraper.export import export_to_json, save_and_index
+from king_context.scraper.export import export_to_json
 from king_context.scraper.fetch import fetch_pages
 from king_context.scraper.filter import filter_urls
 
@@ -68,6 +70,7 @@ class UpdateReport:
     name: str
     reused: int
     enriched: int
+    lost: int
     removed_urls: list[str]
     added_urls: list[str]
     total_sections: int
@@ -97,11 +100,56 @@ def _load_corpus(corpus_path: Path) -> dict:
 
 
 def _section_hash(section: dict) -> str:
-    """Resolve a section's content hash, falling back to a recompute for legacy corpora."""
+    """Resolve a section's content hash, falling back to a recompute for legacy corpora.
+
+    The fallback assumes the JSON-stored ``content`` round-trips to the same bytes
+    a fresh chunk produces; under the standard ``json.loads`` settings (NFC unicode,
+    UTF-8 encoding) this holds. Corpora with non-NFC content will miss-match here
+    and pay LLM cost on the first update; subsequent updates after that one
+    rewrites the corpus carry the stored ``_meta.content_hash`` and cost nothing.
+    """
     stored = section.get("_meta", {}).get("content_hash")
     if stored:
         return stored
     return hashlib.sha256(section.get("content", "").encode("utf-8")).hexdigest()
+
+
+def _reset_work_dir(work_dir: Path) -> None:
+    """Wipe per-stage state so update never inherits artifacts from a prior run.
+
+    Critical for correctness: stale ``enriched/batch_*.json`` triggers the resume
+    logic in ``enrich.py`` and silently returns the OLD batch contents instead of
+    enriching the fresh chunks. Stale ``pages/*.md`` from URLs no longer present
+    upstream would survive ``chunk_pages`` and resurface in the new corpus as
+    "reused" because their content hash still matches the old sections.
+    """
+    for sub in ("pages", "chunks", "enriched"):
+        target = work_dir / sub
+        if target.exists():
+            shutil.rmtree(target)
+    manifest = work_dir / "manifest.json"
+    if manifest.exists():
+        manifest.unlink()
+
+
+def _atomic_write_json(path: Path, doc: dict) -> None:
+    """Write JSON via tempfile + os.replace so an interrupted update never leaves a partial file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(doc, indent=2, ensure_ascii=False)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp_name, path)
+        tmp_name = None
+    finally:
+        if tmp_name is not None and Path(tmp_name).exists():
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
 
 
 def _enrichment_from_section(section: dict) -> dict:
@@ -234,6 +282,7 @@ async def update_corpus(
 
     work_dir = get_work_dir(source_url)
     work_dir.mkdir(parents=True, exist_ok=True)
+    _reset_work_dir(work_dir)
 
     print(f"[update] target: {name} ({source_url})")
     print("[discover] running...")
@@ -262,6 +311,16 @@ async def update_corpus(
     fresh_chunks = chunk_pages(work_dir / "pages", work_dir, config)
     print(f"  produced {len(fresh_chunks)} chunks")
 
+    # Refuse to wipe a non-empty corpus when discover/filter produced nothing.
+    # Most often this is a network blip or an over-aggressive filter regex; the
+    # original corpus is the safer artifact to preserve.
+    if not fresh_chunks and corpus.get("sections"):
+        raise ValueError(
+            f"refused to overwrite {corpus_path} with an empty corpus "
+            f"(discover/filter produced 0 URLs). The existing corpus is "
+            "untouched. Investigate before retrying."
+        )
+
     reuse_index = _build_reuse_index(corpus)
     plan = _plan_update(fresh_chunks, filtered.accepted, reuse_index, corpus)
 
@@ -271,9 +330,20 @@ async def update_corpus(
         print("aborted by user")
         raise SystemExit(1)
 
-    print("[enrich] running...")
-    enriched_new = await enrich_chunks(plan.new_chunks, config, work_dir)
-    print(f"  enriched {len(enriched_new)} new chunks")
+    if plan.new_chunks:
+        print("[enrich] running...")
+        enriched_new = await enrich_chunks(plan.new_chunks, config, work_dir)
+        print(f"  enriched {len(enriched_new)} new chunks")
+    else:
+        print("[enrich] nothing to enrich (all chunks reused)")
+        enriched_new = []
+
+    lost = len(plan.new_chunks) - len(enriched_new)
+    if lost > 0:
+        print(
+            f"warning: {lost} chunk(s) failed enrichment and are not in "
+            "the output corpus"
+        )
 
     reused_enriched = _materialise_reused(plan.reused_chunks, reuse_index)
     final = _interleave_in_chunk_order(fresh_chunks, reused_enriched, enriched_new)
@@ -287,12 +357,13 @@ async def update_corpus(
     )
 
     print("[export] running...")
-    save_and_index(doc, corpus_path, auto_seed=False)
+    _atomic_write_json(corpus_path, doc)
 
     return UpdateReport(
         name=name,
         reused=len(reused_enriched),
         enriched=len(enriched_new),
+        lost=lost,
         removed_urls=plan.removed_urls,
         added_urls=plan.added_urls,
         total_sections=len(final),
@@ -315,6 +386,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Skip the cost confirmation prompt before enrichment.",
     )
     parser.add_argument(
+        "--corpus-path",
+        type=Path,
+        default=None,
+        help=(
+            "Explicit path to the corpus JSON. Bypasses the default lookup in "
+            "data/<name>.json and .king-context/data/<name>.json."
+        ),
+    )
+    parser.add_argument(
         "--provider",
         default=None,
         help="Scraper provider name (e.g. 'firecrawl', 'crawl4ai').",
@@ -330,13 +410,24 @@ def _build_parser() -> argparse.ArgumentParser:
 def update_main(argv: list[str]) -> int:
     args = _build_parser().parse_args(argv)
     if args.provider:
-        os.environ.setdefault("SCRAPE_PROVIDER", args.provider)
+        # The user explicitly asked for this provider on the command line, so
+        # the flag wins over any pre-existing env (unlike the existing
+        # cli.run_pipeline path which uses setdefault). Stage-specific envs
+        # SCRAPE_DISCOVER_PROVIDER / SCRAPE_FETCH_PROVIDER still take
+        # precedence per ADR-0009.
+        os.environ["SCRAPE_PROVIDER"] = args.provider
 
-    try:
-        corpus_path = find_corpus(args.name)
-    except FileNotFoundError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+    if args.corpus_path is not None:
+        corpus_path = args.corpus_path
+        if not corpus_path.exists():
+            print(f"error: corpus path does not exist: {corpus_path}", file=sys.stderr)
+            return 1
+    else:
+        try:
+            corpus_path = find_corpus(args.name)
+        except FileNotFoundError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
 
     config = load_config(enrichment_model=args.model)
 
@@ -356,10 +447,13 @@ def update_main(argv: list[str]) -> int:
     except SystemExit as exc:
         return int(exc.code or 1)
 
+    extras = ""
+    if report.lost > 0:
+        extras = f", lost {report.lost}"
     print(
         f"update {report.name}: "
         f"{report.total_sections} sections "
-        f"(reused {report.reused}, enriched {report.enriched}, "
-        f"+{len(report.added_urls)} URLs / -{len(report.removed_urls)} URLs)"
+        f"(reused {report.reused}, enriched {report.enriched}{extras}, "
+        f"added {len(report.added_urls)} URLs, removed {len(report.removed_urls)} URLs)"
     )
     return 0

--- a/tests/test_scraper/test_update.py
+++ b/tests/test_scraper/test_update.py
@@ -1,0 +1,308 @@
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from king_context.scraper import update
+from king_context.scraper.chunk import Chunk
+from king_context.scraper.config import ScraperConfig
+from king_context.scraper.enrich import EnrichedChunk
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _section(content: str, **overrides) -> dict:
+    base = {
+        "title": "T",
+        "path": "/p",
+        "url": "https://docs.example.com/page",
+        "keywords": ["k1", "k2", "k3", "k4", "k5"],
+        "use_cases": ["Use when X", "Configure when Y"],
+        "tags": ["api"],
+        "priority": 8,
+        "content": content,
+        "_meta": {"content_hash": _hash(content)},
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_corpus(tmp_path: Path, sections=None, source_url=None) -> Path:
+    corpus = {
+        "name": "demo",
+        "display_name": "Demo",
+        "version": "v1",
+        "base_url": "https://docs.example.com",
+        "sections": sections if sections is not None else [
+            _section("aaa", title="A"),
+            _section("bbb", title="B"),
+        ],
+        "_meta": {"source_url": source_url or "https://docs.example.com"},
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(corpus))
+    return path
+
+
+def _chunk(content: str, **overrides) -> Chunk:
+    base = dict(
+        title="T",
+        breadcrumb="T",
+        content=content,
+        source_url="https://docs.example.com/page",
+        path="/page/t",
+        token_count=10,
+    )
+    base.update(overrides)
+    return Chunk(**base)
+
+
+# --- pure unit logic ------------------------------------------------------
+
+
+def test_section_hash_uses_meta_when_present():
+    assert update._section_hash(_section("foo")) == _hash("foo")
+
+
+def test_section_hash_falls_back_to_content_when_meta_missing():
+    legacy = {"content": "legacy", "keywords": [], "use_cases": [], "tags": [], "priority": 1}
+    assert update._section_hash(legacy) == _hash("legacy")
+
+
+def test_resolve_source_url_prefers_meta():
+    corpus = {
+        "base_url": "https://docs.example.com",
+        "_meta": {"source_url": "https://docs.example.com/v2"},
+    }
+    assert update._resolve_source_url(corpus) == "https://docs.example.com/v2"
+
+
+def test_resolve_source_url_falls_back_to_base_url():
+    corpus = {"base_url": "https://docs.example.com"}
+    assert update._resolve_source_url(corpus) == "https://docs.example.com"
+
+
+def test_build_reuse_index():
+    corpus = {"sections": [_section("aaa"), _section("bbb")]}
+    index = update._build_reuse_index(corpus)
+    assert _hash("aaa") in index
+    assert _hash("bbb") in index
+    assert index[_hash("aaa")]["keywords"] == ["k1", "k2", "k3", "k4", "k5"]
+
+
+def test_plan_update_classifies_chunks():
+    corpus = {"sections": [_section("aaa"), _section("bbb")]}
+    reuse = update._build_reuse_index(corpus)
+    fresh = [_chunk("aaa"), _chunk("ccc")]  # one reused, one new
+    plan = update._plan_update(
+        fresh,
+        ["https://docs.example.com/page"],
+        reuse,
+        corpus,
+    )
+    assert [c.content for c in plan.reused_chunks] == ["aaa"]
+    assert [c.content for c in plan.new_chunks] == ["ccc"]
+
+
+def test_plan_added_and_removed_urls():
+    corpus = {
+        "sections": [
+            _section("a", url="https://x/old"),
+            _section("b", url="https://x/keep"),
+        ],
+    }
+    fresh_urls = ["https://x/keep", "https://x/new"]
+    plan = update._plan_update([], fresh_urls, {}, corpus)
+    assert plan.added_urls == ["https://x/new"]
+    assert plan.removed_urls == ["https://x/old"]
+
+
+def test_materialise_reused_carries_enrichment_but_takes_fresh_identity():
+    """Reused chunks adopt fresh title/path/url, keep enrichment values."""
+    corpus = {"sections": [_section("aaa", title="OLD", path="/old/path")]}
+    reuse = update._build_reuse_index(corpus)
+    fresh = [_chunk("aaa", title="NEW", path="/new/path",
+                    source_url="https://docs.example.com/new")]
+    materialised = update._materialise_reused(fresh, reuse)
+    assert len(materialised) == 1
+    e = materialised[0]
+    assert e.title == "NEW"  # fresh identity
+    assert e.path == "/new/path"
+    assert e.url == "https://docs.example.com/new"
+    assert e.keywords == ["k1", "k2", "k3", "k4", "k5"]  # carried forward
+    assert e.priority == 8
+
+
+def test_interleave_in_chunk_order_preserves_fresh_order():
+    fresh = [_chunk("aaa"), _chunk("bbb"), _chunk("ccc")]
+    reused = [
+        EnrichedChunk(
+            title="A", path="/a", url="u", content="aaa",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("aaa"),
+        ),
+        EnrichedChunk(
+            title="C", path="/c", url="u", content="ccc",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("ccc"),
+        ),
+    ]
+    enriched = [
+        EnrichedChunk(
+            title="B", path="/b", url="u", content="bbb",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("bbb"),
+        ),
+    ]
+    final = update._interleave_in_chunk_order(fresh, reused, enriched)
+    assert [e.content for e in final] == ["aaa", "bbb", "ccc"]
+
+
+# --- find_corpus + load_corpus -------------------------------------------
+
+
+def test_find_corpus_raises_when_missing():
+    with pytest.raises(FileNotFoundError):
+        update.find_corpus("does-not-exist-anywhere")
+
+
+def test_load_corpus_raises_on_bad_json(tmp_path: Path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        update._load_corpus(bad)
+
+
+# --- update_corpus end to end (with mocked pipeline) ---------------------
+
+
+def _patch_pipeline(monkeypatch, *, fresh_chunks, fresh_urls, enriched_new):
+    """Replace every network or LLM call in update_corpus with stubs."""
+
+    async def fake_discover(base_url, config, provider):
+        from king_context.scraper.discover import DiscoveryResult
+        return DiscoveryResult(
+            base_url=base_url,
+            discovered_at="2026-05-08T00:00:00+00:00",
+            total_urls=len(fresh_urls),
+            urls=list(fresh_urls),
+        )
+
+    def fake_filter(urls, base_url, config):
+        from king_context.scraper.filter import FilterResult
+        return FilterResult(
+            accepted=list(urls),
+            rejected=[],
+            maybe=[],
+            filter_method="heuristic",
+            llm_fallback_used=False,
+        )
+
+    async def fake_fetch(urls, work_dir, config, provider, *, force_refresh=False):
+        from king_context.scraper.fetch import FetchResult
+        return FetchResult(total=len(urls), completed=len(urls), failed=0, results=[])
+
+    def fake_chunk(pages_dir, work_dir, config):
+        return list(fresh_chunks)
+
+    async def fake_enrich(chunks, config, work_dir):
+        return list(enriched_new)
+
+    monkeypatch.setattr(update, "discover_urls", fake_discover)
+    monkeypatch.setattr(update, "filter_urls", fake_filter)
+    monkeypatch.setattr(update, "fetch_pages", fake_fetch)
+    monkeypatch.setattr(update, "chunk_pages", fake_chunk)
+    monkeypatch.setattr(update, "enrich_chunks", fake_enrich)
+    # Skip provider resolution entirely.
+    monkeypatch.setattr(update, "get_discovery_provider", lambda *a, **k: object())
+    monkeypatch.setattr(update, "get_fetch_provider", lambda *a, **k: object())
+    monkeypatch.setattr(update, "resolve_provider_name", lambda *a, **k: "firecrawl")
+
+
+def test_update_corpus_reuses_unchanged_and_enriches_new(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[
+            _section("aaa", title="A"),
+            _section("bbb", title="B"),
+        ],
+    )
+    fresh_chunks = [_chunk("aaa"), _chunk("ccc")]  # bbb removed, ccc new
+    enriched_new = [
+        EnrichedChunk(
+            title="C", path="/c", url="u", content="ccc",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("ccc"),
+        ),
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=enriched_new,
+    )
+
+    config = ScraperConfig(openrouter_api_key="test")
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=config,
+        yes=True,
+    ))
+
+    assert report.reused == 1
+    assert report.enriched == 1
+    assert report.total_sections == 2
+
+    rewritten = json.loads(corpus_path.read_text())
+    contents = [s["content"] for s in rewritten["sections"]]
+    assert contents == ["aaa", "ccc"]
+
+
+def test_update_corpus_errors_when_no_source_url(tmp_path: Path):
+    corpus = {
+        "name": "demo",
+        "version": "v1",
+        "base_url": "",
+        "sections": [],
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(corpus))
+
+    with pytest.raises(ValueError, match="source_url"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+
+
+def test_update_main_returns_1_when_corpus_missing(capsys):
+    rc = update.update_main(["does-not-exist", "--yes"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err.lower()
+
+
+def test_update_main_exit_code_on_user_abort(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(tmp_path)
+    monkeypatch.setattr("builtins.input", lambda *_: "n")
+
+    fresh_chunks = [_chunk("zzz")]  # forces an enrichment prompt
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+    monkeypatch.setattr(update, "find_corpus", lambda name: corpus_path)
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+
+    rc = update.update_main(["demo"])
+    assert rc == 1

--- a/tests/test_scraper/test_update.py
+++ b/tests/test_scraper/test_update.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -257,6 +258,7 @@ def test_update_corpus_reuses_unchanged_and_enriches_new(tmp_path: Path, monkeyp
 
     assert report.reused == 1
     assert report.enriched == 1
+    assert report.lost == 0
     assert report.total_sections == 2
 
     rewritten = json.loads(corpus_path.read_text())
@@ -288,6 +290,176 @@ def test_update_main_returns_1_when_corpus_missing(capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "not found" in err.lower()
+
+
+def test_update_corpus_refuses_to_wipe_to_empty(tmp_path: Path, monkeypatch):
+    """A discover/filter blip producing 0 URLs must not overwrite the corpus."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A"), _section("bbb", title="B")],
+    )
+    original = corpus_path.read_text()
+
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[],  # discover/filter produced nothing
+        fresh_urls=[],
+        enriched_new=[],
+    )
+
+    with pytest.raises(ValueError, match="empty corpus"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=corpus_path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+
+    # Corpus on disk untouched.
+    assert corpus_path.read_text() == original
+
+
+def test_update_corpus_short_circuits_when_all_chunks_reused(tmp_path: Path, monkeypatch):
+    """If every fresh chunk hashes to an existing section, skip enrich entirely."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A"), _section("bbb", title="B")],
+    )
+    fresh_chunks = [_chunk("aaa"), _chunk("bbb")]
+
+    enrich_calls = {"count": 0}
+
+    async def fake_enrich(chunks, config, work_dir):
+        enrich_calls["count"] += 1
+        return []
+
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+    monkeypatch.setattr(update, "enrich_chunks", fake_enrich)
+
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+
+    assert enrich_calls["count"] == 0
+    assert report.reused == 2
+    assert report.enriched == 0
+
+
+def test_update_corpus_reports_lost_chunks(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(
+        tmp_path, sections=[_section("aaa", title="A")]
+    )
+    fresh_chunks = [_chunk("aaa"), _chunk("xxx"), _chunk("yyy")]
+    # enrich returns only one of two new chunks: simulates a validation failure.
+    enriched_new = [
+        EnrichedChunk(
+            title="X", path="/x", url="u", content="xxx",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("xxx"),
+        ),
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=enriched_new,
+    )
+
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+
+    assert report.reused == 1
+    assert report.enriched == 1
+    assert report.lost == 1
+    assert report.total_sections == 2  # aaa + xxx; yyy lost
+
+
+def test_reset_work_dir_removes_stale_state(tmp_path: Path):
+    work = tmp_path / "work"
+    (work / "pages").mkdir(parents=True)
+    (work / "pages" / "old.md").write_text("stale")
+    (work / "chunks").mkdir(parents=True)
+    (work / "chunks" / "old.json").write_text("[]")
+    (work / "enriched").mkdir(parents=True)
+    (work / "enriched" / "batch_0001.json").write_text("[]")
+    (work / "manifest.json").write_text("{}")
+
+    update._reset_work_dir(work)
+
+    assert not (work / "pages").exists()
+    assert not (work / "chunks").exists()
+    assert not (work / "enriched").exists()
+    assert not (work / "manifest.json").exists()
+
+
+def test_reset_work_dir_is_safe_on_clean_dir(tmp_path: Path):
+    work = tmp_path / "work"
+    work.mkdir()
+    update._reset_work_dir(work)  # must not raise
+
+
+def test_atomic_write_json_writes_complete_file(tmp_path: Path):
+    target = tmp_path / "corpus.json"
+    update._atomic_write_json(target, {"hello": "world"})
+    assert json.loads(target.read_text()) == {"hello": "world"}
+    # No leftover tempfile.
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_update_main_corpus_path_flag_bypasses_lookup(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(tmp_path)
+    fresh_chunks = [_chunk(s["content"]) for s in [_section("aaa"), _section("bbb")]]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+    # find_corpus must NOT be called when --corpus-path is provided.
+    monkeypatch.setattr(update, "find_corpus", lambda name: (_ for _ in ()).throw(
+        AssertionError("find_corpus should not be called when --corpus-path is set")
+    ))
+
+    rc = update.update_main([
+        "demo", "--yes",
+        "--corpus-path", str(corpus_path),
+    ])
+    assert rc == 0
+
+
+def test_update_main_corpus_path_flag_errors_when_missing(tmp_path: Path, capsys):
+    rc = update.update_main([
+        "demo", "--yes",
+        "--corpus-path", str(tmp_path / "nope.json"),
+    ])
+    assert rc == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_update_main_provider_flag_overrides_env(monkeypatch):
+    """Unlike `setdefault`, an explicit --provider should win over a pre-set env."""
+    monkeypatch.setenv("SCRAPE_PROVIDER", "firecrawl")
+    # Force the rest of the run to bail cheaply: corpus not found returns 1.
+    rc = update.update_main([
+        "does-not-exist", "--yes",
+        "--provider", "crawl4ai",
+    ])
+    assert rc == 1
+    assert os.environ["SCRAPE_PROVIDER"] == "crawl4ai"
 
 
 def test_update_main_exit_code_on_user_abort(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

`king-scrape update <name>`. Refetches upstream of an indexed corpus, rechunks, reuses every section whose chunked content is byte identical to the previous scrape. Only new or changed chunks hit the LLM, so a typical refresh costs cents instead of dollars. The integrity unit is the chunk's `content_hash` from ADR-0012; reused sections carry forward `keywords`, `use_cases`, `tags`, `priority` but adopt fresh `title`, `path`, `url` so an upstream page reorganisation is reflected.

  ## Related issue

  Closes #18 

  ## Type of change

  - [x] New feature (non-breaking change that adds functionality)

  ## How it was tested

  pytest -q
  
  725 passed, 1 skipped

  24 tests in `tests/test_scraper/test_update.py`:

  - Pure unit logic: `_section_hash` (with and without `_meta`), `_resolve_source_url` (meta vs base_url fallback), `_build_reuse_index`, `_plan_update` classification + added/removed URL
  - Pure unit logic: `_section_hash` (with and without `_meta`), `_resolve_source_url` (meta vs base_url fallback), `_build_reuse_index`, `_plan_update` classification + added/removed URL diffs, `_materialise_reused` (carries enrichment, takes fresh identity), `_interleave_in_chunk_order` ordering
  - Corpus loading: missing corpus, malformed JSON
  - End-to-end with mocked pipeline: reuse + enrich path produces correct merged JSON, refuse-to-wipe-empty guard, short-circuit when all reused, lost-chunk count surfaced when enrichment validation fails
  - Work-dir reset: stale `pages/`, `chunks/`, `enriched/`, `manifest.json` all wiped; safe on clean dir
  - Atomic write: complete file, no leftover tempfile
  - CLI: `--corpus-path` bypasses lookup, missing path returns 1, `--provider` flag overrides env, user-abort returns 1, missing corpus returns 1

  Haven't run a live update against a real corpus in this PR. Happy to do that as part of review if you want; the audit subcommand from #N (PR 2) plus this one is the natural pair to demo on `data/elevenlabs-api.json`.

  ## Checklist

  - [x] My code follows the project style (English-only code, comments, and identifiers)
  - [x] I ran the test suite locally and it passes (`pytest`)
  - [x] I added or updated tests where it made sense
  - [x] I updated the documentation in `docs/` and/or `README.md` if behavior changed *(new "Refresh an indexed corpus" section in `docs/CLI_GUIDE.md`, command overview row, ADR-0014 added under `.king-context/adr/`, CHANGELOG entry)*
  - [x] I read the [Contributing guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
  - [x] My commits follow the project commit message style
  - [x] I confirmed there are no secrets or credentials in the diff

  ## Additional notes

  A few choices worth flagging:

  - **Subcommand dispatch follows the same pattern as `audit`** from #49  (PR 2): a four-line `if argv[1] == "update":` branch in `cli.main`. No argparse subparser refactor. Two subcommands now use this dispatch; a third would justify the refactor.
  - **Work directory is reset at the start of every update** (`pages/`, `chunks/`, `enriched/`, `manifest.json` wiped). Without this, two distinct critical bugs fire: stale `enriched/batch_*.json` triggers the resume logic in `enrich.py` and silently returns OLD enriched chunks instead of fresh ones; and orphan `pages/*.md` from URLs no longer accepted by the
   filter survive `chunk_pages` and resurface as "reused" sections in the new corpus. Both bugs surfaced in the senior code review pass before push and are now covered by tests. At 10x corpora the reset matters more, not less; cheap and unconditional is the right call.
  - **Refuse to wipe a non-empty corpus to empty.** If discover or filter produces zero URLs (network blip, over-aggressive regex), the update aborts with `ValueError` before writing and the original `data/<name>.json` is untouched. Tested.
  - **Atomic write back via tempfile + `os.replace`.** An interrupted update never leaves a partial JSON file in `data/<name>.json`.
  - **`fetch_pages` gains a `force_refresh=True` keyword arg.** Update calls it with `True` so changed upstream pages are actually re-downloaded instead of being skipped by the existing slug-presence resume logic. Provider Protocols (ADR-0010) are untouched: this is a pipeline-side flag.
  - **Short-circuit when nothing changed.** If every fresh chunk hashes to an existing section, `enrich_chunks` is not called at all (saves one disk-stat round trip and is unambiguously correct). Tested.
  - **Lost chunks are visible.** If 3 of 50 new chunks fail validation through the LLM retries, `UpdateReport.lost = 3`, a warning prints, and the CLI summary includes `lost 3`. Pre-fix this was a silent drop.
  - **`--corpus-path` flag** for non-standard layouts (CI artifacts, monorepo subprojects). Bypasses the default `data/<name>.json` and `.king-context/data/<name>.json` lookup.
  - **`--provider` flag overrides env.** Existing `cli.run_pipeline` uses `setdefault` and silently ignores the flag when `SCRAPE_PROVIDER` is already set; new code in update fixes that
  footgun for its own surface (`os.environ["SCRAPE_PROVIDER"] = ...`). Stage-specific envs (`SCRAPE_DISCOVER_PROVIDER`, `SCRAPE_FETCH_PROVIDER`) still take precedence per ADR-0009. The same fix should land in `cli.run_pipeline` as a follow-up, but that's out of scope here.
  - **`auto_seed=False` on the export.** Update writes back to the corpus committed in the repo, not to the local indexed MCP store. After a successful update, refresh the local index with `kctx index .king-context/data/<name>.json` (or `kctx index --all`). Matches the project's existing ethos: indexed retrieval state is reproducible from the JSON committed in the repo, never the source of truth.

Independent of `audit` functionally; the two compose well as a pair (audit to see drift, update to act on it). ADR-0014 records the rationale and rejects the alternatives (page-level reuse, full rescrape under a flag, diff-against-audit-report, mutate corpus in place without atomic write).