### PR TITLE
fix(scraper): one chunk failure no longer aborts enrich batch (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A single chunk's `ProviderError` no longer aborts the entire concurrent
+  enrich batch (#47). `_enrich_one` is now contract-bound never to raise:
+  non-transient primary errors break the retry loop early and fall through
+  to the schema fallback (the layer designed to absorb malformed JSON);
+  the schema fallback's own failures are absorbed; the chunk is dropped
+  from the output and the batch keeps running. `enrich_chunks` adds
+  `return_exceptions=True` to its `asyncio.gather` call as a defensive
+  guard. Per-chunk failures and per-task `CancelledError`s emit a warning
+  on stderr and a per-batch summary line (`batch NNNN: X enriched, Y
+  dropped`) so contributors can see exactly how many chunks were lost.
+- The schema fallback's enrichments are no longer cached under the
+  primary client's cache key. Pre-fix, a successful schema-fallback
+  response was written to `enrich_cache` keyed by the primary's model;
+  next run with the primary healthy would short-circuit at the cache
+  check and serve fallback content as if it were primary. The cache
+  invariant is now: only successful primary responses are cached.
+- `enrich_chunks` deduplicates the schema fallback when the primary is a
+  `FallbackClient` whose own fallback leg points at the same underlying
+  client. Pre-fix this configuration paid for two LLM calls against the
+  same client per failed chunk; now the schema-fallback step is skipped
+  and the FallbackClient's internal fallback is the only call.
+- The bare `except Exception` in `_enrich_one` was narrowed to
+  `(ProviderError, asyncio.TimeoutError, ValueError, json.JSONDecodeError)`
+  so programming errors (`AttributeError`, `TypeError`, etc.) propagate
+  instead of being silently retried as transient provider hiccups.
+
 ### Added
 
 - Content-hash provenance through every layer of the scraper pipeline

--- a/src/king_context/scraper/enrich.py
+++ b/src/king_context/scraper/enrich.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -231,57 +232,79 @@ async def _enrich_one(
     primary_client: LLMClient,
     schema_fallback: LLMClient | None = None,
 ) -> EnrichedChunk | None:
-    """Enrich a single chunk with up to 2 retries on validation failure."""
-    cache_key = enrich_cache.make_key(
-        chunk.content,
-        primary_client.model,
-        PROMPT_VERSION,
-    )
+    """Enrich a single chunk. Never raises; returns ``None`` on terminal failure.
+
+    Tries the primary client up to three times. Transient ``ProviderError``
+    rounds are retried; a non-transient ``ProviderError`` (e.g. unparseable
+    JSON, schema validation gone wrong) breaks the retry loop early and falls
+    through to the schema fallback. Validation failures use the full retry
+    budget. If the schema fallback also fails, returns ``None`` so the caller
+    can record the chunk as "lost" and continue the batch.
+
+    The "never raises per chunk" contract is what lets ``enrich_chunks`` run
+    a 500-chunk batch without one bad model response cancelling the rest of
+    the in-flight requests (#47).
+
+    Cache invariant: only successful primary responses get written to the
+    enrichment cache. The schema fallback's outputs are intentionally NOT
+    cached under the primary's key, because next run with the primary
+    healthy would otherwise serve fallback content as if it were primary.
+    """
+    # Defensive ``getattr`` so a future client wrapper that drops ``.model``
+    # produces a stable fallback key rather than a swallowed AttributeError.
+    model_id = getattr(primary_client, "model", "unknown")
+    cache_key = enrich_cache.make_key(chunk.content, model_id, PROMPT_VERSION)
     cached = enrich_cache.get(cache_key)
     if cached is not None and not validate_enrichment(cached):
         return _to_enriched_chunk(chunk, cached)
 
     prompt = ENRICHMENT_PROMPT.format(title=chunk.title, content=chunk.content)
+    fallback_reason = "validation_failed_3x"
 
     for attempt in range(3):  # 1 initial attempt + 2 retries
+        # Reset to the validation-failure default each iteration so the
+        # final reason reflects the LAST attempt's failure mode, not a
+        # stale value from an earlier transient retry.
+        attempt_reason = "validation_failed_3x"
         try:
             enrichment = await primary_client.complete(prompt)
             errors = validate_enrichment(enrichment)
             if not errors:
                 enrich_cache.put(cache_key, enrichment)
                 return _to_enriched_chunk(chunk, enrichment)
+            # Validation failed; keep retrying within the budget.
         except ProviderError as exc:
-            if not exc.transient or attempt == 2:
-                raise
-            continue
-        except Exception:
-            pass
+            attempt_reason = f"primary_provider_error:{exc.reason or 'unknown'}"
+            if not exc.transient:
+                # Non-transient: more retries will not help. Break out and
+                # let the schema fallback (if any) absorb the failure.
+                fallback_reason = attempt_reason
+                break
+        except (asyncio.TimeoutError, ValueError, json.JSONDecodeError) as exc:
+            # Narrow defensive catch: timeouts surface as TimeoutError on
+            # newer Python; JSON parse and value errors come from the
+            # provider's response handling. Programming errors
+            # (AttributeError, TypeError) deliberately propagate so a
+            # regression cannot hide as silent retries.
+            attempt_reason = f"primary_unexpected_error:{type(exc).__name__}"
+        fallback_reason = attempt_reason
 
     if schema_fallback is not None:
         log_fallback(
             stage="enrich",
             primary=primary_client,
             fallback=schema_fallback,
-            reason="validation_failed_3x",
+            reason=fallback_reason,
         )
         try:
             enrichment = await schema_fallback.complete(prompt)
             fallback_errors = validate_enrichment(enrichment)
             if not fallback_errors:
-                enrich_cache.put(cache_key, enrichment)
+                # Intentionally no cache write: see docstring "Cache invariant".
                 return _to_enriched_chunk(chunk, enrichment)
-            raise ProviderError(
-                "validation_failed_3x",
-                transient=False,
-                provider=schema_fallback.name,
-                message=(
-                    "Enrichment schema fallback returned invalid metadata: "
-                    + "; ".join(fallback_errors)
-                ),
-            )
-        except ProviderError:
-            raise
-        except Exception:
+        except (ProviderError, asyncio.TimeoutError, ValueError, json.JSONDecodeError):
+            # Provider-class failures from the fallback are absorbed by design;
+            # programming errors propagate so regressions surface in CI.
             pass
 
     return None
@@ -354,8 +377,25 @@ async def enrich_chunks(
     primary_client = _with_provider_semaphores(clients.primary, semaphores)
     schema_fallback = _with_provider_semaphores(clients.schema_fallback, semaphores)
     assert primary_client is not None
+
+    # Avoid double-billing when the primary is a FallbackClient whose own
+    # fallback leg is the same underlying client as the configured schema
+    # fallback. ``_with_provider_semaphores`` re-wraps clients, so identity
+    # on the wrapper is not enough; compare the underlying ``_client`` (or
+    # the wrapper itself if it has none).
+    def _unwrap(c: LLMClient | None) -> LLMClient | None:
+        return getattr(c, "_client", c)
+
+    if (
+        isinstance(primary_client, FallbackClient)
+        and schema_fallback is not None
+        and _unwrap(primary_client.fallback) is _unwrap(schema_fallback)
+    ):
+        schema_fallback = None
+
     batch_size = config.enrichment_batch_size
     total_chunks = len(chunks) + len(enriched)  # original total
+    total_dropped = 0
 
     async def guarded(chunk: Chunk) -> EnrichedChunk | None:
         return await _enrich_one(
@@ -367,11 +407,49 @@ async def enrich_chunks(
     for batch_idx, start in enumerate(range(0, len(chunks), batch_size)):
         batch_num = batch_offset + batch_idx
         batch = chunks[start:start + batch_size]
-        results = await asyncio.gather(*[guarded(c) for c in batch])
+        # ``return_exceptions=True`` so one chunk's failure cannot cancel the
+        # rest of the in-flight batch (#47). ``_enrich_one`` already absorbs
+        # per-chunk errors and returns ``None`` on terminal failure; this
+        # guard is defensive in case a future change introduces a new raise
+        # path or a cancellation slips through.
+        results: list[EnrichedChunk | None | BaseException] = await asyncio.gather(
+            *[guarded(c) for c in batch], return_exceptions=True
+        )
 
+        batch_dropped = 0
         for result in results:
-            if result is not None:
-                enriched.append(result)
+            # An outer-task cancellation propagates through ``await
+            # asyncio.gather(...)`` directly; a child CancelledError
+            # returned as a value here means a per-task cancel that we
+            # treat as a per-chunk failure and keep going.
+            if isinstance(result, asyncio.CancelledError):
+                print(
+                    f"  warning: chunk cancelled: {result}",
+                    file=sys.stderr,
+                )
+                batch_dropped += 1
+                continue
+            if isinstance(result, BaseException):
+                print(
+                    f"  warning: chunk failed with {type(result).__name__}: {result}",
+                    file=sys.stderr,
+                )
+                batch_dropped += 1
+                continue
+            if result is None:
+                # _enrich_one absorbed the failure and returned None.
+                batch_dropped += 1
+                continue
+            enriched.append(result)
+
+        total_dropped += batch_dropped
+        if batch_dropped:
+            survived = len(batch) - batch_dropped
+            print(
+                f"  batch {batch_num:04d}: {survived} enriched, "
+                f"{batch_dropped} dropped (running total dropped: {total_dropped})",
+                file=sys.stderr,
+            )
 
         if enriched_dir is not None:
             checkpoint = [

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -137,7 +137,13 @@ def test_enrich_retries_transient_provider_error():
     assert len(client.calls) == 2
 
 
-def test_enrich_raises_transient_provider_error_after_retries():
+def test_enrich_drops_chunk_after_transient_retries_exhausted():
+    """Per-chunk failure must not abort the batch (#47).
+
+    With no schema fallback configured, three transient errors leave the
+    chunk unrecovered. New contract: ``enrich_chunks`` returns a list with
+    that chunk omitted; no exception escapes.
+    """
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -158,9 +164,9 @@ def test_enrich_raises_transient_provider_error_after_retries():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(client),
     ):
-        with pytest.raises(ProviderError):
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
+    assert result == []
     assert len(client.calls) == 3
 
 
@@ -216,7 +222,8 @@ def test_enrich_respects_fallback_provider_concurrency():
     assert max_in_flight == 1
 
 
-def test_enrich_surfaces_provider_error_from_fallback_client():
+def test_enrich_drops_chunk_when_fallback_client_also_fails():
+    """A FallbackClient whose both legs throw must not abort the batch."""
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -250,14 +257,13 @@ def test_enrich_surfaces_provider_error_from_fallback_client():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(client),
     ):
-        with pytest.raises(ProviderError) as exc:
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.primary_error is primary_errors[-1]
-    assert exc.value.fallback_error is fallback_errors[-1]
+    assert result == []
 
 
-def test_enrich_does_not_retry_non_transient_fallback_error():
+def test_enrich_drops_chunk_on_non_transient_fallback_error():
+    """Non-transient fallback errors are absorbed; the batch keeps going."""
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -287,15 +293,20 @@ def test_enrich_does_not_retry_non_transient_fallback_error():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(client, fallback),
     ):
-        with pytest.raises(ProviderError) as exc:
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.transient is False
+    assert result == []
     assert len(primary.calls) == 1
+    # The schema_fallback is identity-equal to the FallbackClient's inner
+    # fallback leg (after _SemaphoredClient unwrapping), so enrich_chunks
+    # dedupes it: the fallback client is called exactly once, by
+    # FallbackClient's internal step. Without the dedupe, _enrich_one
+    # would call it again as a schema-fallback retry and waste a request.
     assert len(fallback.calls) == 1
 
 
-def test_enrich_raises_when_schema_fallback_returns_invalid_metadata():
+def test_enrich_drops_chunk_when_schema_fallback_returns_invalid_metadata():
+    """Schema fallback returning invalid metadata is absorbed; chunk dropped."""
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -314,11 +325,9 @@ def test_enrich_raises_when_schema_fallback_returns_invalid_metadata():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(primary, fallback),
     ):
-        with pytest.raises(ProviderError) as exc:
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.reason == "validation_failed_3x"
-    assert exc.value.provider == "openrouter"
+    assert result == []
     assert len(primary.calls) == 3
     assert len(fallback.calls) == 1
 
@@ -342,3 +351,221 @@ def test_estimate_cost():
     assert cost["estimated_cost"] >= 0
     # Output tokens: 10 chunks * 150 = 1500
     assert cost["estimated_output_tokens"] == 1500
+
+
+def test_enrich_schema_fallback_success_does_not_poison_primary_cache(tmp_path):
+    """Schema fallback's output must not be cached under the primary's key.
+
+    If it were, a subsequent run with the primary healthy would short-
+    circuit at the cache check and serve the previous fallback's output
+    as if it were primary content. The fix in #47 caches only successful
+    primary responses.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section", content="this content needs enrichment")
+
+    async def primary_fails(prompt, *, system=None, json_mode=True):
+        raise ProviderError(
+            "invalid_response",
+            transient=False,
+            message="LLM response was not parseable JSON",
+            provider="openrouter",
+        )
+
+    primary = FakeLLMClient(side_effect=primary_fails, name="openrouter")
+    fallback = FakeLLMClient(
+        responses=[make_valid_enrichment()], name="openrouter-fallback"
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(primary, fallback),
+    ):
+        first = asyncio.run(enrich_chunks([chunk], config))
+
+    assert len(first) == 1  # fallback succeeded
+
+    # Now check the cache: the primary's cache key MUST NOT carry the
+    # fallback's enrichment, otherwise the contract is broken.
+    from king_context.scraper import enrich_cache as cache
+    from king_context.scraper.enrich import PROMPT_VERSION
+    primary_cache_key = cache.make_key(chunk.content, "test-model", PROMPT_VERSION)
+    cached = cache.get(primary_cache_key)
+    assert cached is None, (
+        "schema fallback's enrichment leaked into the primary's cache key; "
+        "next run with the primary healthy would serve fallback content."
+    )
+
+
+def test_enrich_one_bad_chunk_does_not_abort_batch(capsys):
+    """The #47 repro: one chunk with non-transient ProviderError, others succeed.
+
+    Pre-fix, a single non-transient ProviderError raised by ``_enrich_one``
+    would propagate through ``asyncio.gather`` and cancel every other chunk
+    in flight. After the fix, the failing chunk is dropped and the batch
+    completes with the surviving chunks.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunks = [
+        make_chunk("Good 1", content="good content one"),
+        make_chunk("Bad", content="bad content"),
+        make_chunk("Good 2", content="good content two"),
+    ]
+    valid = make_valid_enrichment()
+    bad_error = ProviderError(
+        "invalid_response",
+        transient=False,
+        message="LLM response was not parseable JSON",
+        provider="openrouter",
+    )
+
+    async def mock_complete(prompt, *, system=None, json_mode=True):
+        if "bad content" in prompt:
+            raise bad_error
+        return valid
+
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    # Two surviving chunks; the bad one is dropped, no exception raised.
+    assert len(result) == 2
+    titles = {e.title for e in result}
+    assert titles == {"Good 1", "Good 2"}
+
+
+def test_enrich_non_transient_primary_error_falls_through_to_schema_fallback():
+    """Non-transient primary errors must reach the schema fallback (#47).
+
+    The schema fallback exists precisely to absorb malformed JSON from the
+    primary. Pre-fix, a non-transient ``ProviderError`` from the primary
+    raised on the first attempt and never reached the fallback path.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+
+    async def primary_fails(prompt, *, system=None, json_mode=True):
+        raise ProviderError(
+            "invalid_response",
+            transient=False,
+            message="LLM response was not parseable JSON",
+            provider="openrouter",
+        )
+
+    primary = FakeLLMClient(side_effect=primary_fails, name="openrouter")
+    fallback = FakeLLMClient(
+        responses=[make_valid_enrichment()], name="openrouter-fallback"
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(primary, fallback),
+    ):
+        result = asyncio.run(enrich_chunks([chunk], config))
+
+    assert len(result) == 1
+    # Primary should have been tried only once (non-transient breaks the
+    # retry loop early). Fallback runs once and succeeds.
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+
+
+def test_enrich_gather_return_exceptions_keeps_other_chunks_alive(capsys):
+    """Defensive guard: even if ``_enrich_one`` ever raises, gather absorbs it.
+
+    ``_enrich_one`` is contract-bound to never raise, but ``return_exceptions``
+    on the gather call protects against future regressions and against
+    asyncio cancellation surfacing through unrelated code paths.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunks = [
+        make_chunk("a", content="alpha"),
+        make_chunk("b", content="bravo"),
+    ]
+
+    async def mock_complete(prompt, *, system=None, json_mode=True):
+        return make_valid_enrichment()
+
+    client = FakeLLMClient(side_effect=mock_complete)
+
+    # Patch _enrich_one itself so the first call raises a synthetic
+    # exception. Without return_exceptions=True the second chunk's task
+    # would be cancelled when gather propagates the exception.
+    from king_context.scraper.enrich import _enrich_one as real_enrich_one
+
+    call_count = {"n": 0}
+
+    async def flaky_enrich_one(chunk, primary_client, schema_fallback=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("synthetic explosion")
+        return await real_enrich_one(chunk, primary_client, schema_fallback)
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ), patch(
+        "king_context.scraper.enrich._enrich_one",
+        side_effect=flaky_enrich_one,
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    # Only the second chunk should make it through; the first is logged
+    # as a warning and skipped.
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "synthetic explosion" in err
+    assert "RuntimeError" in err
+    # Per-batch summary line lands on stderr too.
+    assert "1 enriched, 1 dropped" in err
+
+
+def test_enrich_per_chunk_cancellation_does_not_abort_batch(capsys):
+    """A child task's CancelledError returned by gather is treated as a drop."""
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunks = [
+        make_chunk("a", content="alpha"),
+        make_chunk("b", content="bravo"),
+    ]
+
+    async def mock_complete(prompt, *, system=None, json_mode=True):
+        return make_valid_enrichment()
+
+    client = FakeLLMClient(side_effect=mock_complete)
+    from king_context.scraper.enrich import _enrich_one as real_enrich_one
+
+    async def cancelling_enrich_one(chunk, primary_client, schema_fallback=None):
+        if chunk.title == "a":
+            raise asyncio.CancelledError("simulated per-task cancel")
+        return await real_enrich_one(chunk, primary_client, schema_fallback)
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ), patch(
+        "king_context.scraper.enrich._enrich_one",
+        side_effect=cancelling_enrich_one,
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "cancelled" in err.lower()


### PR DESCRIPTION
## Summary

A single chunk's failure no longer aborts the entire concurrent enrich batch. `asyncio.gather` was called without `return_exceptions=True`, so the first non-transient `ProviderError` from `_enrich_one` cancelled every in-flight chunk and crashed `king-scrape` mid-pipeline. After the fix, `_enrich_one` is contract-bound never to raise (non-transient errors break the retry loop early and fall through to the schema fallback; everything else is absorbed and the chunk is dropped), and `enrich_chunks` adds `return_exceptions=True` as a defensive guard with a per-batch summary on stderr.

  While in there: schema-fallback enrichments are no longer cached under the primary's cache key (was a silent quality regression — next run with the primary healthy would short-circuit at the cache check and serve fallback content), the schema fallback is deduplicated when it points at the same underlying client as the primary's `FallbackClient` inner fallback (saves one LLM call per failed chunk in that config), and the bare `except Exception` was narrowed so programming errors propagate instead of hiding as transient retries.

  ## Related issue

  Closes #47.

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## How it was tested

  pytest -q
  739 passed, 1 skipped


  16 tests in `test_enrich.py` (4 rewritten for the new "never raise per chunk" contract, 5 new):

  - The original repro: a non-transient `ProviderError` on one chunk in a batch of three; the bad chunk drops, the other two enrich, no exception escapes
  - Non-transient primary error falls through to the schema fallback (the layer designed to absorb malformed JSON, which previously never got a chance)
  - Cache invariant: a schema-fallback success does not write to the primary's cache key
  - `gather` with `return_exceptions=True` keeps siblings alive when one task raises, with a capsys assertion on the per-batch summary line
  - Per-chunk `CancelledError` returned by `gather` treated as a drop, not a batch abort
  - Existing 4 tests that previously asserted `pytest.raises(ProviderError)` now assert `result == []` and verify call counts plus the new dedupe behaviour

  I haven't run a live `king-scrape` against a 500+ chunk site in this PR. Happy to do that in review if you want; the unit tests cover the issue's repro precisely.

  ## Checklist

  - [x] My code follows the project style (English-only code, comments, and identifiers)
  - [x] I ran the test suite locally and it passes (`pytest`)
  - [x] I added or updated tests where it made sense
  - [x] I updated the documentation in `docs/` and/or `README.md` if behavior changed *(no public-surface change beyond the user-visible warning lines on stderr; CHANGELOG entry added)*
  - [x] I read the [Contributing guide](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
  - [x] My commits follow the project commit message style
  - [x] I confirmed there are no secrets or credentials in the diff
