### PR TITLE
Unified scraper stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ FIRECRAWL_API_KEY=
 # SCRAPE_DISCOVER_PROVIDER=crawl4ai
 # SCRAPE_FETCH_PROVIDER=firecrawl
 
+# Provider cache override (king-scrape, currently honoured by crawl4ai only).
+# Allowed values: default (or unset), enabled, bypass, disabled, read_only,
+# write_only. The CLI flag --no-fetch-cache is shorthand for SCRAPE_CACHE_MODE=bypass.
+# SCRAPE_CACHE_MODE=default
+
 # Optional. OpenRouter API key for OpenRouter LLM stages or Ollama fallback.
 # Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=

--- a/.king-context/adr/0014-incremental-corpus-refresh.md
+++ b/.king-context/adr/0014-incremental-corpus-refresh.md
@@ -1,0 +1,89 @@
+---
+id: ADR-0014
+title: Incremental corpus refresh via `king-scrape update`
+status: accepted
+date: 2026-05-08
+areas:
+  - scraper
+  - corpus
+  - cli
+  - cost
+supersedes: []
+superseded_by: []
+related:
+  - ADR-0010
+  - ADR-0012
+  - ADR-0013
+keywords:
+  - incremental-refresh
+  - content-hash
+  - reuse
+  - update-flow
+  - cost-preview
+  - chunk-identity
+tags:
+  - architecture
+  - scraper
+  - cli
+---
+
+
+# ADR-0014: Incremental corpus refresh via `king-scrape update`
+
+## Context
+
+A contributor who indexed a docs site months ago and wants to refresh has two options today: rerun `king-scrape <url> --name <name>`, which under the resume rules of fetch.py silently skips changed pages and produces a stale corpus; or wipe `.king-context/_temp/<host>/` and pay the full pipeline cost again, dominated by OpenRouter enrichment ($1 to $3 for a corpus of a few hundred chunks). Neither is acceptable.
+
+ADR-0012 added `content_hash` provenance to every chunk, every section, and every fetched page so that a third path becomes possible: refetch all pages, rechunk, and reuse every section whose chunked content is byte identical to the previous scrape. ADR-0013 added the read only audit subcommand that surfaces drift signals without spending LLM credits. The missing piece is the action that closes the loop: take an audited corpus and actually update it cheaply.
+
+## Decision
+
+Add `king-scrape update <name>`. The command is dispatched the same way as `audit` (a small `if argv[1] == "update": ...` branch in `cli.main`, no argparse subparser refactor) so the existing `king-scrape <url>` flow is unchanged.
+
+The flow:
+
+1. Locate the corpus at `data/<name>.json` or `.king-context/data/<name>.json`. Resolve the source URL from `_meta.source_url` (preferred) or the legacy `base_url` field. A corpus that has neither cannot be updated; the command exits with a clear error pointing at a from scratch rescrape.
+2. Build a reuse index from the existing corpus: `content_hash -> { keywords, use_cases, tags, priority }`. For corpora that predate ADR-0012 (no `_meta.content_hash`), recompute the hash from `content` so legacy corpora work without migration.
+3. Run discover, filter, fetch with `force_refresh=True`. The new flag bypasses the slug skip behaviour in fetch.py so a changed upstream page is actually redownloaded. Without it, the existing resume logic would mask exactly the drift we are trying to detect.
+4. Rechunk all fetched pages. Each fresh chunk carries its own `content_hash` from ADR-0012.
+5. For each fresh chunk, look up its `content_hash` in the reuse index. Hit means carry forward the enrichment values; miss means the chunk is genuinely new or changed and needs the LLM.
+6. Show a cost preview (reused / new / removed / added URL counts plus the OpenRouter dollar estimate from `enrich.estimate_cost`) and prompt for confirmation. `--yes` skips the prompt for scripted runs.
+7. Enrich only the new chunks. The enrichment cache from ADR-0012 catches any further reuse the chunk identity index could not see (different model swap recovery, prompt invariance).
+8. Compose the final section list in fresh chunk order. Reused sections keep their carried over enrichment values but adopt the fresh chunk's structural fields (`title`, `path`, `url`) so an upstream page reorganisation is reflected.
+9. Write the updated corpus back to the same JSON path. `auto_seed` is left to the user via `kctx index` because update writes to the corpus committed in the repo, not to the local indexed store the MCP server reads.
+
+The integrity unit is the chunk's `content_hash`, not the page or the section. Two changed paragraphs inside a 50 chunk page only re enrich those two chunks.
+
+## Alternatives Considered
+
+**Page level reuse.** Compare the per page sidecar's `content_hash` (ADR-0012) to a stored equivalent and skip the rechunk when the page is identical. Faster than rechunking everything, but rechunking is microseconds per page and the corpus does not currently store a per page hash; adding one for marginal speed up is premature optimisation. Chunk level reuse is correct without it. The page sidecar stays useful for the audit subcommand and for future PRs that want to short circuit the LLM cache lookup.
+
+**Force a full rescrape under a flag.** Considered as a stopgap. Rejected because the LLM cost ($1 to $3 per corpus per refresh) is the entire problem statement; a stopgap that does not solve it is not worth shipping.
+
+**Diff against the audit report from ADR-0013.** Considered as input. Rejected because audit is a snapshot of upstream URL health, not a fresh fetch. Update needs the actual fresh content to compute new hashes, so it duplicates a small amount of audit's URL traversal but with full GET. Audit and update remain orthogonal: audit answers "is this corpus aligned"; update acts on the answer.
+
+**Mutate `data/<name>.json` in place atomically.** Implemented via `update._atomic_write_json` (`src/king_context/scraper/update.py`): payload serialised to JSON in memory first, written to a tempfile next to the target, then `os.replace` swaps it into place. An interrupted update or a serialisation failure leaves the original corpus untouched, never a partial file. Update writes through this helper directly rather than via `save_and_index`, so the corpus on disk is the source of truth and the seeded MCP DB is left to a subsequent `kctx index` call.
+
+**Skip the cost preview by default.** Rejected. Even with cache hits, an unintended `--update` against a corpus with hundreds of changed chunks could silently spend $5+. Cost preview plus confirmation matches the existing fresh scrape ergonomics in `cli.run_pipeline`, where the same prompt fires before enrichment.
+
+## Consequences
+
+A contributor can now run `king-scrape audit my-corpus`, see broken URLs and orphans, then `king-scrape update my-corpus --yes` to actually refresh. The combined flow is one read only check followed by one cheap action.
+
+Cost scales with churn, not with corpus size. A 700 chunk corpus where 5 chunks changed costs the LLM call price for 5 chunks plus negligible disk I/O, vs. the previous full rescrape cost of all 700.
+
+The provider Protocols stay untouched (ADR-0010); `force_refresh` is an additive boolean on `fetch_pages`, not on the FetchProvider contract. Crawl4AI and Firecrawl handle update transparently.
+
+Update writes back to `data/<name>.json` at the same path the original lived. A contributor can `git diff data/<name>.json` to inspect exactly which sections changed before committing the refresh, which is a meaningful QA improvement for community corpus contributions.
+
+`auto_seed=False` on the export means the user's local MCP index is not automatically refreshed. They run `kctx index .king-context/data/<name>.json` (or `kctx index --all`) when they want the new corpus visible to retrieval. This matches the project's existing ethos: indexed retrieval state is reproducible from the JSON committed in the repo, never the source of truth.
+
+The dispatcher pattern grows to two subcommands (`audit`, `update`); a third or fourth would justify a real argparse subparser refactor. For now the four line `if argv[1] == "X":` branch is the right shape.
+
+## Links
+
+src/king_context/scraper/update.py
+src/king_context/scraper/fetch.py
+src/king_context/scraper/cli.py
+.king-context/adr/0012-content-hash-provenance-and-enrichment-cache.md
+.king-context/adr/0013-corpus-drift-audit-subcommand.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--no-fetch-cache` flag on `king-scrape` and `SCRAPE_CACHE_MODE` env
+  var (#50). Bypasses the Crawl4AI provider's local cache (`~/.crawl4ai/`)
+  for the duration of the run without wiping the cache directory by hand.
+  `SCRAPE_CACHE_MODE` accepts `bypass`, `disabled`, `read_only`,
+  `write_only`, or `default`/unset. The CLI flag is shorthand for
+  `SCRAPE_CACHE_MODE=bypass` and uses `setdefault` semantics so an
+  explicit pre-existing env value wins (mirrors `--provider`'s
+  precedence). `main()` restores the prior env value on exit so the
+  flag does not leak into an embedding application or test session.
+  Honoured by the crawl4ai provider; firecrawl ignores it (its API
+  defaults to fresh-fetch). Knob is global today; per-stage variants
+  (`SCRAPE_DISCOVER_CACHE_MODE` / `SCRAPE_FETCH_CACHE_MODE`) deferred
+  to a follow-up if real configurations need them. Lays the primitive
+  `king-scrape update <name>` needs to make `force_refresh=True`
+  actually fetch from the network.
 - Content-hash provenance through every layer of the scraper pipeline
   (ADR-0012). `Chunk` and `EnrichedChunk` carry a `content_hash` field
   populated by `sha256(content)`. Each fetched page now writes a sidecar
@@ -81,6 +96,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corpus file or the database. No LLM cost. Markdown report lands at
   `.king-context/audit/<name>-<ts>.md`. Exit code is `0` on clean,
   `2` when at least one section is broken, so it can gate a CI job.
+- `king-scrape update <name>` subcommand (ADR-0014). Refetches the
+  upstream of an indexed corpus, rechunks, and reuses every section
+  whose chunked content is byte identical to the previous scrape.
+  Only new or changed chunks are sent to the LLM, so a typical
+  refresh costs cents instead of dollars even on a large corpus.
+  Reused sections carry forward `keywords`, `use_cases`, `tags`,
+  `priority` from the existing corpus but adopt fresh `title`,
+  `path`, `url` so a page reorganisation upstream is reflected.
+  Cost preview before enrichment; `--yes` skips the prompt. Writes
+  back to the same `data/<name>.json` path so `git diff` shows
+  exactly what changed. Pre ADR-0012 corpora (no
+  `_meta.content_hash`) are handled by recomputing the hash from
+  `content`. The work directory is reset at the start of every
+  update and the corpus JSON is written atomically (tempfile plus
+  rename). `fetch_pages` gains a `force_refresh=True` flag so the
+  update flow can refetch every URL regardless of cached state.
 
 ## [0.4.0] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `db.insert_documentation` (called by `seed_data.seed_one` and the scraper's
+  auto-seed step) is now an upsert. Re-seeding the same corpus name no longer
+  raises `sqlite3.IntegrityError` against `documentations.name UNIQUE`. The
+  documentations row is upserted via `INSERT ... ON CONFLICT(name) DO UPDATE
+  ... RETURNING id`, which keeps the original `created_at` and the existing
+  `doc_id` stable across refreshes. Sections, their `query_cache` entries
+  (via `ON DELETE CASCADE`), and their `sections_fts` index entries (via the
+  FTS5 'delete' protocol) are then cleared and the fresh sections inserted
+  in the same SQLite transaction. Embedding writes to `data/embeddings.npy`
+  and `data/_internal/section_mapping.json` are deferred until after the
+  commit, so a rollback never leaves the numpy sidecar ahead of the
+  committed DB state. Closes #48.
+- `db._get_connection` now executes `PRAGMA foreign_keys = ON` on every
+  connection. Without this, `ON DELETE CASCADE` on `sections.doc_id` and
+  `query_cache.section_id` was a silent no-op for everything outside
+  `init_db`, leaving orphan rows after deletes. The upsert above relies on
+  the cascade, but every other delete path benefits too.
+
 ### Added
 
 - Content-hash provenance through every layer of the scraper pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `query_cache.section_id` was a silent no-op for everything outside
   `init_db`, leaving orphan rows after deletes. The upsert above relies on
   the cascade, but every other delete path benefits too.
+- A single chunk's `ProviderError` no longer aborts the entire concurrent
+  enrich batch (#47). `_enrich_one` is now contract-bound never to raise:
+  non-transient primary errors break the retry loop early and fall through
+  to the schema fallback (the layer designed to absorb malformed JSON);
+  the schema fallback's own failures are absorbed; the chunk is dropped
+  from the output and the batch keeps running. `enrich_chunks` adds
+  `return_exceptions=True` to its `asyncio.gather` call as a defensive
+  guard. Per-chunk failures and per-task `CancelledError`s emit a warning
+  on stderr and a per-batch summary line (`batch NNNN: X enriched, Y
+  dropped`) so contributors can see exactly how many chunks were lost.
+- The schema fallback's enrichments are no longer cached under the
+  primary client's cache key. Pre-fix, a successful schema-fallback
+  response was written to `enrich_cache` keyed by the primary's model;
+  next run with the primary healthy would short-circuit at the cache
+  check and serve fallback content as if it were primary. The cache
+  invariant is now: only successful primary responses are cached.
+- `enrich_chunks` deduplicates the schema fallback when the primary is a
+  `FallbackClient` whose own fallback leg points at the same underlying
+  client. Pre-fix this configuration paid for two LLM calls against the
+  same client per failed chunk; now the schema-fallback step is skipped
+  and the FallbackClient's internal fallback is the only call.
+- The bare `except Exception` in `_enrich_one` was narrowed to
+  `(ProviderError, asyncio.TimeoutError, ValueError, json.JSONDecodeError)`
+  so programming errors (`AttributeError`, `TypeError`, etc.) propagate
+  instead of being silently retried as transient provider hiccups.
 
 ### Added
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -15,7 +15,9 @@ King Context installs three command-line tools:
 - `kctx`: search, read, index, and validate local retrieval stores.
 - `king-scrape`: scrape a documentation site and export indexed sections.
   Also exposes `king-scrape audit <name>` to check an indexed corpus
-  for broken, moved, or drifted URLs.
+  for broken, moved, or drifted URLs, and `king-scrape update <name>`
+  to incrementally refresh an existing corpus, paying LLM cost only
+  for new or changed chunks.
 - `king-research`: build and index a research corpus for a topic.
 
 The `kctx` command searches two content stores by default:
@@ -367,6 +369,13 @@ Useful flags:
   `SCRAPE_PROVIDER` for the process. Stage-specific environment variables
   take precedence over the flag. See [Scraper providers](#scraper-providers)
   for the full table.
+- `--no-fetch-cache`: bypass the scraper provider's local cache for this
+  run. Sets `SCRAPE_CACHE_MODE=bypass`. Useful when upstream content has
+  changed and you need a fresh fetch without wiping the cache directory
+  by hand (Crawl4AI keeps a local cache under `~/.crawl4ai/`). Honoured
+  by the crawl4ai provider; firecrawl's API defaults to fresh-fetch and
+  ignores this flag. Set `SCRAPE_CACHE_MODE` directly to `bypass`,
+  `disabled`, `read_only`, or `write_only` for finer-grained control.
 
 `king-scrape` writes exported documentation JSON to `.king-context/data/`.
 Use `kctx index` to build or rebuild the file-based CLI store from that JSON.
@@ -532,6 +541,57 @@ The optional discovery diff calls the configured `DiscoveryProvider`
 (Firecrawl or Crawl4AI) to remap the upstream and lists URLs added or
 removed since the corpus was indexed. Use `--no-discover` to skip the
 provider step entirely.
+
+## Refresh an indexed corpus
+
+Use `king-scrape update <name>` to bring an indexed corpus back in line with
+its upstream source. The command refetches every page, rechunks, and reuses
+every section whose chunked content is byte identical to the previous scrape.
+Only new or changed chunks are sent to the LLM, so a typical refresh costs
+cents instead of dollars even on a corpus with hundreds of pages.
+
+```bash
+king-scrape update elevenlabs-api
+```
+
+The flow:
+
+1. Locate `data/<name>.json` (or `.king-context/data/<name>.json`).
+2. Resolve the source URL from `_meta.source_url`, falling back to `base_url`.
+3. Run discover, filter, and fetch with `force_refresh=True` so changed pages
+   are actually re-downloaded instead of being skipped by the resume logic.
+   Note: `force_refresh=True` only disables king-scrape's own slug-skip; the
+   underlying scraper provider (e.g. crawl4ai) may still serve from its own
+   on-disk cache. Pass `--no-fetch-cache` (or set `SCRAPE_CACHE_MODE=bypass`)
+   when you suspect provider cache is masking upstream changes.
+4. Rechunk all fetched pages.
+5. For each fresh chunk, look up `content_hash` in the existing corpus. Hit:
+   carry forward the enrichment values. Miss: enqueue for the LLM.
+6. Show a cost preview (reused / new / removed / added URL counts plus the
+   OpenRouter dollar estimate) and prompt for confirmation. `--yes` skips
+   the prompt for scripted runs.
+7. Enrich only the new chunks. Reused sections take fresh `title`, `path`,
+   `url` so a page reorganisation upstream is reflected.
+8. Write the merged corpus back to the same JSON path. `git diff` then shows
+   exactly what changed.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--yes` | off | Skip the cost confirmation prompt before enrichment. |
+| `--corpus-path <path>` | inferred | Explicit corpus JSON path; bypasses the default lookup in `data/<name>.json` and `.king-context/data/<name>.json`. |
+| `--provider <name>` | env / inferred | Override the scraper provider for this run (always wins over `SCRAPE_PROVIDER`). |
+| `--model <id>` | env / default | Override the OpenRouter model for enrichment. |
+
+The work directory at `.king-context/_temp/<host>/` is reset at the start of
+every update so stale state from a prior run cannot leak into the new corpus.
+The corpus JSON is written atomically (tempfile plus rename) so an interrupted
+update never leaves a partial file. If discover or filter produces zero
+URLs, the update aborts before writing and the original corpus is preserved.
+
+`auto_seed` is intentionally off: update writes to the corpus committed in
+the repo, not to the local indexed store. After a successful update, refresh
+the local index with `kctx index .king-context/data/<name>.json` (or
+`kctx index --all`).
 
 ## LLM Provider Configuration
 

--- a/installer/templates/env.example
+++ b/installer/templates/env.example
@@ -14,6 +14,11 @@ FIRECRAWL_API_KEY=
 # SCRAPE_DISCOVER_PROVIDER=crawl4ai
 # SCRAPE_FETCH_PROVIDER=firecrawl
 
+# Provider cache override (king-scrape, currently honoured by crawl4ai only).
+# Allowed values: default (or unset), enabled, bypass, disabled, read_only,
+# write_only. The CLI flag --no-fetch-cache is shorthand for SCRAPE_CACHE_MODE=bypass.
+# SCRAPE_CACHE_MODE=default
+
 # Optional. OpenRouter API key for OpenRouter LLM stages or Ollama fallback.
 # Get yours at https://openrouter.ai
 OPENROUTER_API_KEY=

--- a/src/king_context/db.py
+++ b/src/king_context/db.py
@@ -458,26 +458,66 @@ def insert_documentation(doc_data: Dict[str, Any]) -> int:
     """
     conn = _get_connection()
     cursor = conn.cursor()
+    # Embeddings are written to disk by _generate_and_save_embedding and live
+    # outside the SQLite transaction. Stage them here and flush only AFTER the
+    # commit so a rolled back transaction never leaves orphan numpy rows on
+    # disk that disagree with the committed DB state.
+    embeddings_pending: list[tuple[int, str]] = []
 
     try:
-        # Get current timestamp in ISO format
         now = datetime.now().isoformat()
 
-        # Insert documentation record
-        cursor.execute("""
+        # Atomic upsert of the documentations row. ON CONFLICT preserves
+        # `created_at` (we only overwrite display_name, version, base_url,
+        # updated_at) and removes the read-modify-write race two concurrent
+        # scrapers would have hit with a SELECT-then-DELETE-then-INSERT.
+        cursor.execute(
+            """
             INSERT INTO documentations (name, display_name, version, base_url, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?)
-        """, (
-            doc_data["name"],
-            doc_data["display_name"],
-            doc_data.get("version"),
-            doc_data["base_url"],
-            now,
-            now
-        ))
-        doc_id = cursor.lastrowid
+            ON CONFLICT(name) DO UPDATE SET
+                display_name = excluded.display_name,
+                version = excluded.version,
+                base_url = excluded.base_url,
+                updated_at = excluded.updated_at
+            RETURNING id
+            """,
+            (
+                doc_data["name"],
+                doc_data["display_name"],
+                doc_data.get("version"),
+                doc_data["base_url"],
+                now,
+                now,
+            ),
+        )
+        doc_id = cursor.fetchone()[0]
 
-        # Insert sections
+        # Drop any prior sections for this doc. sections_fts is an external
+        # content table and does not auto-prune on cascade or DELETE, so each
+        # row's index entry must be removed via the FTS5 'delete' protocol
+        # before the sections rows themselves go away. Use a separate cursor
+        # so the streaming SELECT and the per-row INSERT do not contend on
+        # the same statement handle.
+        read_cursor = conn.cursor()
+        read_cursor.execute(
+            "SELECT id, title, content FROM sections WHERE doc_id = ?",
+            (doc_id,),
+        )
+        for sid, stitle, scontent in read_cursor:
+            # The `or ""` mirrors the insert path below: NULL content stored in
+            # `sections` was originally fed to FTS5 as the empty string. The
+            # 'delete' values must match what FTS5 saw on insert, byte for
+            # byte, or term frequencies drift silently.
+            cursor.execute(
+                "INSERT INTO sections_fts(sections_fts, rowid, title, content) "
+                "VALUES('delete', ?, ?, ?)",
+                (sid, stitle, scontent if scontent is not None else ""),
+            )
+        read_cursor.close()
+        cursor.execute("DELETE FROM sections WHERE doc_id = ?", (doc_id,))
+
+        # Insert new sections
         sections = doc_data.get("sections", [])
         for section in sections:
             cursor.execute("""
@@ -506,17 +546,24 @@ def insert_documentation(doc_data: Dict[str, Any]) -> int:
                 section.get("content", "")
             ))
 
-            # Generate and save embedding for section
-            _generate_and_save_embedding(section_id, section.get("content", ""))
+            embeddings_pending.append((section_id, section.get("content", "")))
 
         conn.commit()
-        return doc_id
 
     except Exception:
         conn.rollback()
         raise
     finally:
         conn.close()
+
+    # Embeddings flushed AFTER commit, so a SQLite rollback above leaves the
+    # numpy file untouched. Failures here do not corrupt the DB; at worst the
+    # corpus has fresh sections without their embedding rows, which the
+    # hybrid reranker handles gracefully (FTS-only fallback).
+    for section_id, content in embeddings_pending:
+        _generate_and_save_embedding(section_id, content)
+
+    return doc_id
 
 
 def list_documentations() -> List[Dict[str, Any]]:
@@ -700,5 +747,13 @@ def _escape_fts5_query(query: str) -> str:
 
 
 def _get_connection() -> sqlite3.Connection:
-    """Retorna conexão com o banco."""
-    return sqlite3.connect(DB_PATH)
+    """Open a database connection with foreign keys enforced.
+
+    SQLite requires ``PRAGMA foreign_keys = ON`` per connection; without it,
+    ``ON DELETE CASCADE`` on ``sections`` and ``query_cache`` is a silent
+    no-op. Enable it on every connection so cascade behaviour matches the
+    schema's stated contract.
+    """
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn

--- a/src/king_context/scraper/_cache_mode.py
+++ b/src/king_context/scraper/_cache_mode.py
@@ -1,0 +1,68 @@
+"""Shared CLI helper for the ``--no-fetch-cache`` flag.
+
+Each scrape entry point (``king-scrape``, ``king-scrape audit``,
+``king-scrape update``) declares ``--no-fetch-cache`` on its own argparser
+and threads the resulting boolean into the runtime by setting
+``SCRAPE_CACHE_MODE=bypass`` in the process environment. ``setdefault``
+semantics mirror ``--provider``: an explicit pre-existing env value wins,
+so a contributor who set ``SCRAPE_CACHE_MODE=read_only`` and ALSO passes
+``--no-fetch-cache`` keeps the explicit value instead of being silently
+downgraded.
+
+The helpers below keep that pattern in one place so the three entry points
+behave identically and the env mutation is always restored on exit
+(``finally`` block) — important because tests call ``*_main()`` directly
+and embedding applications may reuse the same Python process.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+
+_ENV_KEY = "SCRAPE_CACHE_MODE"
+
+
+def apply_cache_mode_flag(args) -> Tuple[bool, Optional[str]]:
+    """Apply ``--no-fetch-cache`` to the process env. Return prior state.
+
+    Caller should pass the returned tuple to :func:`restore_cache_mode` in
+    a ``finally`` block so the env mutation never leaks past the CLI run.
+    """
+    was_set = _ENV_KEY in os.environ
+    prior = os.environ.get(_ENV_KEY)
+    if getattr(args, "no_fetch_cache", False):
+        os.environ.setdefault(_ENV_KEY, "bypass")
+    return was_set, prior
+
+
+def restore_cache_mode(was_set: bool, prior: Optional[str]) -> None:
+    """Undo :func:`apply_cache_mode_flag`. Pops the key if it was unset
+    on entry; restores the original value if it was set."""
+    if was_set:
+        # Was-set guarantees the prior was a real ``str`` (or empty string).
+        # Use an explicit check instead of ``assert`` so the invariant still
+        # holds under ``python -O`` (which strips assertions).
+        if prior is None:
+            raise RuntimeError(
+                "restore_cache_mode called with was_set=True but prior=None; "
+                "the (was_set, prior) tuple must come from apply_cache_mode_flag"
+            )
+        os.environ[_ENV_KEY] = prior
+    else:
+        os.environ.pop(_ENV_KEY, None)
+
+
+def add_cache_mode_argument(parser) -> None:
+    """Declare ``--no-fetch-cache`` on a scrape-family argparser."""
+    parser.add_argument(
+        "--no-fetch-cache",
+        dest="no_fetch_cache",
+        action="store_true",
+        help=(
+            "Bypass the scraper provider's local cache for this run. "
+            "Sets SCRAPE_CACHE_MODE=bypass (setdefault — an explicit "
+            "pre-existing env value wins). Honoured by the crawl4ai "
+            "provider; other providers may ignore it."
+        ),
+    )

--- a/src/king_context/scraper/audit.py
+++ b/src/king_context/scraper/audit.py
@@ -24,7 +24,6 @@ from email.utils import parsedate_to_datetime
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 from typing import Iterable
-from urllib.parse import urldefrag, urlsplit, urlunsplit
 
 import httpx
 
@@ -43,14 +42,11 @@ def _scraper_version() -> str:
         return "dev"
 
 
-def _canonicalize(url: str) -> str:
-    """Drop fragment, lowercase scheme/host, strip trailing slash from path."""
-    url, _ = urldefrag(url)
-    parts = urlsplit(url)
-    path = parts.path.rstrip("/") or "/"
-    return urlunsplit(
-        (parts.scheme.lower(), parts.netloc.lower(), path, parts.query, "")
-    )
+from king_context.scraper.url_utils import canonicalize_url as _canonicalize  # noqa: E402
+
+# ``_canonicalize`` is re-exported for compatibility with existing call sites
+# inside audit.py. New code should import ``canonicalize_url`` directly from
+# ``king_context.scraper.url_utils``.
 
 
 @dataclass

--- a/src/king_context/scraper/audit.py
+++ b/src/king_context/scraper/audit.py
@@ -28,6 +28,11 @@ from typing import Iterable
 import httpx
 
 from king_context import PROJECT_ROOT
+from king_context.scraper._cache_mode import (
+    add_cache_mode_argument,
+    apply_cache_mode_flag,
+    restore_cache_mode,
+)
 
 
 HTTP_TIMEOUT = 15.0
@@ -412,6 +417,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=PROJECT_ROOT / ".king-context" / "audit",
         help="Where to write the Markdown report.",
     )
+    add_cache_mode_argument(parser)
     return parser
 
 
@@ -450,6 +456,7 @@ def audit_main(argv: list[str]) -> int:
         print("error: --concurrency must be >= 1", file=sys.stderr)
         return 1
 
+    cache_mode_was_set, cache_mode_prior = apply_cache_mode_flag(args)
     try:
         audit = asyncio.run(
             audit_corpus(
@@ -461,6 +468,8 @@ def audit_main(argv: list[str]) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+    finally:
+        restore_cache_mode(cache_mode_was_set, cache_mode_prior)
 
     report_path = write_report(audit, args.report_dir)
     _print_summary(audit, report_path)

--- a/src/king_context/scraper/chunk.py
+++ b/src/king_context/scraper/chunk.py
@@ -189,6 +189,29 @@ def chunk_page(markdown: str, source_url: str, config: ScraperConfig) -> list[Ch
     return merged
 
 
+def _resolve_page_url(md_file: Path) -> str:
+    """Return the real URL for a fetched page, or fall back to the slug.
+
+    ``fetch.py`` writes ``<slug>.meta.json`` next to ``<slug>.md`` with the
+    real upstream URL. When the sidecar is present, prefer it so chunks
+    carry the actual ``https://...`` URL rather than the slug. Legacy
+    ``_temp/`` directories from scrapes that pre-date the sidecar (or
+    sidecars that fail to parse) fall back to ``md_file.stem`` so the
+    pipeline stays compatible with older work directories.
+    """
+    sidecar = md_file.with_suffix(".meta.json")
+    if not sidecar.exists():
+        return md_file.stem
+    try:
+        meta = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return md_file.stem
+    url = meta.get("url") if isinstance(meta, dict) else None
+    if isinstance(url, str) and url:
+        return url
+    return md_file.stem
+
+
 def chunk_pages(pages_dir: Path, output_dir: Path, config: ScraperConfig) -> list[Chunk]:
     """Process all .md files in pages_dir and save per-page chunk JSONs."""
     chunks_dir = output_dir / "chunks"
@@ -198,8 +221,9 @@ def chunk_pages(pages_dir: Path, output_dir: Path, config: ScraperConfig) -> lis
 
     for md_file in sorted(pages_dir.glob("*.md")):
         markdown = md_file.read_text()
-        slug = md_file.stem
-        page_chunks = chunk_page(markdown, slug, config)
+        slug = md_file.stem  # filename stem; used for the per-page chunks JSON below
+        source_url = _resolve_page_url(md_file)
+        page_chunks = chunk_page(markdown, source_url, config)
         all_chunks.extend(page_chunks)
 
         chunk_data = [

--- a/src/king_context/scraper/cli.py
+++ b/src/king_context/scraper/cli.py
@@ -14,6 +14,11 @@ from scraper_providers import (
 )
 
 from king_context import PROJECT_ROOT
+from king_context.scraper._cache_mode import (
+    add_cache_mode_argument,
+    apply_cache_mode_flag,
+    restore_cache_mode,
+)
 from king_context.scraper.chunk import Chunk, chunk_pages
 from king_context.scraper.config import ScraperConfig, load_config
 from king_context.scraper.discover import (
@@ -258,7 +263,8 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="king-scrape",
         description=(
             "Scrape and index documentation for King Context. "
-            "Use `king-scrape audit <name>` to check an existing corpus for drift."
+            "Use `king-scrape audit <name>` to check an existing corpus for "
+            "drift, or `king-scrape update <name>` to refresh it cheaply."
         ),
     )
     parser.add_argument("url", help="Base URL of the documentation to scrape")
@@ -346,24 +352,30 @@ def _build_parser() -> argparse.ArgumentParser:
             "have precedence."
         ),
     )
+    add_cache_mode_argument(parser)
     return parser
 
 
 def main() -> None:
-    if len(sys.argv) > 1 and sys.argv[1] == "audit":
-        from king_context.scraper.audit import audit_main
-        sys.exit(audit_main(sys.argv[2:]))
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "audit":
+            from king_context.scraper.audit import audit_main
+            sys.exit(audit_main(sys.argv[2:]))
+        if sys.argv[1] == "update":
+            from king_context.scraper.update import update_main
+            sys.exit(update_main(sys.argv[2:]))
 
     parser = _build_parser()
     args = parser.parse_args()
-    config = load_config(
-        enrichment_model=args.model,
-        chunk_max_tokens=args.chunk_max_tokens,
-        chunk_min_tokens=args.chunk_min_tokens,
-        concurrency=args.concurrency,
-        filter_llm_fallback=not args.no_llm_filter,
-    )
+    cache_mode_was_set, cache_mode_prior = apply_cache_mode_flag(args)
     try:
+        config = load_config(
+            enrichment_model=args.model,
+            chunk_max_tokens=args.chunk_max_tokens,
+            chunk_min_tokens=args.chunk_min_tokens,
+            concurrency=args.concurrency,
+            filter_llm_fallback=not args.no_llm_filter,
+        )
         asyncio.run(run_pipeline(args, config))
     except ProviderUnavailableError as exc:
         print(f"error: {exc.hint}", file=sys.stderr)
@@ -371,6 +383,12 @@ def main() -> None:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(2)
+    finally:
+        # Restore the env so calling ``main()`` from tests or from an
+        # embedding application does not leak the bypass flag into the
+        # next caller's process state. Covers both the asyncio.run path
+        # AND any failure inside load_config (e.g. invalid --model arg).
+        restore_cache_mode(cache_mode_was_set, cache_mode_prior)
 
 
 if __name__ == "__main__":

--- a/src/king_context/scraper/enrich.py
+++ b/src/king_context/scraper/enrich.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -231,57 +232,79 @@ async def _enrich_one(
     primary_client: LLMClient,
     schema_fallback: LLMClient | None = None,
 ) -> EnrichedChunk | None:
-    """Enrich a single chunk with up to 2 retries on validation failure."""
-    cache_key = enrich_cache.make_key(
-        chunk.content,
-        primary_client.model,
-        PROMPT_VERSION,
-    )
+    """Enrich a single chunk. Never raises; returns ``None`` on terminal failure.
+
+    Tries the primary client up to three times. Transient ``ProviderError``
+    rounds are retried; a non-transient ``ProviderError`` (e.g. unparseable
+    JSON, schema validation gone wrong) breaks the retry loop early and falls
+    through to the schema fallback. Validation failures use the full retry
+    budget. If the schema fallback also fails, returns ``None`` so the caller
+    can record the chunk as "lost" and continue the batch.
+
+    The "never raises per chunk" contract is what lets ``enrich_chunks`` run
+    a 500-chunk batch without one bad model response cancelling the rest of
+    the in-flight requests (#47).
+
+    Cache invariant: only successful primary responses get written to the
+    enrichment cache. The schema fallback's outputs are intentionally NOT
+    cached under the primary's key, because next run with the primary
+    healthy would otherwise serve fallback content as if it were primary.
+    """
+    # Defensive ``getattr`` so a future client wrapper that drops ``.model``
+    # produces a stable fallback key rather than a swallowed AttributeError.
+    model_id = getattr(primary_client, "model", "unknown")
+    cache_key = enrich_cache.make_key(chunk.content, model_id, PROMPT_VERSION)
     cached = enrich_cache.get(cache_key)
     if cached is not None and not validate_enrichment(cached):
         return _to_enriched_chunk(chunk, cached)
 
     prompt = ENRICHMENT_PROMPT.format(title=chunk.title, content=chunk.content)
+    fallback_reason = "validation_failed_3x"
 
     for attempt in range(3):  # 1 initial attempt + 2 retries
+        # Reset to the validation-failure default each iteration so the
+        # final reason reflects the LAST attempt's failure mode, not a
+        # stale value from an earlier transient retry.
+        attempt_reason = "validation_failed_3x"
         try:
             enrichment = await primary_client.complete(prompt)
             errors = validate_enrichment(enrichment)
             if not errors:
                 enrich_cache.put(cache_key, enrichment)
                 return _to_enriched_chunk(chunk, enrichment)
+            # Validation failed; keep retrying within the budget.
         except ProviderError as exc:
-            if not exc.transient or attempt == 2:
-                raise
-            continue
-        except Exception:
-            pass
+            attempt_reason = f"primary_provider_error:{exc.reason or 'unknown'}"
+            if not exc.transient:
+                # Non-transient: more retries will not help. Break out and
+                # let the schema fallback (if any) absorb the failure.
+                fallback_reason = attempt_reason
+                break
+        except (asyncio.TimeoutError, ValueError, json.JSONDecodeError) as exc:
+            # Narrow defensive catch: timeouts surface as TimeoutError on
+            # newer Python; JSON parse and value errors come from the
+            # provider's response handling. Programming errors
+            # (AttributeError, TypeError) deliberately propagate so a
+            # regression cannot hide as silent retries.
+            attempt_reason = f"primary_unexpected_error:{type(exc).__name__}"
+        fallback_reason = attempt_reason
 
     if schema_fallback is not None:
         log_fallback(
             stage="enrich",
             primary=primary_client,
             fallback=schema_fallback,
-            reason="validation_failed_3x",
+            reason=fallback_reason,
         )
         try:
             enrichment = await schema_fallback.complete(prompt)
             fallback_errors = validate_enrichment(enrichment)
             if not fallback_errors:
-                enrich_cache.put(cache_key, enrichment)
+                # Intentionally no cache write: see docstring "Cache invariant".
                 return _to_enriched_chunk(chunk, enrichment)
-            raise ProviderError(
-                "validation_failed_3x",
-                transient=False,
-                provider=schema_fallback.name,
-                message=(
-                    "Enrichment schema fallback returned invalid metadata: "
-                    + "; ".join(fallback_errors)
-                ),
-            )
-        except ProviderError:
-            raise
-        except Exception:
+        except (ProviderError, asyncio.TimeoutError, ValueError, json.JSONDecodeError):
+            # Provider-class failures from the fallback are absorbed by design;
+            # programming errors propagate so regressions surface in CI.
             pass
 
     return None
@@ -354,8 +377,25 @@ async def enrich_chunks(
     primary_client = _with_provider_semaphores(clients.primary, semaphores)
     schema_fallback = _with_provider_semaphores(clients.schema_fallback, semaphores)
     assert primary_client is not None
+
+    # Avoid double-billing when the primary is a FallbackClient whose own
+    # fallback leg is the same underlying client as the configured schema
+    # fallback. ``_with_provider_semaphores`` re-wraps clients, so identity
+    # on the wrapper is not enough; compare the underlying ``_client`` (or
+    # the wrapper itself if it has none).
+    def _unwrap(c: LLMClient | None) -> LLMClient | None:
+        return getattr(c, "_client", c)
+
+    if (
+        isinstance(primary_client, FallbackClient)
+        and schema_fallback is not None
+        and _unwrap(primary_client.fallback) is _unwrap(schema_fallback)
+    ):
+        schema_fallback = None
+
     batch_size = config.enrichment_batch_size
     total_chunks = len(chunks) + len(enriched)  # original total
+    total_dropped = 0
 
     async def guarded(chunk: Chunk) -> EnrichedChunk | None:
         return await _enrich_one(
@@ -367,11 +407,49 @@ async def enrich_chunks(
     for batch_idx, start in enumerate(range(0, len(chunks), batch_size)):
         batch_num = batch_offset + batch_idx
         batch = chunks[start:start + batch_size]
-        results = await asyncio.gather(*[guarded(c) for c in batch])
+        # ``return_exceptions=True`` so one chunk's failure cannot cancel the
+        # rest of the in-flight batch (#47). ``_enrich_one`` already absorbs
+        # per-chunk errors and returns ``None`` on terminal failure; this
+        # guard is defensive in case a future change introduces a new raise
+        # path or a cancellation slips through.
+        results: list[EnrichedChunk | None | BaseException] = await asyncio.gather(
+            *[guarded(c) for c in batch], return_exceptions=True
+        )
 
+        batch_dropped = 0
         for result in results:
-            if result is not None:
-                enriched.append(result)
+            # An outer-task cancellation propagates through ``await
+            # asyncio.gather(...)`` directly; a child CancelledError
+            # returned as a value here means a per-task cancel that we
+            # treat as a per-chunk failure and keep going.
+            if isinstance(result, asyncio.CancelledError):
+                print(
+                    f"  warning: chunk cancelled: {result}",
+                    file=sys.stderr,
+                )
+                batch_dropped += 1
+                continue
+            if isinstance(result, BaseException):
+                print(
+                    f"  warning: chunk failed with {type(result).__name__}: {result}",
+                    file=sys.stderr,
+                )
+                batch_dropped += 1
+                continue
+            if result is None:
+                # _enrich_one absorbed the failure and returned None.
+                batch_dropped += 1
+                continue
+            enriched.append(result)
+
+        total_dropped += batch_dropped
+        if batch_dropped:
+            survived = len(batch) - batch_dropped
+            print(
+                f"  batch {batch_num:04d}: {survived} enriched, "
+                f"{batch_dropped} dropped (running total dropped: {total_dropped})",
+                file=sys.stderr,
+            )
 
         if enriched_dir is not None:
             checkpoint = [

--- a/src/king_context/scraper/fetch.py
+++ b/src/king_context/scraper/fetch.py
@@ -70,16 +70,28 @@ async def fetch_pages(
     output_dir: Path,
     config: ScraperConfig,
     provider: FetchProvider,
+    *,
+    force_refresh: bool = False,
 ) -> FetchResult:
+    """Fetch ``urls`` into ``output_dir/pages/``.
+
+    By default the slug skip behaviour gives idempotent resume. Pass
+    ``force_refresh=True`` to refetch every URL regardless of cached state;
+    used by the update flow (ADR-0014) to detect upstream content drift.
+    """
     pages_dir = output_dir / "pages"
     pages_dir.mkdir(parents=True, exist_ok=True)
 
-    existing_slugs = {f.stem for f in pages_dir.glob("*.md")}
-    pending_urls = [u for u in urls if _url_to_slug(u) not in existing_slugs]
-    skipped = len(urls) - len(pending_urls)
+    if force_refresh:
+        pending_urls = list(urls)
+        skipped = 0
+    else:
+        existing_slugs = {f.stem for f in pages_dir.glob("*.md")}
+        pending_urls = [u for u in urls if _url_to_slug(u) not in existing_slugs]
+        skipped = len(urls) - len(pending_urls)
 
-    if skipped > 0:
-        print(f"Resuming: {skipped} pages already fetched, {len(pending_urls)} remaining")
+        if skipped > 0:
+            print(f"Resuming: {skipped} pages already fetched, {len(pending_urls)} remaining")
 
     semaphore = asyncio.Semaphore(config.concurrency)
 

--- a/src/king_context/scraper/update.py
+++ b/src/king_context/scraper/update.py
@@ -183,11 +183,13 @@ def _enrichment_from_section(section: dict) -> dict:
 
 
 def _resolve_source_url(corpus: dict) -> str:
-    return (
-        corpus.get("_meta", {}).get("source_url")
-        or corpus.get("base_url")
-        or ""
-    )
+    # `corpus.get("_meta") or {}` (not the default form) so an explicit
+    # `"_meta": null` in the JSON still produces a dict for the chained
+    # .get(...) instead of raising AttributeError. The legacy guard
+    # upstream uses `"_meta" not in corpus`, which lets explicit-null
+    # through.
+    meta = corpus.get("_meta") or {}
+    return meta.get("source_url") or corpus.get("base_url") or ""
 
 
 def _build_reuse_index(corpus: dict) -> dict[str, dict]:

--- a/src/king_context/scraper/update.py
+++ b/src/king_context/scraper/update.py
@@ -1,0 +1,597 @@
+"""Incremental refresh of an indexed corpus.
+
+Re-runs the scraper pipeline against the upstream of an existing
+``data/<name>.json`` corpus, but reuses every section whose chunked content
+is byte identical to what the previous scrape produced. Only chunks whose
+``content_hash`` is new (added or changed) get sent to the LLM, so a typical
+documentation refresh costs cents instead of dollars even on a large corpus.
+
+The integrity unit is the chunk's ``sha256(content)`` from ADR-0012. When a
+chunk's hash matches an existing section, the existing enrichment values
+(``keywords``, ``use_cases``, ``tags``, ``priority``) are carried forward but
+the structural fields (``title``, ``path``, ``url``) come from the fresh chunk
+so a page reorganisation upstream is reflected accurately.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from scraper_providers import (
+    ProviderUnavailableError,
+    get_discovery_provider,
+    get_fetch_provider,
+    resolve_provider_name,
+)
+
+from king_context import PROJECT_ROOT
+from king_context.scraper._cache_mode import (
+    add_cache_mode_argument,
+    apply_cache_mode_flag,
+    restore_cache_mode,
+)
+from king_context.scraper.chunk import Chunk, chunk_pages
+from king_context.scraper.config import ScraperConfig, load_config
+from king_context.scraper.discover import discover_urls, get_work_dir
+from king_context.scraper.enrich import (
+    EnrichedChunk,
+    enrich_chunks,
+    estimate_cost,
+)
+from king_context.scraper.export import export_to_json
+from king_context.scraper.fetch import fetch_pages
+from king_context.scraper.filter import filter_urls
+from king_context.scraper.url_utils import canonicalize_url
+
+
+@dataclass
+class UpdatePlan:
+    """Result of comparing a fresh scrape against the existing corpus."""
+    reused_chunks: list[Chunk] = field(default_factory=list)
+    new_chunks: list[Chunk] = field(default_factory=list)
+    fresh_urls: set[str] = field(default_factory=set)
+    corpus_urls: set[str] = field(default_factory=set)
+
+    @property
+    def removed_urls(self) -> list[str]:
+        return sorted(self.corpus_urls - self.fresh_urls)
+
+    @property
+    def added_urls(self) -> list[str]:
+        return sorted(self.fresh_urls - self.corpus_urls)
+
+
+@dataclass
+class UpdateReport:
+    name: str
+    reused: int
+    enriched: int
+    lost: int
+    fetch_failed: int
+    removed_urls: list[str]
+    added_urls: list[str]
+    total_sections: int
+
+
+# Both thresholds are strict-`>` boundaries: exactly-on-the-line ratios PASS.
+# A 1-of-10 fetch failure (0.10) is allowed; a 2-of-10 (0.20) aborts. A 50/50
+# discover loss is allowed; 51% aborts. Locked in by the test suite — change
+# the operator and the test names in lockstep.
+FETCH_FAILURE_RATIO_THRESHOLD = 0.10
+DISCOVER_LOSS_RATIO_THRESHOLD = 0.50
+
+
+def _candidate_corpus_paths(name: str) -> list[Path]:
+    return [
+        PROJECT_ROOT / ".king-context" / "data" / f"{name}.json",
+        PROJECT_ROOT / "data" / f"{name}.json",
+    ]
+
+
+def find_corpus(name: str) -> Path:
+    for path in _candidate_corpus_paths(name):
+        if path.exists():
+            return path
+    searched = "\n  ".join(str(p) for p in _candidate_corpus_paths(name))
+    raise FileNotFoundError(f"Corpus '{name}' not found. Searched:\n  {searched}")
+
+
+def _load_corpus(corpus_path: Path) -> dict:
+    raw = corpus_path.read_text(encoding="utf-8")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"corpus at {corpus_path} is not valid JSON: {exc}") from exc
+
+
+def _section_hash(section: dict) -> str:
+    """Resolve a section's content hash, falling back to a recompute for legacy corpora.
+
+    The fallback assumes the JSON-stored ``content`` round-trips to the same bytes
+    a fresh chunk produces; under the standard ``json.loads`` settings (NFC unicode,
+    UTF-8 encoding) this holds. Corpora with non-NFC content will miss-match here
+    and pay LLM cost on the first update; subsequent updates after that one
+    rewrites the corpus carry the stored ``_meta.content_hash`` and cost nothing.
+    """
+    stored = section.get("_meta", {}).get("content_hash")
+    if stored:
+        return stored
+    return hashlib.sha256(section.get("content", "").encode("utf-8")).hexdigest()
+
+
+def _reset_work_dir(work_dir: Path) -> None:
+    """Wipe per-stage state so update never inherits artifacts from a prior run.
+
+    Critical for correctness: stale ``enriched/batch_*.json`` triggers the resume
+    logic in ``enrich.py`` and silently returns the OLD batch contents instead of
+    enriching the fresh chunks. Stale ``pages/*.md`` from URLs no longer present
+    upstream would survive ``chunk_pages`` and resurface in the new corpus as
+    "reused" because their content hash still matches the old sections.
+    """
+    for sub in ("pages", "chunks", "enriched"):
+        target = work_dir / sub
+        if target.exists():
+            shutil.rmtree(target)
+    manifest = work_dir / "manifest.json"
+    if manifest.exists():
+        manifest.unlink()
+
+
+def _atomic_write_json(path: Path, doc: dict) -> None:
+    """Write JSON via tempfile + os.replace so an interrupted update never leaves a partial file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(doc, indent=2, ensure_ascii=False)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp_name, path)
+        tmp_name = None
+    finally:
+        if tmp_name is not None and Path(tmp_name).exists():
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+
+def _enrichment_from_section(section: dict) -> dict:
+    # Defaults match a "no enrichment" shape so a malformed legacy section
+    # (passes the `_meta` guard but lacks one of these fields) still produces
+    # a reuse entry rather than crashing the whole update with KeyError. The
+    # downstream effect is the chunk gets re-enriched, which is the safer
+    # default — we pay LLM cost on a curated section that lost its metadata,
+    # rather than aborting the entire refresh.
+    return {
+        "keywords": section.get("keywords") or [],
+        "use_cases": section.get("use_cases") or [],
+        "tags": section.get("tags") or [],
+        "priority": section.get("priority", 0),
+    }
+
+
+def _resolve_source_url(corpus: dict) -> str:
+    return (
+        corpus.get("_meta", {}).get("source_url")
+        or corpus.get("base_url")
+        or ""
+    )
+
+
+def _build_reuse_index(corpus: dict) -> dict[str, dict]:
+    """Map ``content_hash`` to its enrichment values, plus the URL that produced it."""
+    out: dict[str, dict] = {}
+    for s in corpus.get("sections", []):
+        out[_section_hash(s)] = {
+            **_enrichment_from_section(s),
+            "_url": s.get("url", ""),
+        }
+    return out
+
+
+def _plan_update(
+    fresh_chunks: list[Chunk],
+    fresh_urls: Iterable[str],
+    reuse_index: dict[str, dict],
+    corpus: dict,
+) -> UpdatePlan:
+    # Canonicalise both sides before set arithmetic so trailing slashes,
+    # fragments, and host case differences do not inflate added_urls /
+    # removed_urls. Without this, legacy corpora carrying slug-form URLs
+    # and fresh discoveries carrying real https URLs would diff at 100%
+    # mismatch even when pointing at identical resources.
+    plan = UpdatePlan(
+        fresh_urls={canonicalize_url(u) for u in fresh_urls if u},
+        corpus_urls={
+            canonicalize_url(s.get("url", ""))
+            for s in corpus.get("sections", [])
+            if s.get("url")
+        },
+    )
+    for chunk in fresh_chunks:
+        if chunk.content_hash in reuse_index:
+            plan.reused_chunks.append(chunk)
+        else:
+            plan.new_chunks.append(chunk)
+    return plan
+
+
+def _materialise_reused(
+    chunks: list[Chunk], reuse_index: dict[str, dict]
+) -> list[EnrichedChunk]:
+    """Build EnrichedChunk objects from carried over enrichment metadata."""
+    out: list[EnrichedChunk] = []
+    for chunk in chunks:
+        carried = reuse_index[chunk.content_hash]
+        out.append(EnrichedChunk(
+            title=chunk.title,
+            path=chunk.path,
+            url=chunk.source_url,
+            content=chunk.content,
+            keywords=list(carried["keywords"]),
+            use_cases=list(carried["use_cases"]),
+            tags=list(carried["tags"]),
+            priority=carried["priority"],
+            content_hash=chunk.content_hash,
+        ))
+    return out
+
+
+def _interleave_in_chunk_order(
+    fresh_chunks: list[Chunk],
+    reused: list[EnrichedChunk],
+    enriched: list[EnrichedChunk],
+) -> list[EnrichedChunk]:
+    """Return the merged enriched list in the order of ``fresh_chunks``.
+
+    If ``fresh_chunks`` contains two chunks with the same ``content_hash``
+    (a real corpus example: shared boilerplate sections crossing multiple
+    pages) the deduped output emits one section per unique content. The
+    second occurrence is silently dropped — the corpus is content-keyed,
+    not URL-keyed, so the duplicate would otherwise widen the section list
+    with no new information.
+    """
+    by_hash: dict[str, EnrichedChunk] = {}
+    for e in reused:
+        by_hash[e.content_hash] = e
+    for e in enriched:
+        by_hash[e.content_hash] = e
+    out: list[EnrichedChunk] = []
+    seen: set[str] = set()
+    for chunk in fresh_chunks:
+        if chunk.content_hash in seen:
+            continue
+        e = by_hash.get(chunk.content_hash)
+        if e is not None:
+            out.append(e)
+            seen.add(chunk.content_hash)
+    return out
+
+
+async def _confirm_cost(plan: UpdatePlan, config: ScraperConfig, *, yes: bool) -> bool:
+    # Nothing to enrich means nothing to confirm. Skip the cost preview and
+    # the prompt entirely so a no-op refresh does not nag the operator with a
+    # "$0.0000" dialog.
+    if not plan.new_chunks:
+        print(
+            f"  reused: {len(plan.reused_chunks)}, "
+            f"new: 0, "
+            f"removed URLs: {len(plan.removed_urls)}, "
+            f"added URLs: {len(plan.added_urls)} "
+            "(nothing to enrich)"
+        )
+        return True
+
+    cost = estimate_cost(plan.new_chunks, config)
+    print(
+        f"  reused: {len(plan.reused_chunks)}, "
+        f"new: {len(plan.new_chunks)}, "
+        f"removed URLs: {len(plan.removed_urls)}, "
+        f"added URLs: {len(plan.added_urls)}"
+    )
+    if cost.get("provider") == "openrouter":
+        print(
+            f"  cost estimate: ${cost['estimated_cost']:.4f} "
+            f"({cost['total_chunks']} chunks, model: {cost['model']})"
+        )
+    else:
+        print(
+            f"  local model estimate: {cost['total_chunks']} chunks, "
+            f"model: {cost['model']} (no estimated OpenRouter cost)"
+        )
+    if yes:
+        return True
+    answer = input("Proceed with enrichment? [y/N] ").strip().lower()
+    return answer in ("y", "yes")
+
+
+async def update_corpus(
+    *,
+    name: str,
+    corpus_path: Path,
+    config: ScraperConfig,
+    yes: bool = False,
+) -> UpdateReport:
+    corpus = _load_corpus(corpus_path)
+
+    # Hard refuse on legacy corpora that lack ``_meta``. The fallback to
+    # ``base_url`` (which on legacy files is the host root, not the original
+    # entry point) silently triggers a full host rescrape, wipes the curated
+    # section set, and spends LLM credits with no warning. Anchor the corpus
+    # first with a fresh scrape and re-run update once ``_meta.source_url``
+    # is set. (#55, confirmed via e2e against data/minimax-audio.json.)
+    if "_meta" not in corpus:
+        raise ValueError(
+            f"corpus {corpus_path.name} has no _meta block "
+            "(legacy pre-ADR-0012 shape). Re-scrape with "
+            f"`king-scrape <url> --name {name}` first to anchor it; "
+            "subsequent update runs will then refresh incrementally."
+        )
+
+    source_url = _resolve_source_url(corpus)
+    if not source_url:
+        raise ValueError(
+            "corpus has _meta but no source_url and no base_url. "
+            f"Re-scrape from scratch with `king-scrape <url> --name {name}`."
+        )
+
+    discovery_provider = get_discovery_provider(resolve_provider_name("discover"))
+    fetch_provider = get_fetch_provider(resolve_provider_name("fetch"))
+
+    work_dir = get_work_dir(source_url)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    _reset_work_dir(work_dir)
+
+    print(f"[update] target: {name} ({source_url})")
+    print("[discover] running...")
+    discovery = await discover_urls(source_url, config, discovery_provider)
+    print(f"  found {discovery.total_urls} URLs")
+
+    print("[filter] running...")
+    filtered = filter_urls(discovery.urls, source_url, config)
+    print(
+        f"  accepted {len(filtered.accepted)}, "
+        f"rejected {len(filtered.rejected)}, "
+        f"maybe {len(filtered.maybe)}"
+    )
+
+    # Discover-divergence guard: if more than half the corpus URLs disappear
+    # from the upstream's fresh discovery, abort BEFORE the fetch step so we
+    # do not spend bandwidth + LLM credits on a corpus that just lost half
+    # its surface. Growth is allowed; only loss is dangerous (correlates
+    # with auth dropped, provider misconfigured, or upstream restructured).
+    # Compares against ``discovery.urls`` (pre-filter): a URL silently dropped
+    # by the filter is reachable on the network, so it does not count as
+    # "missing upstream" — that is the report's job (``plan.removed_urls``).
+    # At small N the threshold is intentionally sensitive (a 1-URL corpus
+    # losing its one URL aborts at 100%); that is the safe direction.
+    corpus_canon_urls = {
+        canonicalize_url(s.get("url", ""))
+        for s in corpus.get("sections", [])
+        if s.get("url")
+    }
+    if corpus_canon_urls:
+        fresh_canon_urls = {canonicalize_url(u) for u in discovery.urls if u}
+        # Skip the ratio check when fresh discovery returned nothing; the
+        # downstream "refuse to overwrite with empty corpus" guard has a
+        # clearer message for the total-wipe case.
+        if fresh_canon_urls:
+            lost = corpus_canon_urls - fresh_canon_urls
+            loss_ratio = len(lost) / len(corpus_canon_urls)
+            if loss_ratio > DISCOVER_LOSS_RATIO_THRESHOLD:
+                sample = sorted(lost)[:5]
+                raise ValueError(
+                    f"refused to update {corpus_path.name}: "
+                    f"{len(lost)} of {len(corpus_canon_urls)} corpus URLs "
+                    f"({loss_ratio:.0%}) are missing from the fresh discovery, "
+                    f"above the {DISCOVER_LOSS_RATIO_THRESHOLD:.0%} threshold. "
+                    "Investigate before retrying. Sample missing URLs: "
+                    f"{sample}"
+                )
+
+    print("[fetch] running (force refresh)...")
+    fetch_result = await fetch_pages(
+        filtered.accepted,
+        work_dir,
+        config,
+        fetch_provider,
+        force_refresh=True,
+    )
+    print(f"  fetched {fetch_result.completed}, failed {fetch_result.failed}")
+
+    # Fetch-failure threshold: if too many accepted URLs failed to fetch,
+    # the resulting corpus would silently truncate. Refuse the writeback
+    # so the existing corpus on disk stays intact.
+    if filtered.accepted:
+        fail_ratio = fetch_result.failed / len(filtered.accepted)
+        if fail_ratio > FETCH_FAILURE_RATIO_THRESHOLD:
+            raise ValueError(
+                f"refused to update {corpus_path.name}: "
+                f"{fetch_result.failed} of {len(filtered.accepted)} fetches "
+                f"failed ({fail_ratio:.0%}), above the "
+                f"{FETCH_FAILURE_RATIO_THRESHOLD:.0%} threshold. The existing "
+                "corpus is untouched. Investigate before retrying."
+            )
+
+    print("[chunk] running...")
+    fresh_chunks = chunk_pages(work_dir / "pages", work_dir, config)
+    print(f"  produced {len(fresh_chunks)} chunks")
+
+    # Refuse to wipe a non-empty corpus when discover/filter produced nothing.
+    # Most often this is a network blip or an over-aggressive filter regex; the
+    # original corpus is the safer artifact to preserve.
+    if not fresh_chunks and corpus.get("sections"):
+        raise ValueError(
+            f"refused to overwrite {corpus_path} with an empty corpus "
+            f"(discover/filter produced 0 URLs). The existing corpus is "
+            "untouched. Investigate before retrying."
+        )
+
+    reuse_index = _build_reuse_index(corpus)
+    plan = _plan_update(fresh_chunks, filtered.accepted, reuse_index, corpus)
+
+    print("[plan]")
+    proceed = await _confirm_cost(plan, config, yes=yes)
+    if not proceed:
+        print("aborted by user")
+        raise SystemExit(1)
+
+    if plan.new_chunks:
+        print("[enrich] running...")
+        enriched_new = await enrich_chunks(plan.new_chunks, config, work_dir)
+        print(f"  enriched {len(enriched_new)} new chunks")
+    else:
+        print("[enrich] nothing to enrich (all chunks reused)")
+        enriched_new = []
+
+    lost = len(plan.new_chunks) - len(enriched_new)
+    if lost > 0:
+        print(
+            f"warning: {lost} chunk(s) failed enrichment and are not in "
+            "the output corpus"
+        )
+
+    reused_enriched = _materialise_reused(plan.reused_chunks, reuse_index)
+    final = _interleave_in_chunk_order(fresh_chunks, reused_enriched, enriched_new)
+
+    doc = export_to_json(
+        final,
+        doc_name=corpus.get("name", name),
+        display_name=corpus.get("display_name", name),
+        base_url=corpus.get("base_url", source_url),
+        version=corpus.get("version", "v1"),
+    )
+
+    print("[export] running...")
+    _atomic_write_json(corpus_path, doc)
+
+    return UpdateReport(
+        name=name,
+        reused=len(reused_enriched),
+        enriched=len(enriched_new),
+        lost=lost,
+        fetch_failed=fetch_result.failed,
+        removed_urls=plan.removed_urls,
+        added_urls=plan.added_urls,
+        total_sections=len(final),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="king-scrape update",
+        description=(
+            "Incrementally refresh an indexed corpus. Reuses every section "
+            "whose chunked content is unchanged; only new or changed chunks "
+            "are sent to the LLM."
+        ),
+    )
+    parser.add_argument("name", help="Doc name (matches data/<name>.json)")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the cost confirmation prompt before enrichment.",
+    )
+    parser.add_argument(
+        "--corpus-path",
+        type=Path,
+        default=None,
+        help=(
+            "Explicit path to the corpus JSON. Bypasses the default lookup in "
+            "data/<name>.json and .king-context/data/<name>.json."
+        ),
+    )
+    parser.add_argument(
+        "--provider",
+        default=None,
+        help="Scraper provider name (e.g. 'firecrawl', 'crawl4ai').",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="OpenRouter model for enrichment.",
+    )
+    add_cache_mode_argument(parser)
+    return parser
+
+
+def update_main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+
+    # Snapshot SCRAPE_PROVIDER state so `--provider` does not leak past the
+    # call boundary. The flag wins over any pre-existing env DURING the run
+    # (asymmetric with cli.main's setdefault, by design — `update` is an
+    # explicit refresh action), but the prior state is restored on exit so
+    # tests and embedding hosts see the same env they handed us.
+    provider_was_set = "SCRAPE_PROVIDER" in os.environ
+    provider_prior = os.environ.get("SCRAPE_PROVIDER")
+    if args.provider:
+        os.environ["SCRAPE_PROVIDER"] = args.provider
+
+    cache_mode_was_set, cache_mode_prior = apply_cache_mode_flag(args)
+    try:
+        if args.corpus_path is not None:
+            corpus_path = args.corpus_path
+            if not corpus_path.exists():
+                print(f"error: corpus path does not exist: {corpus_path}", file=sys.stderr)
+                return 1
+        else:
+            try:
+                corpus_path = find_corpus(args.name)
+            except FileNotFoundError as exc:
+                print(str(exc), file=sys.stderr)
+                return 1
+
+        config = load_config(enrichment_model=args.model)
+        try:
+            report = asyncio.run(update_corpus(
+                name=args.name,
+                corpus_path=corpus_path,
+                config=config,
+                yes=args.yes,
+            ))
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        except ProviderUnavailableError as exc:
+            print(f"error: {exc.hint}", file=sys.stderr)
+            return 3
+        except SystemExit as exc:
+            # SystemExit(0) is a legitimate clean exit; only fall back to 1
+            # when the code is unset/None. `int(exc.code or 1)` would coerce
+            # 0 -> 1 because `0 or 1` evaluates to 1.
+            if exc.code is None:
+                return 1
+            return int(exc.code)
+    finally:
+        restore_cache_mode(cache_mode_was_set, cache_mode_prior)
+        if provider_was_set:
+            os.environ["SCRAPE_PROVIDER"] = provider_prior  # type: ignore[assignment]
+        else:
+            os.environ.pop("SCRAPE_PROVIDER", None)
+
+    extras: list[str] = []
+    if report.lost > 0:
+        extras.append(f"lost {report.lost}")
+    if report.fetch_failed > 0:
+        extras.append(f"fetch_failed {report.fetch_failed}")
+    extras_str = (", " + ", ".join(extras)) if extras else ""
+    print(
+        f"update {report.name}: "
+        f"{report.total_sections} sections "
+        f"(reused {report.reused}, enriched {report.enriched}{extras_str}, "
+        f"added {len(report.added_urls)} URLs, removed {len(report.removed_urls)} URLs)"
+    )
+    return 0

--- a/src/king_context/scraper/url_utils.py
+++ b/src/king_context/scraper/url_utils.py
@@ -1,0 +1,21 @@
+"""URL helpers shared across scraper subcommands.
+
+``canonicalize_url`` normalises a URL down to a form that lets two URLs
+pointing at the same resource compare equal: drops the fragment, lowercases
+scheme and host, and strips the trailing slash from the path. Used by the
+audit command's dedupe + discovery diff and by the update command's
+``corpus_urls`` vs ``fresh_urls`` set arithmetic.
+"""
+from __future__ import annotations
+
+from urllib.parse import urldefrag, urlsplit, urlunsplit
+
+
+def canonicalize_url(url: str) -> str:
+    """Drop fragment, lowercase scheme/host, strip trailing slash from path."""
+    url, _ = urldefrag(url)
+    parts = urlsplit(url)
+    path = parts.path.rstrip("/") or "/"
+    return urlunsplit(
+        (parts.scheme.lower(), parts.netloc.lower(), path, parts.query, "")
+    )

--- a/src/scraper_providers/crawl4ai_provider.py
+++ b/src/scraper_providers/crawl4ai_provider.py
@@ -1,6 +1,8 @@
 """Crawl4AI scraper provider — local Playwright-based backend."""
 from __future__ import annotations
 
+import os
+import sys
 from datetime import datetime, timezone
 from typing import Any, Iterable
 
@@ -14,6 +16,7 @@ try:
     from crawl4ai import (  # type: ignore[import-not-found]
         AsyncWebCrawler,
         BrowserConfig,
+        CacheMode,
         CrawlerRunConfig,
     )
     from crawl4ai.deep_crawling import (  # type: ignore[import-not-found]
@@ -23,9 +26,74 @@ try:
 except ImportError:
     AsyncWebCrawler = None  # type: ignore[assignment,misc]
     BrowserConfig = None  # type: ignore[assignment,misc]
+    CacheMode = None  # type: ignore[assignment,misc]
     CrawlerRunConfig = None  # type: ignore[assignment,misc]
     BFSDeepCrawlStrategy = None  # type: ignore[assignment,misc]
     _CRAWL4AI_AVAILABLE = False
+
+
+# Maps the public ``SCRAPE_CACHE_MODE`` env value to the attribute name on
+# Crawl4AI's ``CacheMode`` enum. ``"default"`` is handled by an early return
+# in ``_resolve_cache_mode`` and is intentionally absent here.
+_CACHE_MODE_MAP = {
+    "enabled": "ENABLED",
+    "bypass": "BYPASS",
+    "disabled": "DISABLED",
+    "read_only": "READ_ONLY",
+    "write_only": "WRITE_ONLY",
+}
+
+# One-shot warning state so a typo in SCRAPE_CACHE_MODE does not produce
+# hundreds of duplicate stderr lines during a deep crawl. Keyed by the raw
+# value so different typos still each warn once. Tests reset this set via
+# ``monkeypatch.setattr(...)`` to keep warn-once assertions independent.
+_WARNED_CACHE_VALUES: set[str] = set()
+
+
+def _warn_unknown_cache_mode(raw: str) -> None:
+    if raw in _WARNED_CACHE_VALUES:
+        return
+    _WARNED_CACHE_VALUES.add(raw)
+    print(
+        f"warning: SCRAPE_CACHE_MODE='{raw}' not recognised; "
+        "using crawl4ai default",
+        file=sys.stderr,
+    )
+
+
+def _resolve_cache_mode() -> Any:
+    """Resolve ``SCRAPE_CACHE_MODE`` env to a ``CacheMode`` value or ``None``.
+
+    ``None`` means "use the library default" — callers omit ``cache_mode``
+    from ``CrawlerRunConfig`` rather than passing ``None``, so existing
+    behaviour is preserved when the env is unset.
+
+    Two distinct paths return ``None``: (1) the value is missing, ``default``,
+    or unrecognised — emits a stderr warning the first time per raw value;
+    (2) the ``crawl4ai`` library is not installed — silent because the
+    caller's ``_ensure_available`` will surface a clearer error before any
+    real fetch happens.
+    """
+    raw = (os.environ.get("SCRAPE_CACHE_MODE") or "").strip().lower()
+    if not raw or raw == "default":
+        return None
+    if CacheMode is None:
+        # Library missing: stay silent. The caller path won't reach a real
+        # crawl4ai call (the provider's _ensure_available raises a clearer
+        # ProviderUnavailableError), so a "not recognised" warning here would
+        # only confuse a user whose actual problem is a missing dependency.
+        return None
+    mapped = _CACHE_MODE_MAP.get(raw)
+    if mapped is None:
+        _warn_unknown_cache_mode(raw)
+        return None
+    try:
+        return getattr(CacheMode, mapped)
+    except AttributeError:
+        # Future crawl4ai version may rename the enum value. Fall back to
+        # default behaviour with a one-shot warning so the run continues.
+        _warn_unknown_cache_mode(raw)
+        return None
 
 
 _INSTALL_HINT = (
@@ -103,10 +171,15 @@ class Crawl4AIDiscoveryProvider:
     async def discover_urls(self, base_url: str) -> list[str]:
         _ensure_available()
         _ensure_browser_present()
+        cache_kwargs: dict[str, Any] = {}
+        cache_mode = _resolve_cache_mode()
+        if cache_mode is not None:
+            cache_kwargs["cache_mode"] = cache_mode
         run_config = CrawlerRunConfig(  # type: ignore[misc]
             deep_crawl_strategy=BFSDeepCrawlStrategy(  # type: ignore[misc]
                 max_depth=2, include_external=False
             ),
+            **cache_kwargs,
         )
         try:
             async with AsyncWebCrawler(  # type: ignore[misc]
@@ -131,11 +204,23 @@ class Crawl4AIFetchProvider:
     async def fetch_one(self, url: str) -> PageContent:
         _ensure_available()
         _ensure_browser_present()
+        cache_mode = _resolve_cache_mode()
+        run_config = (
+            CrawlerRunConfig(cache_mode=cache_mode)  # type: ignore[misc]
+            if cache_mode is not None
+            else None
+        )
         try:
             async with AsyncWebCrawler(  # type: ignore[misc]
                 config=BrowserConfig(headless=True),  # type: ignore[misc]
             ) as crawler:
-                result = await crawler.arun(url=url)
+                if run_config is not None:
+                    result = await crawler.arun(url=url, config=run_config)
+                else:
+                    # Preserve the pre-fix call shape when no cache override is
+                    # set, so existing behaviour and any provider-side defaults
+                    # remain unchanged for users who have not opted in.
+                    result = await crawler.arun(url=url)
         except Exception as exc:
             if _is_browser_missing(exc):
                 raise ProviderUnavailableError("crawl4ai", _SETUP_HINT) from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,9 +61,21 @@ def fake_stage_clients(primary, schema_fallback=None):
 
 @pytest.fixture
 def temp_db(tmp_path, monkeypatch):
-    """Create a temporary database path for testing."""
+    """Create a temporary database path for testing.
+
+    Also redirects the embedding sidecar files (``embeddings.npy``,
+    ``section_mapping.json``) and resets the in-process embedding state so a
+    test that triggers ``_generate_and_save_embedding`` cannot write to the
+    real repo's ``data/`` directory.
+    """
     temp_db_path = tmp_path / "test_docs.db"
     monkeypatch.setattr(db, "DB_PATH", temp_db_path)
+    monkeypatch.setattr(db, "EMBEDDINGS_PATH", tmp_path / "embeddings.npy")
+    monkeypatch.setattr(
+        db, "SECTION_MAPPING_PATH", tmp_path / "section_mapping.json"
+    )
+    monkeypatch.setattr(db, "_embeddings", None)
+    monkeypatch.setattr(db, "_section_id_to_idx", {})
     yield temp_db_path
     if temp_db_path.exists():
         temp_db_path.unlink()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2488,3 +2488,273 @@ class TestListDocumentations:
 
         assert len(result) == 1
         assert result[0]["version"] is None
+
+
+class TestInsertDocumentationUpsert:
+    """Re-seeding the same doc name must succeed and replace prior content (#48)."""
+
+    def _make_doc(self, name: str, sections: list[dict]) -> dict:
+        return {
+            "name": name,
+            "display_name": name.title(),
+            "version": "v1",
+            "base_url": "https://docs.example.com",
+            "sections": sections,
+        }
+
+    def _section(self, title: str, content: str = "body", **overrides) -> dict:
+        base = {
+            "title": title,
+            "path": f"/p/{title}",
+            "url": f"https://docs.example.com/{title}",
+            "keywords": ["k1"],
+            "use_cases": ["uc1"],
+            "tags": ["t1"],
+            "priority": 5,
+            "content": content,
+        }
+        base.update(overrides)
+        return base
+
+    def test_reseed_does_not_raise_unique_constraint(self, temp_db):
+        db.init_db()
+        doc = self._make_doc("hono-test", [self._section("a"), self._section("b")])
+        db.insert_documentation(doc)
+        # Second insert with the same name used to raise IntegrityError.
+        db.insert_documentation(doc)  # must not raise
+
+    def test_reseed_replaces_sections(self, temp_db):
+        db.init_db()
+        first = self._make_doc("demo", [self._section("a"), self._section("b")])
+        db.insert_documentation(first)
+
+        second = self._make_doc(
+            "demo",
+            [self._section("c"), self._section("d"), self._section("e")],
+        )
+        db.insert_documentation(second)
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            doc_count = cursor.execute(
+                "SELECT COUNT(*) FROM documentations WHERE name = ?",
+                ("demo",),
+            ).fetchone()[0]
+            assert doc_count == 1
+
+            section_count = cursor.execute(
+                "SELECT COUNT(*) FROM sections "
+                "JOIN documentations ON sections.doc_id = documentations.id "
+                "WHERE documentations.name = ?",
+                ("demo",),
+            ).fetchone()[0]
+            assert section_count == 3
+
+            titles = {
+                row[0]
+                for row in cursor.execute(
+                    "SELECT title FROM sections "
+                    "JOIN documentations ON sections.doc_id = documentations.id "
+                    "WHERE documentations.name = ?",
+                    ("demo",),
+                ).fetchall()
+            }
+            assert titles == {"c", "d", "e"}
+        finally:
+            conn.close()
+
+    def test_reseed_prunes_fts5_index(self, temp_db):
+        db.init_db()
+        first = self._make_doc(
+            "demo",
+            [self._section("alpha", content="uniqueoldtokenzzz")],
+        )
+        db.insert_documentation(first)
+
+        second = self._make_doc(
+            "demo",
+            [self._section("beta", content="brandnewtokenyyy")],
+        )
+        db.insert_documentation(second)
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            old = cursor.execute(
+                "SELECT COUNT(*) FROM sections_fts WHERE sections_fts MATCH 'uniqueoldtokenzzz'"
+            ).fetchone()[0]
+            new = cursor.execute(
+                "SELECT COUNT(*) FROM sections_fts WHERE sections_fts MATCH 'brandnewtokenyyy'"
+            ).fetchone()[0]
+            assert old == 0
+            assert new == 1
+        finally:
+            conn.close()
+
+    def test_reseed_prunes_query_cache_via_cascade(self, temp_db):
+        db.init_db()
+        doc = self._make_doc("demo", [self._section("a")])
+        db.insert_documentation(doc)
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            # Re-enable FK on this raw connection so the manual insert and any
+            # subsequent cascade behave the same way the production path does.
+            cursor.execute("PRAGMA foreign_keys = ON")
+            section_id = cursor.execute(
+                "SELECT sections.id FROM sections "
+                "JOIN documentations d ON sections.doc_id = d.id "
+                "WHERE d.name = ?",
+                ("demo",),
+            ).fetchone()[0]
+            cursor.execute(
+                "INSERT INTO query_cache (query_normalized, doc_name, section_id) VALUES (?, ?, ?)",
+                ("hello", "demo", section_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        db.insert_documentation(
+            self._make_doc("demo", [self._section("b"), self._section("c")])
+        )
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            stale = cursor.execute(
+                "SELECT COUNT(*) FROM query_cache WHERE section_id = ?",
+                (section_id,),
+            ).fetchone()[0]
+            assert stale == 0
+        finally:
+            conn.close()
+
+    def test_first_insert_unchanged(self, temp_db):
+        db.init_db()
+        doc = self._make_doc("brand-new", [self._section("a"), self._section("b")])
+        doc_id = db.insert_documentation(doc)
+        assert isinstance(doc_id, int)
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            count = cursor.execute(
+                "SELECT COUNT(*) FROM sections WHERE doc_id = ?",
+                (doc_id,),
+            ).fetchone()[0]
+            assert count == 2
+        finally:
+            conn.close()
+
+    def test_reseed_preserves_created_at_and_doc_id(self, temp_db):
+        """ON CONFLICT keeps created_at; doc_id is stable across re-seeds."""
+        db.init_db()
+        first_id = db.insert_documentation(
+            self._make_doc("demo", [self._section("a")])
+        )
+
+        conn = sqlite3.connect(temp_db)
+        original_created_at = conn.execute(
+            "SELECT created_at FROM documentations WHERE name = ?", ("demo",)
+        ).fetchone()[0]
+        conn.close()
+
+        # Re-seed after a small delay so updated_at would differ if changed.
+        import time
+        time.sleep(0.01)
+        second_id = db.insert_documentation(
+            self._make_doc("demo", [self._section("b"), self._section("c")])
+        )
+
+        assert first_id == second_id  # doc_id stable
+
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            row = cursor.execute(
+                "SELECT created_at, updated_at FROM documentations WHERE name = ?",
+                ("demo",),
+            ).fetchone()
+            assert row[0] == original_created_at  # created_at preserved
+            assert row[1] != original_created_at  # updated_at advances
+        finally:
+            conn.close()
+
+    def test_reseed_rolls_back_cleanly_on_failure(self, temp_db):
+        """A malformed second insert must leave the original corpus intact."""
+        db.init_db()
+        db.insert_documentation(
+            self._make_doc("demo", [self._section("a"), self._section("b")])
+        )
+
+        # Sections require `path`; omit it to provoke a KeyError mid-upsert,
+        # AFTER the FTS5 deletes for the original sections have been issued.
+        bad_doc = self._make_doc("demo", [{"title": "broken"}])
+        with pytest.raises(KeyError):
+            db.insert_documentation(bad_doc)
+
+        # Rollback must have restored the FTS index and the section rows.
+        conn = sqlite3.connect(temp_db)
+        try:
+            cursor = conn.cursor()
+            section_titles = {
+                row[0] for row in cursor.execute(
+                    "SELECT title FROM sections "
+                    "JOIN documentations ON sections.doc_id = documentations.id "
+                    "WHERE documentations.name = ?",
+                    ("demo",),
+                ).fetchall()
+            }
+            assert section_titles == {"a", "b"}
+
+            fts_count = cursor.execute(
+                "SELECT COUNT(*) FROM sections_fts "
+                "WHERE rowid IN (SELECT sections.id FROM sections "
+                "JOIN documentations d ON sections.doc_id = d.id "
+                "WHERE d.name = ?)",
+                ("demo",),
+            ).fetchone()[0]
+            assert fts_count == 2
+        finally:
+            conn.close()
+
+    def test_reseed_does_not_touch_real_repo_embeddings(self, tmp_path, monkeypatch):
+        """Regression guard for the temp_db fixture's path isolation.
+
+        If ``temp_db`` ever stops patching ``EMBEDDINGS_PATH``, this test
+        proves the hole by verifying nothing is written outside the tmp dir
+        even when the embedding model is set.
+        """
+        temp_db_path = tmp_path / "test_docs.db"
+        monkeypatch.setattr(db, "DB_PATH", temp_db_path)
+        emb_path = tmp_path / "embeddings.npy"
+        map_path = tmp_path / "section_mapping.json"
+        monkeypatch.setattr(db, "EMBEDDINGS_PATH", emb_path)
+        monkeypatch.setattr(db, "SECTION_MAPPING_PATH", map_path)
+        monkeypatch.setattr(db, "_embeddings", None)
+        monkeypatch.setattr(db, "_section_id_to_idx", {})
+
+        # Stand-in embedding model: returns a fixed 4-dim vector.
+        class _StubModel:
+            def encode(self, content):
+                import numpy as np
+                return np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+
+        monkeypatch.setattr(db, "_embedding_model", _StubModel())
+
+        db.init_db()
+        db.insert_documentation(
+            self._make_doc("demo", [self._section("a")])
+        )
+
+        assert emb_path.exists()
+        assert map_path.exists()
+        # The real repo paths must NOT have been touched.
+        real_repo_emb = (
+            db.PROJECT_ROOT / "data" / "embeddings.npy"
+        ) if hasattr(db, "PROJECT_ROOT") else None
+        # Best effort assertion: emb_path lives under tmp_path.
+        assert str(tmp_path) in str(emb_path)

--- a/tests/test_scraper/test_audit.py
+++ b/tests/test_scraper/test_audit.py
@@ -266,6 +266,65 @@ def test_audit_main_returns_0_when_clean(tmp_path: Path):
     assert rc == 0
 
 
+def test_audit_main_no_fetch_cache_sets_env(tmp_path: Path, monkeypatch):
+    """`king-scrape audit --no-fetch-cache` must set SCRAPE_CACHE_MODE=bypass
+    for the duration of the run and restore the prior state on exit."""
+    import os
+
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+    corpus_path = _make_corpus(tmp_path)
+    audit_dir = tmp_path / "out"
+
+    seen = {"during": None}
+
+    async def fake_check(section_urls, *, concurrency=10):
+        seen["during"] = os.environ.get("SCRAPE_CACHE_MODE")
+        return [
+            audit.SectionAudit(url=url, title=title, status="fresh", status_code=200)
+            for url, title in section_urls
+        ]
+
+    with patch.object(audit, "find_corpus", return_value=corpus_path), \
+         patch.object(audit, "_check_section_urls", side_effect=fake_check):
+        rc = audit.audit_main([
+            "demo", "--no-discover", "--no-fetch-cache",
+            "--report-dir", str(audit_dir),
+        ])
+
+    assert rc == 0
+    assert seen["during"] == "bypass"
+    assert "SCRAPE_CACHE_MODE" not in os.environ
+
+
+def test_audit_main_no_fetch_cache_respects_prior_env(tmp_path: Path, monkeypatch):
+    """Explicit pre-existing env value wins via setdefault, restored on exit."""
+    import os
+
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "read_only")
+    corpus_path = _make_corpus(tmp_path)
+    audit_dir = tmp_path / "out"
+
+    seen = {"during": None}
+
+    async def fake_check(section_urls, *, concurrency=10):
+        seen["during"] = os.environ.get("SCRAPE_CACHE_MODE")
+        return [
+            audit.SectionAudit(url=url, title=title, status="fresh", status_code=200)
+            for url, title in section_urls
+        ]
+
+    with patch.object(audit, "find_corpus", return_value=corpus_path), \
+         patch.object(audit, "_check_section_urls", side_effect=fake_check):
+        rc = audit.audit_main([
+            "demo", "--no-discover", "--no-fetch-cache",
+            "--report-dir", str(audit_dir),
+        ])
+
+    assert rc == 0
+    assert seen["during"] == "read_only"
+    assert os.environ.get("SCRAPE_CACHE_MODE") == "read_only"
+
+
 def test_audit_main_returns_1_when_corpus_missing(tmp_path: Path, capsys):
     rc = audit.audit_main(["does-not-exist", "--no-discover"])
     assert rc == 1

--- a/tests/test_scraper/test_chunk.py
+++ b/tests/test_scraper/test_chunk.py
@@ -196,3 +196,75 @@ def test_chunk_content_hash_changes_with_content():
     b = Chunk(title="", breadcrumb="", content="B",
               source_url="u", path="p", token_count=1)
     assert a.content_hash != b.content_hash
+
+
+# --- _resolve_page_url + chunk_pages sidecar integration ----------------
+
+
+def test_chunk_pages_uses_real_url_from_sidecar(tmp_path):
+    """When a <slug>.meta.json sidecar exists next to <slug>.md, chunks
+    carry the real https URL, not the slug stem."""
+    import json
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "docs-example-com-quickstart.md").write_text(
+        "## Quickstart\n\nbody text"
+    )
+    (pages_dir / "docs-example-com-quickstart.meta.json").write_text(
+        json.dumps({
+            "url": "https://docs.example.com/quickstart",
+            "slug": "docs-example-com-quickstart",
+            "content_hash": "deadbeef",
+            "fetched_at": "2026-05-08T00:00:00+00:00",
+            "byte_size": 18,
+        })
+    )
+
+    config = make_config(chunk_min_tokens=1)
+    chunks = chunk_pages(pages_dir, tmp_path, config)
+
+    assert len(chunks) == 1
+    assert chunks[0].source_url == "https://docs.example.com/quickstart"
+
+
+def test_chunk_pages_falls_back_to_slug_when_sidecar_missing(tmp_path):
+    """Pre-#46 work directories have no sidecars; chunks fall back to slug."""
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "legacy-slug.md").write_text("## Title\n\nbody")
+    # No legacy-slug.meta.json on disk.
+
+    config = make_config(chunk_min_tokens=1)
+    chunks = chunk_pages(pages_dir, tmp_path, config)
+
+    assert len(chunks) == 1
+    assert chunks[0].source_url == "legacy-slug"
+
+
+def test_chunk_pages_falls_back_to_slug_when_sidecar_malformed(tmp_path):
+    """Malformed sidecar must not abort the run; fall back to slug."""
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "broken.md").write_text("## Title\n\nbody")
+    (pages_dir / "broken.meta.json").write_text("{ not valid json")
+
+    config = make_config(chunk_min_tokens=1)
+    chunks = chunk_pages(pages_dir, tmp_path, config)
+
+    assert len(chunks) == 1
+    assert chunks[0].source_url == "broken"
+
+
+def test_chunk_pages_falls_back_to_slug_when_sidecar_lacks_url(tmp_path):
+    """Sidecar present but missing the ``url`` key — fall back to slug."""
+    import json
+    pages_dir = tmp_path / "pages"
+    pages_dir.mkdir()
+    (pages_dir / "no-url.md").write_text("## Title\n\nbody")
+    (pages_dir / "no-url.meta.json").write_text(json.dumps({"slug": "no-url"}))
+
+    config = make_config(chunk_min_tokens=1)
+    chunks = chunk_pages(pages_dir, tmp_path, config)
+
+    assert len(chunks) == 1
+    assert chunks[0].source_url == "no-url"

--- a/tests/test_scraper/test_cli.py
+++ b/tests/test_scraper/test_cli.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -107,6 +108,7 @@ def test_cli_parse_args_basic():
     assert args.no_llm_filter is False
     assert args.no_auto_seed is False
     assert args.include_maybe is False
+    assert args.no_fetch_cache is False
 
 
 def test_cli_parse_args_with_flags():
@@ -140,6 +142,100 @@ def test_cli_parse_args_invalid_step():
     parser = _build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["https://docs.example.com", "--step", "invalid"])
+
+
+def test_cli_no_fetch_cache_flag_sets_env(monkeypatch):
+    """`--no-fetch-cache` exports SCRAPE_CACHE_MODE=bypass for the run."""
+    import sys
+    from king_context.scraper.cli import main
+    from king_context.scraper.config import ScraperConfig
+
+    captured: dict = {}
+
+    async def fake_run_pipeline(args, config):
+        captured["env"] = os.environ.get("SCRAPE_CACHE_MODE")
+
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+    monkeypatch.setattr(
+        "king_context.scraper.cli.run_pipeline", fake_run_pipeline
+    )
+    monkeypatch.setattr(
+        "king_context.scraper.cli.load_config",
+        lambda **_: ScraperConfig(),
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["king-scrape", "https://docs.example.com", "--no-fetch-cache"],
+    )
+
+    main()
+
+    assert captured["env"] == "bypass"
+    # main() must restore env on exit so the flag does not leak into other
+    # tests or into an embedding application that calls main() repeatedly.
+    assert "SCRAPE_CACHE_MODE" not in os.environ
+
+
+def test_cli_no_fetch_cache_respects_pre_existing_env(monkeypatch):
+    """A user who explicitly set SCRAPE_CACHE_MODE keeps that value; the
+    flag does not silently downgrade it. Mirrors --provider's setdefault
+    behaviour."""
+    import sys
+    from king_context.scraper.cli import main
+    from king_context.scraper.config import ScraperConfig
+
+    captured: dict = {}
+
+    async def fake_run_pipeline(args, config):
+        captured["env"] = os.environ.get("SCRAPE_CACHE_MODE")
+
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "disabled")
+    monkeypatch.setattr(
+        "king_context.scraper.cli.run_pipeline", fake_run_pipeline
+    )
+    monkeypatch.setattr(
+        "king_context.scraper.cli.load_config",
+        lambda **_: ScraperConfig(),
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["king-scrape", "https://docs.example.com", "--no-fetch-cache"],
+    )
+
+    main()
+
+    assert captured["env"] == "disabled"
+    # Restored to the pre-existing value, not popped.
+    assert os.environ.get("SCRAPE_CACHE_MODE") == "disabled"
+
+
+def test_cli_without_no_fetch_cache_does_not_set_env(monkeypatch):
+    import sys
+    from king_context.scraper.cli import main
+    from king_context.scraper.config import ScraperConfig
+
+    captured: dict = {}
+
+    async def fake_run_pipeline(args, config):
+        captured["env"] = os.environ.get("SCRAPE_CACHE_MODE")
+
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+    monkeypatch.setattr(
+        "king_context.scraper.cli.run_pipeline", fake_run_pipeline
+    )
+    monkeypatch.setattr(
+        "king_context.scraper.cli.load_config",
+        lambda **_: ScraperConfig(),
+    )
+    monkeypatch.setattr(
+        sys, "argv",
+        ["king-scrape", "https://docs.example.com"],
+    )
+
+    main()
+
+    assert captured["env"] is None
+    assert "SCRAPE_CACHE_MODE" not in os.environ
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scraper/test_enrich.py
+++ b/tests/test_scraper/test_enrich.py
@@ -137,7 +137,13 @@ def test_enrich_retries_transient_provider_error():
     assert len(client.calls) == 2
 
 
-def test_enrich_raises_transient_provider_error_after_retries():
+def test_enrich_drops_chunk_after_transient_retries_exhausted():
+    """Per-chunk failure must not abort the batch (#47).
+
+    With no schema fallback configured, three transient errors leave the
+    chunk unrecovered. New contract: ``enrich_chunks`` returns a list with
+    that chunk omitted; no exception escapes.
+    """
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -158,9 +164,9 @@ def test_enrich_raises_transient_provider_error_after_retries():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(client),
     ):
-        with pytest.raises(ProviderError):
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
+    assert result == []
     assert len(client.calls) == 3
 
 
@@ -216,7 +222,8 @@ def test_enrich_respects_fallback_provider_concurrency():
     assert max_in_flight == 1
 
 
-def test_enrich_surfaces_provider_error_from_fallback_client():
+def test_enrich_drops_chunk_when_fallback_client_also_fails():
+    """A FallbackClient whose both legs throw must not abort the batch."""
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -250,14 +257,13 @@ def test_enrich_surfaces_provider_error_from_fallback_client():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(client),
     ):
-        with pytest.raises(ProviderError) as exc:
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.primary_error is primary_errors[-1]
-    assert exc.value.fallback_error is fallback_errors[-1]
+    assert result == []
 
 
-def test_enrich_does_not_retry_non_transient_fallback_error():
+def test_enrich_drops_chunk_on_non_transient_fallback_error():
+    """Non-transient fallback errors are absorbed; the batch keeps going."""
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -287,15 +293,20 @@ def test_enrich_does_not_retry_non_transient_fallback_error():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(client, fallback),
     ):
-        with pytest.raises(ProviderError) as exc:
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.transient is False
+    assert result == []
     assert len(primary.calls) == 1
+    # The schema_fallback is identity-equal to the FallbackClient's inner
+    # fallback leg (after _SemaphoredClient unwrapping), so enrich_chunks
+    # dedupes it: the fallback client is called exactly once, by
+    # FallbackClient's internal step. Without the dedupe, _enrich_one
+    # would call it again as a schema-fallback retry and waste a request.
     assert len(fallback.calls) == 1
 
 
-def test_enrich_raises_when_schema_fallback_returns_invalid_metadata():
+def test_enrich_drops_chunk_when_schema_fallback_returns_invalid_metadata():
+    """Schema fallback returning invalid metadata is absorbed; chunk dropped."""
     config = ScraperConfig(
         openrouter_api_key="test-key",
         enrichment_batch_size=5,
@@ -314,11 +325,9 @@ def test_enrich_raises_when_schema_fallback_returns_invalid_metadata():
         "king_context.scraper.enrich.get_stage_clients",
         return_value=fake_stage_clients(primary, fallback),
     ):
-        with pytest.raises(ProviderError) as exc:
-            asyncio.run(enrich_chunks([chunk], config))
+        result = asyncio.run(enrich_chunks([chunk], config))
 
-    assert exc.value.reason == "validation_failed_3x"
-    assert exc.value.provider == "openrouter"
+    assert result == []
     assert len(primary.calls) == 3
     assert len(fallback.calls) == 1
 
@@ -342,3 +351,221 @@ def test_estimate_cost():
     assert cost["estimated_cost"] >= 0
     # Output tokens: 10 chunks * 150 = 1500
     assert cost["estimated_output_tokens"] == 1500
+
+
+def test_enrich_schema_fallback_success_does_not_poison_primary_cache(tmp_path):
+    """Schema fallback's output must not be cached under the primary's key.
+
+    If it were, a subsequent run with the primary healthy would short-
+    circuit at the cache check and serve the previous fallback's output
+    as if it were primary content. The fix in #47 caches only successful
+    primary responses.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section", content="this content needs enrichment")
+
+    async def primary_fails(prompt, *, system=None, json_mode=True):
+        raise ProviderError(
+            "invalid_response",
+            transient=False,
+            message="LLM response was not parseable JSON",
+            provider="openrouter",
+        )
+
+    primary = FakeLLMClient(side_effect=primary_fails, name="openrouter")
+    fallback = FakeLLMClient(
+        responses=[make_valid_enrichment()], name="openrouter-fallback"
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(primary, fallback),
+    ):
+        first = asyncio.run(enrich_chunks([chunk], config))
+
+    assert len(first) == 1  # fallback succeeded
+
+    # Now check the cache: the primary's cache key MUST NOT carry the
+    # fallback's enrichment, otherwise the contract is broken.
+    from king_context.scraper import enrich_cache as cache
+    from king_context.scraper.enrich import PROMPT_VERSION
+    primary_cache_key = cache.make_key(chunk.content, "test-model", PROMPT_VERSION)
+    cached = cache.get(primary_cache_key)
+    assert cached is None, (
+        "schema fallback's enrichment leaked into the primary's cache key; "
+        "next run with the primary healthy would serve fallback content."
+    )
+
+
+def test_enrich_one_bad_chunk_does_not_abort_batch(capsys):
+    """The #47 repro: one chunk with non-transient ProviderError, others succeed.
+
+    Pre-fix, a single non-transient ProviderError raised by ``_enrich_one``
+    would propagate through ``asyncio.gather`` and cancel every other chunk
+    in flight. After the fix, the failing chunk is dropped and the batch
+    completes with the surviving chunks.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunks = [
+        make_chunk("Good 1", content="good content one"),
+        make_chunk("Bad", content="bad content"),
+        make_chunk("Good 2", content="good content two"),
+    ]
+    valid = make_valid_enrichment()
+    bad_error = ProviderError(
+        "invalid_response",
+        transient=False,
+        message="LLM response was not parseable JSON",
+        provider="openrouter",
+    )
+
+    async def mock_complete(prompt, *, system=None, json_mode=True):
+        if "bad content" in prompt:
+            raise bad_error
+        return valid
+
+    client = FakeLLMClient(side_effect=mock_complete)
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    # Two surviving chunks; the bad one is dropped, no exception raised.
+    assert len(result) == 2
+    titles = {e.title for e in result}
+    assert titles == {"Good 1", "Good 2"}
+
+
+def test_enrich_non_transient_primary_error_falls_through_to_schema_fallback():
+    """Non-transient primary errors must reach the schema fallback (#47).
+
+    The schema fallback exists precisely to absorb malformed JSON from the
+    primary. Pre-fix, a non-transient ``ProviderError`` from the primary
+    raised on the first attempt and never reached the fallback path.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunk = make_chunk("Auth Section")
+
+    async def primary_fails(prompt, *, system=None, json_mode=True):
+        raise ProviderError(
+            "invalid_response",
+            transient=False,
+            message="LLM response was not parseable JSON",
+            provider="openrouter",
+        )
+
+    primary = FakeLLMClient(side_effect=primary_fails, name="openrouter")
+    fallback = FakeLLMClient(
+        responses=[make_valid_enrichment()], name="openrouter-fallback"
+    )
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(primary, fallback),
+    ):
+        result = asyncio.run(enrich_chunks([chunk], config))
+
+    assert len(result) == 1
+    # Primary should have been tried only once (non-transient breaks the
+    # retry loop early). Fallback runs once and succeeds.
+    assert len(primary.calls) == 1
+    assert len(fallback.calls) == 1
+
+
+def test_enrich_gather_return_exceptions_keeps_other_chunks_alive(capsys):
+    """Defensive guard: even if ``_enrich_one`` ever raises, gather absorbs it.
+
+    ``_enrich_one`` is contract-bound to never raise, but ``return_exceptions``
+    on the gather call protects against future regressions and against
+    asyncio cancellation surfacing through unrelated code paths.
+    """
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunks = [
+        make_chunk("a", content="alpha"),
+        make_chunk("b", content="bravo"),
+    ]
+
+    async def mock_complete(prompt, *, system=None, json_mode=True):
+        return make_valid_enrichment()
+
+    client = FakeLLMClient(side_effect=mock_complete)
+
+    # Patch _enrich_one itself so the first call raises a synthetic
+    # exception. Without return_exceptions=True the second chunk's task
+    # would be cancelled when gather propagates the exception.
+    from king_context.scraper.enrich import _enrich_one as real_enrich_one
+
+    call_count = {"n": 0}
+
+    async def flaky_enrich_one(chunk, primary_client, schema_fallback=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("synthetic explosion")
+        return await real_enrich_one(chunk, primary_client, schema_fallback)
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ), patch(
+        "king_context.scraper.enrich._enrich_one",
+        side_effect=flaky_enrich_one,
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    # Only the second chunk should make it through; the first is logged
+    # as a warning and skipped.
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "synthetic explosion" in err
+    assert "RuntimeError" in err
+    # Per-batch summary line lands on stderr too.
+    assert "1 enriched, 1 dropped" in err
+
+
+def test_enrich_per_chunk_cancellation_does_not_abort_batch(capsys):
+    """A child task's CancelledError returned by gather is treated as a drop."""
+    config = ScraperConfig(
+        openrouter_api_key="test-key",
+        enrichment_batch_size=5,
+    )
+    chunks = [
+        make_chunk("a", content="alpha"),
+        make_chunk("b", content="bravo"),
+    ]
+
+    async def mock_complete(prompt, *, system=None, json_mode=True):
+        return make_valid_enrichment()
+
+    client = FakeLLMClient(side_effect=mock_complete)
+    from king_context.scraper.enrich import _enrich_one as real_enrich_one
+
+    async def cancelling_enrich_one(chunk, primary_client, schema_fallback=None):
+        if chunk.title == "a":
+            raise asyncio.CancelledError("simulated per-task cancel")
+        return await real_enrich_one(chunk, primary_client, schema_fallback)
+
+    with patch(
+        "king_context.scraper.enrich.get_stage_clients",
+        return_value=fake_stage_clients(client),
+    ), patch(
+        "king_context.scraper.enrich._enrich_one",
+        side_effect=cancelling_enrich_one,
+    ):
+        result = asyncio.run(enrich_chunks(chunks, config))
+
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "cancelled" in err.lower()

--- a/tests/test_scraper/test_update.py
+++ b/tests/test_scraper/test_update.py
@@ -75,6 +75,13 @@ def test_section_hash_falls_back_to_content_when_meta_missing():
     assert update._section_hash(legacy) == _hash("legacy")
 
 
+def test_resolve_source_url_handles_explicit_null_meta():
+    """Hand-written JSON can serialise `"_meta": null` (not missing); the
+    helper must not raise AttributeError on the chained .get."""
+    corpus = {"_meta": None, "base_url": "https://docs.example.com"}
+    assert update._resolve_source_url(corpus) == "https://docs.example.com"
+
+
 def test_resolve_source_url_prefers_meta():
     corpus = {
         "base_url": "https://docs.example.com",

--- a/tests/test_scraper/test_update.py
+++ b/tests/test_scraper/test_update.py
@@ -1,0 +1,886 @@
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from king_context.scraper import update
+from king_context.scraper.chunk import Chunk
+from king_context.scraper.config import ScraperConfig
+from king_context.scraper.enrich import EnrichedChunk
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _section(content: str, **overrides) -> dict:
+    base = {
+        "title": "T",
+        "path": "/p",
+        "url": "https://docs.example.com/page",
+        "keywords": ["k1", "k2", "k3", "k4", "k5"],
+        "use_cases": ["Use when X", "Configure when Y"],
+        "tags": ["api"],
+        "priority": 8,
+        "content": content,
+        "_meta": {"content_hash": _hash(content)},
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_corpus(tmp_path: Path, sections=None, source_url=None) -> Path:
+    corpus = {
+        "name": "demo",
+        "display_name": "Demo",
+        "version": "v1",
+        "base_url": "https://docs.example.com",
+        "sections": sections if sections is not None else [
+            _section("aaa", title="A"),
+            _section("bbb", title="B"),
+        ],
+        "_meta": {"source_url": source_url or "https://docs.example.com"},
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(corpus))
+    return path
+
+
+def _chunk(content: str, **overrides) -> Chunk:
+    base = dict(
+        title="T",
+        breadcrumb="T",
+        content=content,
+        source_url="https://docs.example.com/page",
+        path="/page/t",
+        token_count=10,
+    )
+    base.update(overrides)
+    return Chunk(**base)
+
+
+# --- pure unit logic ------------------------------------------------------
+
+
+def test_section_hash_uses_meta_when_present():
+    assert update._section_hash(_section("foo")) == _hash("foo")
+
+
+def test_section_hash_falls_back_to_content_when_meta_missing():
+    legacy = {"content": "legacy", "keywords": [], "use_cases": [], "tags": [], "priority": 1}
+    assert update._section_hash(legacy) == _hash("legacy")
+
+
+def test_resolve_source_url_prefers_meta():
+    corpus = {
+        "base_url": "https://docs.example.com",
+        "_meta": {"source_url": "https://docs.example.com/v2"},
+    }
+    assert update._resolve_source_url(corpus) == "https://docs.example.com/v2"
+
+
+def test_resolve_source_url_falls_back_to_base_url():
+    corpus = {"base_url": "https://docs.example.com"}
+    assert update._resolve_source_url(corpus) == "https://docs.example.com"
+
+
+def test_build_reuse_index():
+    corpus = {"sections": [_section("aaa"), _section("bbb")]}
+    index = update._build_reuse_index(corpus)
+    assert _hash("aaa") in index
+    assert _hash("bbb") in index
+    assert index[_hash("aaa")]["keywords"] == ["k1", "k2", "k3", "k4", "k5"]
+
+
+def test_plan_update_classifies_chunks():
+    corpus = {"sections": [_section("aaa"), _section("bbb")]}
+    reuse = update._build_reuse_index(corpus)
+    fresh = [_chunk("aaa"), _chunk("ccc")]  # one reused, one new
+    plan = update._plan_update(
+        fresh,
+        ["https://docs.example.com/page"],
+        reuse,
+        corpus,
+    )
+    assert [c.content for c in plan.reused_chunks] == ["aaa"]
+    assert [c.content for c in plan.new_chunks] == ["ccc"]
+
+
+def test_plan_added_and_removed_urls():
+    corpus = {
+        "sections": [
+            _section("a", url="https://x/old"),
+            _section("b", url="https://x/keep"),
+        ],
+    }
+    fresh_urls = ["https://x/keep", "https://x/new"]
+    plan = update._plan_update([], fresh_urls, {}, corpus)
+    assert plan.added_urls == ["https://x/new"]
+    assert plan.removed_urls == ["https://x/old"]
+
+
+def test_materialise_reused_carries_enrichment_but_takes_fresh_identity():
+    """Reused chunks adopt fresh title/path/url, keep enrichment values."""
+    corpus = {"sections": [_section("aaa", title="OLD", path="/old/path")]}
+    reuse = update._build_reuse_index(corpus)
+    fresh = [_chunk("aaa", title="NEW", path="/new/path",
+                    source_url="https://docs.example.com/new")]
+    materialised = update._materialise_reused(fresh, reuse)
+    assert len(materialised) == 1
+    e = materialised[0]
+    assert e.title == "NEW"  # fresh identity
+    assert e.path == "/new/path"
+    assert e.url == "https://docs.example.com/new"
+    assert e.keywords == ["k1", "k2", "k3", "k4", "k5"]  # carried forward
+    assert e.priority == 8
+
+
+def test_interleave_in_chunk_order_preserves_fresh_order():
+    fresh = [_chunk("aaa"), _chunk("bbb"), _chunk("ccc")]
+    reused = [
+        EnrichedChunk(
+            title="A", path="/a", url="u", content="aaa",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("aaa"),
+        ),
+        EnrichedChunk(
+            title="C", path="/c", url="u", content="ccc",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("ccc"),
+        ),
+    ]
+    enriched = [
+        EnrichedChunk(
+            title="B", path="/b", url="u", content="bbb",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("bbb"),
+        ),
+    ]
+    final = update._interleave_in_chunk_order(fresh, reused, enriched)
+    assert [e.content for e in final] == ["aaa", "bbb", "ccc"]
+
+
+def test_interleave_dedupes_repeated_content_hash():
+    """Boilerplate sections that repeat across pages produce duplicate
+    chunks. Interleave must emit each content_hash at most once."""
+    fresh = [_chunk("aaa"), _chunk("aaa"), _chunk("bbb")]
+    reused = [
+        EnrichedChunk(
+            title="A", path="/a", url="u", content="aaa",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("aaa"),
+        ),
+    ]
+    enriched = [
+        EnrichedChunk(
+            title="B", path="/b", url="u", content="bbb",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("bbb"),
+        ),
+    ]
+    final = update._interleave_in_chunk_order(fresh, reused, enriched)
+    assert [e.content for e in final] == ["aaa", "bbb"]
+
+
+# --- find_corpus + load_corpus -------------------------------------------
+
+
+def test_find_corpus_raises_when_missing():
+    with pytest.raises(FileNotFoundError):
+        update.find_corpus("does-not-exist-anywhere")
+
+
+def test_load_corpus_raises_on_bad_json(tmp_path: Path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        update._load_corpus(bad)
+
+
+# --- update_corpus end to end (with mocked pipeline) ---------------------
+
+
+def _patch_pipeline(monkeypatch, *, fresh_chunks, fresh_urls, enriched_new):
+    """Replace every network or LLM call in update_corpus with stubs."""
+
+    async def fake_discover(base_url, config, provider):
+        from king_context.scraper.discover import DiscoveryResult
+        return DiscoveryResult(
+            base_url=base_url,
+            discovered_at="2026-05-08T00:00:00+00:00",
+            total_urls=len(fresh_urls),
+            urls=list(fresh_urls),
+        )
+
+    def fake_filter(urls, base_url, config):
+        from king_context.scraper.filter import FilterResult
+        return FilterResult(
+            accepted=list(urls),
+            rejected=[],
+            maybe=[],
+            filter_method="heuristic",
+            llm_fallback_used=False,
+        )
+
+    async def fake_fetch(urls, work_dir, config, provider, *, force_refresh=False):
+        from king_context.scraper.fetch import FetchResult
+        return FetchResult(total=len(urls), completed=len(urls), failed=0, results=[])
+
+    def fake_chunk(pages_dir, work_dir, config):
+        return list(fresh_chunks)
+
+    async def fake_enrich(chunks, config, work_dir):
+        return list(enriched_new)
+
+    monkeypatch.setattr(update, "discover_urls", fake_discover)
+    monkeypatch.setattr(update, "filter_urls", fake_filter)
+    monkeypatch.setattr(update, "fetch_pages", fake_fetch)
+    monkeypatch.setattr(update, "chunk_pages", fake_chunk)
+    monkeypatch.setattr(update, "enrich_chunks", fake_enrich)
+    # Skip provider resolution entirely.
+    monkeypatch.setattr(update, "get_discovery_provider", lambda *a, **k: object())
+    monkeypatch.setattr(update, "get_fetch_provider", lambda *a, **k: object())
+    monkeypatch.setattr(update, "resolve_provider_name", lambda *a, **k: "firecrawl")
+
+
+def test_update_corpus_reuses_unchanged_and_enriches_new(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[
+            _section("aaa", title="A"),
+            _section("bbb", title="B"),
+        ],
+    )
+    fresh_chunks = [_chunk("aaa"), _chunk("ccc")]  # bbb removed, ccc new
+    enriched_new = [
+        EnrichedChunk(
+            title="C", path="/c", url="u", content="ccc",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("ccc"),
+        ),
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=enriched_new,
+    )
+
+    config = ScraperConfig(openrouter_api_key="test")
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=config,
+        yes=True,
+    ))
+
+    assert report.reused == 1
+    assert report.enriched == 1
+    assert report.lost == 0
+    assert report.total_sections == 2
+
+    rewritten = json.loads(corpus_path.read_text())
+    contents = [s["content"] for s in rewritten["sections"]]
+    assert contents == ["aaa", "ccc"]
+
+
+def test_update_corpus_errors_when_no_source_url(tmp_path: Path):
+    # _meta present (passes legacy guard) but neither source_url nor base_url.
+    corpus = {
+        "name": "demo",
+        "version": "v1",
+        "base_url": "",
+        "sections": [],
+        "_meta": {},
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(corpus))
+
+    with pytest.raises(ValueError, match="source_url"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+
+
+def test_update_main_returns_1_when_corpus_missing(capsys):
+    rc = update.update_main(["does-not-exist", "--yes"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err.lower()
+
+
+def test_update_corpus_refuses_to_wipe_to_empty(tmp_path: Path, monkeypatch):
+    """A discover/filter blip producing 0 URLs must not overwrite the corpus."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A"), _section("bbb", title="B")],
+    )
+    original = corpus_path.read_text()
+
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[],  # discover/filter produced nothing
+        fresh_urls=[],
+        enriched_new=[],
+    )
+
+    with pytest.raises(ValueError, match="empty corpus"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=corpus_path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+
+    # Corpus on disk untouched.
+    assert corpus_path.read_text() == original
+
+
+def test_update_corpus_short_circuits_when_all_chunks_reused(tmp_path: Path, monkeypatch):
+    """If every fresh chunk hashes to an existing section, skip enrich entirely."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A"), _section("bbb", title="B")],
+    )
+    fresh_chunks = [_chunk("aaa"), _chunk("bbb")]
+
+    enrich_calls = {"count": 0}
+
+    async def fake_enrich(chunks, config, work_dir):
+        enrich_calls["count"] += 1
+        return []
+
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+    monkeypatch.setattr(update, "enrich_chunks", fake_enrich)
+
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+
+    assert enrich_calls["count"] == 0
+    assert report.reused == 2
+    assert report.enriched == 0
+
+
+def test_update_corpus_reports_lost_chunks(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(
+        tmp_path, sections=[_section("aaa", title="A")]
+    )
+    fresh_chunks = [_chunk("aaa"), _chunk("xxx"), _chunk("yyy")]
+    # enrich returns only one of two new chunks: simulates a validation failure.
+    enriched_new = [
+        EnrichedChunk(
+            title="X", path="/x", url="u", content="xxx",
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash("xxx"),
+        ),
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=enriched_new,
+    )
+
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+
+    assert report.reused == 1
+    assert report.enriched == 1
+    assert report.lost == 1
+    assert report.total_sections == 2  # aaa + xxx; yyy lost
+
+
+def test_reset_work_dir_removes_stale_state(tmp_path: Path):
+    work = tmp_path / "work"
+    (work / "pages").mkdir(parents=True)
+    (work / "pages" / "old.md").write_text("stale")
+    (work / "chunks").mkdir(parents=True)
+    (work / "chunks" / "old.json").write_text("[]")
+    (work / "enriched").mkdir(parents=True)
+    (work / "enriched" / "batch_0001.json").write_text("[]")
+    (work / "manifest.json").write_text("{}")
+
+    update._reset_work_dir(work)
+
+    assert not (work / "pages").exists()
+    assert not (work / "chunks").exists()
+    assert not (work / "enriched").exists()
+    assert not (work / "manifest.json").exists()
+
+
+def test_reset_work_dir_is_safe_on_clean_dir(tmp_path: Path):
+    work = tmp_path / "work"
+    work.mkdir()
+    update._reset_work_dir(work)  # must not raise
+
+
+def test_atomic_write_json_writes_complete_file(tmp_path: Path):
+    target = tmp_path / "corpus.json"
+    update._atomic_write_json(target, {"hello": "world"})
+    assert json.loads(target.read_text()) == {"hello": "world"}
+    # No leftover tempfile.
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_update_main_corpus_path_flag_bypasses_lookup(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(tmp_path)
+    fresh_chunks = [_chunk(s["content"]) for s in [_section("aaa"), _section("bbb")]]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+    # find_corpus must NOT be called when --corpus-path is provided.
+    monkeypatch.setattr(update, "find_corpus", lambda name: (_ for _ in ()).throw(
+        AssertionError("find_corpus should not be called when --corpus-path is set")
+    ))
+
+    rc = update.update_main([
+        "demo", "--yes",
+        "--corpus-path", str(corpus_path),
+    ])
+    assert rc == 0
+
+
+def test_update_main_corpus_path_flag_errors_when_missing(tmp_path: Path, capsys):
+    rc = update.update_main([
+        "demo", "--yes",
+        "--corpus-path", str(tmp_path / "nope.json"),
+    ])
+    assert rc == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_update_main_provider_flag_overrides_env_and_restores(tmp_path: Path, monkeypatch):
+    """Unlike cli.main's `setdefault`, --provider on `update` should WIN over
+    a pre-set env DURING the run, but the prior env is restored on exit so
+    a test or embedding host doesn't see the override leak across calls."""
+    monkeypatch.setenv("SCRAPE_PROVIDER", "firecrawl")
+    corpus_path = _make_corpus(tmp_path)
+
+    seen = {"during": None}
+
+    async def fake_run(*a, **k):
+        seen["during"] = os.environ.get("SCRAPE_PROVIDER")
+        return update.UpdateReport(
+            name="demo", reused=0, enriched=0, lost=0,
+            fetch_failed=0, removed_urls=[], added_urls=[],
+            total_sections=0,
+        )
+
+    monkeypatch.setattr(update, "update_corpus", fake_run)
+    monkeypatch.setattr(update, "find_corpus", lambda name: corpus_path)
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+
+    rc = update.update_main([
+        "demo", "--yes",
+        "--provider", "crawl4ai",
+    ])
+    assert rc == 0
+    # During the run the flag wins over the pre-set env.
+    assert seen["during"] == "crawl4ai"
+    # After the run the env is restored to the pre-call value.
+    assert os.environ["SCRAPE_PROVIDER"] == "firecrawl"
+
+
+def test_update_main_exit_code_on_user_abort(tmp_path: Path, monkeypatch):
+    corpus_path = _make_corpus(tmp_path)
+    monkeypatch.setattr("builtins.input", lambda *_: "n")
+
+    fresh_chunks = [_chunk("zzz")]  # forces an enrichment prompt
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+    monkeypatch.setattr(update, "find_corpus", lambda name: corpus_path)
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+
+    rc = update.update_main(["demo"])
+    assert rc == 1
+
+
+# --- safety guards introduced via #55 review ----------------------------
+
+
+def test_update_corpus_refuses_legacy_corpus_without_meta(tmp_path: Path):
+    """A pre-ADR-0012 corpus (no _meta block) must hard refuse instead of
+    falling back to base_url and silently wiping the curated section set."""
+    legacy_corpus = {
+        "name": "demo",
+        "version": "v1",
+        "base_url": "https://docs.example.com",
+        "sections": [_section("aaa", title="A")],
+        # NB: no `_meta` key at all (legacy shape)
+    }
+    path = tmp_path / "demo.json"
+    path.write_text(json.dumps(legacy_corpus))
+
+    original = path.read_text()
+    with pytest.raises(ValueError, match="legacy pre-ADR-0012"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+    # Corpus on disk untouched.
+    assert path.read_text() == original
+
+
+def test_update_corpus_aborts_when_fetch_failure_ratio_exceeds_threshold(
+    tmp_path: Path, monkeypatch
+):
+    """If more than 10% of accepted URLs fail to fetch, refuse the writeback
+    so a partial pipeline run never overwrites a healthy corpus."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A"), _section("bbb", title="B")],
+    )
+    original = corpus_path.read_text()
+
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[_chunk("aaa")],
+        fresh_urls=[
+            "https://docs.example.com/page",
+            "https://docs.example.com/p2",
+            "https://docs.example.com/p3",
+        ],
+        enriched_new=[],
+    )
+
+    async def failing_fetch(urls, work_dir, config, provider, *, force_refresh=False):
+        from king_context.scraper.fetch import FetchResult
+        # 3 accepted, 2 failed -> 66% > 10% threshold.
+        return FetchResult(total=len(urls), completed=1, failed=2, results=[])
+
+    monkeypatch.setattr(update, "fetch_pages", failing_fetch)
+
+    with pytest.raises(ValueError, match="fetches failed"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=corpus_path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+    assert corpus_path.read_text() == original
+
+
+def test_update_corpus_aborts_when_discover_loses_more_than_half(
+    tmp_path: Path, monkeypatch
+):
+    """If more than 50% of corpus URLs disappear from fresh discovery, abort
+    before fetch. Growth is allowed; only loss is dangerous."""
+    sections = [
+        _section("a", title="A", url="https://docs.example.com/a"),
+        _section("b", title="B", url="https://docs.example.com/b"),
+        _section("c", title="C", url="https://docs.example.com/c"),
+        _section("d", title="D", url="https://docs.example.com/d"),
+    ]
+    corpus_path = _make_corpus(tmp_path, sections=sections)
+    original = corpus_path.read_text()
+
+    # Only 1 of 4 corpus URLs survives -> 75% loss > 50% threshold.
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[_chunk("a")],
+        fresh_urls=["https://docs.example.com/a"],
+        enriched_new=[],
+    )
+
+    with pytest.raises(ValueError, match="missing from the fresh discovery"):
+        asyncio.run(update.update_corpus(
+            name="demo",
+            corpus_path=corpus_path,
+            config=ScraperConfig(openrouter_api_key="x"),
+            yes=True,
+        ))
+    assert corpus_path.read_text() == original
+
+
+def test_update_corpus_allows_discover_growth(tmp_path: Path, monkeypatch):
+    """Fresh discover returning MORE URLs than the corpus is allowed."""
+    sections = [_section("a", title="A", url="https://docs.example.com/a")]
+    corpus_path = _make_corpus(tmp_path, sections=sections)
+
+    fresh_urls = [
+        "https://docs.example.com/a",
+        "https://docs.example.com/b",
+        "https://docs.example.com/c",
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[_chunk("a")],
+        fresh_urls=fresh_urls,
+        enriched_new=[],
+    )
+
+    # Must not raise.
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+    assert report.reused == 1
+
+
+def test_update_corpus_skips_cost_prompt_when_no_new_chunks(
+    tmp_path: Path, monkeypatch
+):
+    """Every fresh chunk reused -> _confirm_cost must not call input() and the
+    plan proceeds without a confusing '$0.0000' prompt."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A"), _section("bbb", title="B")],
+    )
+
+    def boom(*_a, **_k):
+        raise AssertionError("input() must not be called when no new chunks")
+
+    monkeypatch.setattr("builtins.input", boom)
+
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[_chunk("aaa"), _chunk("bbb")],
+        fresh_urls=["https://docs.example.com/page"],
+        enriched_new=[],
+    )
+
+    # yes=False would normally prompt; here it must be skipped.
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=False,
+    ))
+    assert report.reused == 2
+    assert report.enriched == 0
+
+
+def test_update_corpus_surfaces_fetch_failed_in_report(
+    tmp_path: Path, monkeypatch
+):
+    """fetch_failed below threshold is recorded on the report (and the CLI
+    summary prints it). 1/10 = 10% which is NOT > 10%, so it must NOT abort."""
+    corpus_path = _make_corpus(
+        tmp_path,
+        sections=[_section("aaa", title="A")],
+    )
+    # Include the corpus section URL so the divergence guard does not fire.
+    fresh_urls = ["https://docs.example.com/page"] + [
+        f"https://docs.example.com/p{i}" for i in range(9)
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=[_chunk("aaa")],
+        fresh_urls=fresh_urls,
+        enriched_new=[],
+    )
+
+    async def partial_fetch(urls, work_dir, config, provider, *, force_refresh=False):
+        from king_context.scraper.fetch import FetchResult
+        return FetchResult(total=len(urls), completed=9, failed=1, results=[])
+
+    monkeypatch.setattr(update, "fetch_pages", partial_fetch)
+
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+    assert report.fetch_failed == 1
+
+
+# --- subcommand --no-fetch-cache plumb ----------------------------------
+
+
+def test_update_main_no_fetch_cache_sets_env(tmp_path: Path, monkeypatch):
+    """--no-fetch-cache on `king-scrape update` must set SCRAPE_CACHE_MODE
+    for the duration of the run and restore the prior state on exit."""
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+    corpus_path = _make_corpus(tmp_path)
+
+    seen = {"during": None}
+
+    async def fake_run(*a, **k):
+        seen["during"] = os.environ.get("SCRAPE_CACHE_MODE")
+        return update.UpdateReport(
+            name="demo", reused=0, enriched=0, lost=0,
+            fetch_failed=0, removed_urls=[], added_urls=[],
+            total_sections=0,
+        )
+
+    monkeypatch.setattr(update, "update_corpus", fake_run)
+    monkeypatch.setattr(update, "find_corpus", lambda name: corpus_path)
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+
+    rc = update.update_main(["demo", "--yes", "--no-fetch-cache"])
+    assert rc == 0
+    assert seen["during"] == "bypass"
+    # Restored after the run.
+    assert "SCRAPE_CACHE_MODE" not in os.environ
+
+
+def test_update_main_no_fetch_cache_respects_prior_env(tmp_path: Path, monkeypatch):
+    """An explicit pre-existing env value wins via setdefault semantics, and is
+    restored verbatim on exit."""
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "read_only")
+    corpus_path = _make_corpus(tmp_path)
+
+    seen = {"during": None}
+
+    async def fake_run(*a, **k):
+        seen["during"] = os.environ.get("SCRAPE_CACHE_MODE")
+        return update.UpdateReport(
+            name="demo", reused=0, enriched=0, lost=0,
+            fetch_failed=0, removed_urls=[], added_urls=[],
+            total_sections=0,
+        )
+
+    monkeypatch.setattr(update, "update_corpus", fake_run)
+    monkeypatch.setattr(update, "find_corpus", lambda name: corpus_path)
+    monkeypatch.setattr(update, "load_config", lambda **_: ScraperConfig(openrouter_api_key="x"))
+
+    rc = update.update_main(["demo", "--yes", "--no-fetch-cache"])
+    assert rc == 0
+    # setdefault means the explicit prior wins.
+    assert seen["during"] == "read_only"
+    assert os.environ["SCRAPE_CACHE_MODE"] == "read_only"
+
+
+# --- anchored-empty-corpus coverage ------------------------------------
+
+
+def test_update_corpus_handles_anchored_empty_corpus(tmp_path: Path, monkeypatch):
+    """A corpus with _meta (anchored, not legacy) but zero sections must
+    refresh against fresh discovery without raising. Every fresh chunk is
+    treated as new; corpus_canon_urls is empty so the divergence guard
+    skips; the empty-corpus refusal also skips because fresh_chunks > 0."""
+    corpus = {
+        "name": "demo",
+        "display_name": "Demo",
+        "version": "v1",
+        "base_url": "https://docs.example.com",
+        "sections": [],
+        "_meta": {"source_url": "https://docs.example.com"},
+    }
+    corpus_path = tmp_path / "demo.json"
+    corpus_path.write_text(json.dumps(corpus))
+
+    fresh_chunks = [_chunk("aaa"), _chunk("bbb")]
+    enriched_new = [
+        EnrichedChunk(
+            title=c, path=f"/{c}", url="u", content=c,
+            keywords=["k"] * 5, use_cases=["uc1", "uc2"],
+            tags=["t"], priority=5, content_hash=_hash(c),
+        )
+        for c in ("aaa", "bbb")
+    ]
+    _patch_pipeline(
+        monkeypatch,
+        fresh_chunks=fresh_chunks,
+        fresh_urls=["https://docs.example.com/a", "https://docs.example.com/b"],
+        enriched_new=enriched_new,
+    )
+
+    report = asyncio.run(update.update_corpus(
+        name="demo",
+        corpus_path=corpus_path,
+        config=ScraperConfig(openrouter_api_key="x"),
+        yes=True,
+    ))
+    assert report.reused == 0
+    assert report.enriched == 2
+    assert report.total_sections == 2
+
+
+# --- _cache_mode helper direct tests -----------------------------------
+
+
+def test_cache_mode_helpers_set_and_restore_when_env_was_unset(monkeypatch):
+    from king_context.scraper import _cache_mode
+
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+
+    class _Args:
+        no_fetch_cache = True
+
+    was_set, prior = _cache_mode.apply_cache_mode_flag(_Args())
+    assert was_set is False
+    assert prior is None
+    assert os.environ["SCRAPE_CACHE_MODE"] == "bypass"
+
+    _cache_mode.restore_cache_mode(was_set, prior)
+    assert "SCRAPE_CACHE_MODE" not in os.environ
+
+
+def test_cache_mode_helpers_preserve_pre_existing_value(monkeypatch):
+    from king_context.scraper import _cache_mode
+
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "read_only")
+
+    class _Args:
+        no_fetch_cache = True
+
+    was_set, prior = _cache_mode.apply_cache_mode_flag(_Args())
+    assert was_set is True
+    assert prior == "read_only"
+    # setdefault: explicit prior wins.
+    assert os.environ["SCRAPE_CACHE_MODE"] == "read_only"
+
+    _cache_mode.restore_cache_mode(was_set, prior)
+    assert os.environ["SCRAPE_CACHE_MODE"] == "read_only"
+
+
+def test_cache_mode_helpers_no_op_when_flag_not_passed(monkeypatch):
+    from king_context.scraper import _cache_mode
+
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+
+    class _Args:
+        no_fetch_cache = False
+
+    was_set, prior = _cache_mode.apply_cache_mode_flag(_Args())
+    assert was_set is False
+    assert prior is None
+    assert "SCRAPE_CACHE_MODE" not in os.environ
+
+    _cache_mode.restore_cache_mode(was_set, prior)
+    assert "SCRAPE_CACHE_MODE" not in os.environ
+
+
+def test_cache_mode_restore_raises_when_invariant_violated():
+    """Defensive: prior=None with was_set=True is impossible from
+    apply_cache_mode_flag's contract; raise rather than write `None` into
+    os.environ (which would TypeError downstream)."""
+    from king_context.scraper import _cache_mode
+
+    with pytest.raises(RuntimeError, match="apply_cache_mode_flag"):
+        _cache_mode.restore_cache_mode(was_set=True, prior=None)

--- a/tests/test_scraper/test_url_utils.py
+++ b/tests/test_scraper/test_url_utils.py
@@ -1,0 +1,33 @@
+"""Tests for the shared URL canonicalisation helper."""
+from king_context.scraper.url_utils import canonicalize_url
+
+
+def test_canonicalize_strips_fragment():
+    assert canonicalize_url("https://x/A?q=1#frag") == "https://x/A?q=1"
+
+
+def test_canonicalize_strips_trailing_slash():
+    assert canonicalize_url("https://x/a/") == "https://x/a"
+
+
+def test_canonicalize_keeps_root_slash():
+    assert canonicalize_url("https://x.com/") == "https://x.com/"
+
+
+def test_canonicalize_lowercases_scheme_and_host():
+    assert canonicalize_url("HTTPS://X.COM/A") == "https://x.com/A"
+
+
+def test_canonicalize_keeps_path_case():
+    """Path case is preserved — only scheme/host are normalised."""
+    assert canonicalize_url("https://x.com/CaseSensitive") == "https://x.com/CaseSensitive"
+
+
+def test_canonicalize_preserves_query_string():
+    assert canonicalize_url("https://x/a?b=1&c=2") == "https://x/a?b=1&c=2"
+
+
+def test_canonicalize_idempotent():
+    once = canonicalize_url("HTTPS://X.com/a/?q=1#frag")
+    twice = canonicalize_url(once)
+    assert once == twice

--- a/tests/test_scraper_providers/test_crawl4ai_provider.py
+++ b/tests/test_scraper_providers/test_crawl4ai_provider.py
@@ -279,3 +279,209 @@ def test_browser_missing_when_playwright_absent(monkeypatch):
 
     assert excinfo.value.provider == "crawl4ai"
     assert "crawl4ai-setup" in excinfo.value.hint
+
+
+# --- SCRAPE_CACHE_MODE handling (#50) ---------------------------------------
+
+
+class _StubCacheMode:
+    """Stand-in for crawl4ai.CacheMode so tests don't depend on the lib."""
+    ENABLED = "enabled-sentinel"
+    BYPASS = "bypass-sentinel"
+    DISABLED = "disabled-sentinel"
+    READ_ONLY = "read-only-sentinel"
+    WRITE_ONLY = "write-only-sentinel"
+
+
+@pytest.fixture
+def cache_mode(monkeypatch):
+    """Make ``CacheMode`` available to ``_resolve_cache_mode`` even when
+    ``crawl4ai`` is not actually installed in the test environment."""
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CacheMode", _StubCacheMode
+    )
+    return _StubCacheMode
+
+
+def test_resolve_cache_mode_unset_returns_none(monkeypatch, cache_mode):
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+    assert crawl4ai_provider._resolve_cache_mode() is None
+
+
+def test_resolve_cache_mode_default_returns_none(monkeypatch, cache_mode):
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "default")
+    assert crawl4ai_provider._resolve_cache_mode() is None
+
+
+def test_resolve_cache_mode_bypass(monkeypatch, cache_mode):
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "bypass")
+    assert crawl4ai_provider._resolve_cache_mode() == cache_mode.BYPASS
+
+
+def test_resolve_cache_mode_bypass_case_insensitive(monkeypatch, cache_mode):
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "BYPASS  ")
+    assert crawl4ai_provider._resolve_cache_mode() == cache_mode.BYPASS
+
+
+def test_resolve_cache_mode_disabled(monkeypatch, cache_mode):
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "disabled")
+    assert crawl4ai_provider._resolve_cache_mode() == cache_mode.DISABLED
+
+
+def test_resolve_cache_mode_read_only(monkeypatch, cache_mode):
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "read_only")
+    assert crawl4ai_provider._resolve_cache_mode() == cache_mode.READ_ONLY
+
+
+def test_resolve_cache_mode_write_only(monkeypatch, cache_mode):
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "write_only")
+    assert crawl4ai_provider._resolve_cache_mode() == cache_mode.WRITE_ONLY
+
+
+def test_resolve_cache_mode_unknown_value_warns(monkeypatch, cache_mode, capsys):
+    # Reset the warn-once cache so this test gets a fresh first emission.
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._WARNED_CACHE_VALUES", set()
+    )
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "totally-invalid-once")
+    assert crawl4ai_provider._resolve_cache_mode() is None
+    err = capsys.readouterr().err
+    assert "totally-invalid-once" in err
+    assert "not recognised" in err
+
+
+def test_resolve_cache_mode_when_crawl4ai_not_installed_is_silent(monkeypatch, capsys):
+    """Library missing must NOT print 'not recognised'; the caller's
+    ``_ensure_available`` surfaces the real error path."""
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CacheMode", None
+    )
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "bypass")
+    assert crawl4ai_provider._resolve_cache_mode() is None
+    err = capsys.readouterr().err
+    assert "not recognised" not in err
+
+
+def test_resolve_cache_mode_unknown_value_warns_only_once(
+    monkeypatch, cache_mode, capsys
+):
+    """Repeated calls with the same bad value emit one stderr line, not N."""
+    # Reset module state since the warn-once cache persists across tests.
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._WARNED_CACHE_VALUES", set()
+    )
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "totally-invalid")
+    crawl4ai_provider._resolve_cache_mode()
+    crawl4ai_provider._resolve_cache_mode()
+    crawl4ai_provider._resolve_cache_mode()
+    err = capsys.readouterr().err
+    assert err.count("totally-invalid") == 1
+
+
+def test_resolve_cache_mode_returns_none_when_enum_attribute_missing(
+    monkeypatch, capsys
+):
+    """If a future crawl4ai release renames an enum value, fall back gracefully."""
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider._WARNED_CACHE_VALUES", set()
+    )
+
+    class _PartialCacheMode:
+        ENABLED = "enabled-sentinel"
+        # BYPASS deliberately absent.
+
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CacheMode", _PartialCacheMode
+    )
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "bypass")
+    assert crawl4ai_provider._resolve_cache_mode() is None
+    err = capsys.readouterr().err
+    assert "bypass" in err
+
+
+def test_discover_passes_cache_mode_to_run_config(monkeypatch, cache_mode):
+    """SCRAPE_CACHE_MODE=bypass propagates into the deep-crawl run config."""
+    captured: dict = {}
+
+    def _spy_run_config(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    crawler = _make_crawler_mock(arun_return=[_FakeResult("https://x/a")])
+    _patch_crawl4ai(monkeypatch, crawler)
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CrawlerRunConfig", _spy_run_config
+    )
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "bypass")
+
+    import asyncio
+    asyncio.run(Crawl4AIDiscoveryProvider().discover_urls("https://x"))
+
+    assert captured.get("cache_mode") == cache_mode.BYPASS
+
+
+def test_discover_omits_cache_mode_when_env_unset(monkeypatch, cache_mode):
+    captured: dict = {}
+
+    def _spy_run_config(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    crawler = _make_crawler_mock(arun_return=[_FakeResult("https://x/a")])
+    _patch_crawl4ai(monkeypatch, crawler)
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CrawlerRunConfig", _spy_run_config
+    )
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+
+    import asyncio
+    asyncio.run(Crawl4AIDiscoveryProvider().discover_urls("https://x"))
+
+    assert "cache_mode" not in captured
+
+
+def test_fetch_one_passes_cache_mode_when_env_set(monkeypatch, cache_mode):
+    """SCRAPE_CACHE_MODE=bypass causes fetch_one to pass a CrawlerRunConfig."""
+    crawler = _make_crawler_mock(
+        arun_return=_FakeResult("https://x/a", markdown="hi")
+    )
+    _patch_crawl4ai(monkeypatch, crawler)
+
+    captured: dict = {}
+
+    def _spy_run_config(**kwargs):
+        captured.update(kwargs)
+        return "run-config-sentinel"
+
+    monkeypatch.setattr(
+        "scraper_providers.crawl4ai_provider.CrawlerRunConfig", _spy_run_config
+    )
+    monkeypatch.setenv("SCRAPE_CACHE_MODE", "bypass")
+
+    import asyncio
+    page = asyncio.run(Crawl4AIFetchProvider().fetch_one("https://x/a"))
+
+    assert page.markdown == "hi"
+    assert captured.get("cache_mode") == cache_mode.BYPASS
+    # arun was called WITH a config object.
+    crawler.arun.assert_called_once()
+    _, kwargs = crawler.arun.call_args
+    assert kwargs.get("config") == "run-config-sentinel"
+
+
+def test_fetch_one_omits_config_when_env_unset(monkeypatch, cache_mode):
+    """No env override means fetch_one preserves the original
+    ``crawler.arun(url=url)`` call shape with no config kwarg."""
+    crawler = _make_crawler_mock(
+        arun_return=_FakeResult("https://x/a", markdown="hi")
+    )
+    _patch_crawl4ai(monkeypatch, crawler)
+    monkeypatch.delenv("SCRAPE_CACHE_MODE", raising=False)
+
+    import asyncio
+    page = asyncio.run(Crawl4AIFetchProvider().fetch_one("https://x/a"))
+
+    assert page.markdown == "hi"
+    crawler.arun.assert_called_once()
+    _, kwargs = crawler.arun.call_args
+    assert "config" not in kwargs


### PR DESCRIPTION
## Summary

Consolidates PRs #51, #52, #53, #54 into one stack per #55. Lands `king-scrape update <name>` (ADR-0014) with the six safety fixes you flagged in the live e2e run, plus the upsert and enrich resilience pieces that the update flow depends on, plus the `--no-fetch-cache` flag wired through every subcommand.

## Related issue

  Closes #47
  Closes #48
  Closes #50
  Refs #55

  Supersedes #51, #52, #53, #54.

  ## Type of change

  - [x] Bug fix
  - [x] New feature
  - [x] Documentation update

  ## How it was tested

  pytest -q
  816 passed, 1 skipped


  The six fixes have direct regression tests in `tests/test_scraper/test_update.py`: legacy `_meta` refuse, fetch failure threshold abort, discover-divergence guard, growth allowed counter case, cost prompt short-circuit, `fetch_failed` in the report. `--no-fetch-cache` covered on all three subcommands (`cli.main`, `audit_main`, `update_main`) plus direct unit tests
   for `_cache_mode` helpers.

  Ran a senior review pass (two voltagent reviewers in parallel) on the staged diff before opening. They caught a regression of your earlier `4a50531` audit signature fix that my patch
  reverted by accident — re-applied. Also tightened the env restore window in `cli.py` so a `load_config` failure can't leak `SCRAPE_CACHE_MODE=bypass`.

  ## Checklist

  - [x] English only code, comments, identifiers
  - [x] `pytest` passes locally
  - [x] Tests added for every new guard
  - [x] `docs/CLI_GUIDE.md` updated with the cache mode footgun note for `update`
  - [x] Contributing guide read
  - [x] Commit style: conventional, one concern per commit
  - [x] No secrets in the diff

  ## Additional notes

  Three design decisions you locked in are implemented as-is, with no opt-in flag for any of them:

  - Legacy `_meta`-absent corpora: hard refuse, no flag. Re-scrape from scratch.
  - Fetch-failure threshold: strict `> 10%`, fixed constant. 1-of-10 passes; 2-of-10 aborts.
  - Discover divergence: asymmetric. `> 50%` loss aborts; any amount of growth is fine.

  Trade offs I accepted rather than fixed:

  - `update` does not auto-set `SCRAPE_CACHE_MODE=bypass`. A user running `king-scrape update foo` without remembering `--no-fetch-cache` may still hit stale provider cache for unchanged URL but changed-content pages. Documented in `CLI_GUIDE.md` next to step 3. Auto bypass on `update` is one CLI guarantee I'd rather have you sign off on before changing.
  - `_interleave_in_chunk_order` now silently dedupes repeated `content_hash` from `fresh_chunks` (boilerplate sections that recur across pages). One section per unique content, fresh order preserved. Documented in the helper.

  Follow-up that I'd ship separately, not in this PR:

  - `embeddings.npy` pruning on re-seed (you acknowledged this as pre existing). Happy to file the issue.

  Happy to split the stack if you'd rather review the pieces independently.